### PR TITLE
fix(cmd/service-token): create service tokens error

### DIFF
--- a/packages/crypto/crypto.go
+++ b/packages/crypto/crypto.go
@@ -10,6 +10,15 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
+func GenerateRandomBytes(length int) ([]byte, error) {
+	bytes := make([]byte, length)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
 // will decrypt cipher text to plain text using iv and tag
 func DecryptSymmetric(key []byte, cipherText []byte, tag []byte, iv []byte) ([]byte, error) {
 	// Case: empty string


### PR DESCRIPTION
# Description 📣

This PR resolves an issue with creating service tokens. We con't require project private keys to create service token anymore, and in fact we aren't even returning the user private key to the CLI anymore. 

The CLI would attempt to get the users private key (which isn't stored in the CLI), which would then subsequently fail and throw an error during the service token creation step.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->