### PR TITLE
fix(agent): dynamic secret templating

### DIFF
--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -564,11 +564,11 @@ type UniversalAuthRefreshResponse struct {
 }
 
 type CreateDynamicSecretLeaseV1Request struct {
-	Environment string `json:"environment"`
-	ProjectSlug string `json:"projectSlug"`
-	SecretPath  string `json:"secretPath,omitempty"`
-	Slug        string `json:"slug"`
-	TTL         string `json:"ttl,omitempty"`
+	Environment       string `json:"environmentSlug"`
+	ProjectSlug       string `json:"projectSlug"`
+	SecretPath        string `json:"secretPath,omitempty"`
+	DynamicSecretName string `json:"dynamicSecretName"`
+	TTL               string `json:"ttl,omitempty"`
 }
 
 type CreateDynamicSecretLeaseV1Response struct {

--- a/packages/util/secrets.go
+++ b/packages/util/secrets.go
@@ -162,7 +162,7 @@ func GetSinglePlainTextSecretByNameV3(accessToken string, workspaceId string, en
 	return formattedSecrets, rawSecret.ETag, nil
 }
 
-func CreateDynamicSecretLease(accessToken string, projectSlug string, environmentName string, secretsPath string, slug string, ttl string) (models.DynamicSecretLease, error) {
+func CreateDynamicSecretLease(accessToken string, projectSlug string, environmentSlug string, secretsPath string, dynamicSecretName string, ttl string) (models.DynamicSecretLease, error) {
 	httpClient, err := GetRestyClientWithCustomHeaders()
 	if err != nil {
 		return models.DynamicSecretLease{}, err
@@ -172,11 +172,11 @@ func CreateDynamicSecretLease(accessToken string, projectSlug string, environmen
 		SetHeader("Accept", "application/json")
 
 	dynamicSecretRequest := api.CreateDynamicSecretLeaseV1Request{
-		ProjectSlug: projectSlug,
-		Environment: environmentName,
-		SecretPath:  secretsPath,
-		Slug:        slug,
-		TTL:         ttl,
+		ProjectSlug:       projectSlug,
+		Environment:       environmentSlug,
+		SecretPath:        secretsPath,
+		DynamicSecretName: dynamicSecretName,
+		TTL:               ttl,
 	}
 
 	dynamicSecret, err := api.CallCreateDynamicSecretLeaseV1(httpClient, dynamicSecretRequest)


### PR DESCRIPTION
# Description 📣

This PR fixes the dynamic_secret agent templating, there was quite a few different issues:

1. API was expecting environmentSlug but we were sending environment
2. API was expecting dynamicSecretName but we were sending slug
3. The rendered destination file never refreshes for dynamic secrets. It only renders on first run, making the lease lifecycle management useless

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->