### PR TITLE
misc: fix scoop after repo move

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,6 +146,7 @@ nfpms:
         dst: /usr/share/man/man1/infisical.1.gz
 
 scoop:
+  name: infisical
   bucket:
     owner: Infisical
     name: scoop-infisical


### PR DESCRIPTION
# Description 📣
This PR ensures that the appropriate manifest file (infisical.json) in the scoop repo gets updated. This broke after we moved out the CLI to its own dedicated repo because it started to output the manifest file to cli.json

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->