### PR TITLE
misc: add reading from env for relay-auth-secret in systemd install

### DIFF
--- a/packages/cmd/relay.go
+++ b/packages/cmd/relay.go
@@ -201,14 +201,15 @@ var relaySystemdInstallCmd = &cobra.Command{
 			util.HandleError(fmt.Errorf("type flag is required"), "type is required")
 		}
 
-		relayAuthSecret, err := cmd.Flags().GetString("relay-auth-secret")
+		relayAuthSecret, err := util.GetCmdFlagOrEnv(cmd, "relay-auth-secret", []string{gatewayv2.RELAY_AUTH_SECRET_ENV_NAME})
 		if err != nil {
 			util.HandleError(err, "Unable to parse relay-auth-secret flag")
 		}
 
-		if instanceType == "instance" && relayAuthSecret == "" && os.Getenv(gatewayv2.RELAY_AUTH_SECRET_ENV_NAME) == "" {
+		if instanceType == "instance" && relayAuthSecret == "" {
 			util.HandleError(fmt.Errorf("for type 'instance', --relay-auth-secret flag or %s env must be set", gatewayv2.RELAY_AUTH_SECRET_ENV_NAME))
 		}
+
 		if instanceType != "instance" && token == "" {
 			util.HandleError(fmt.Errorf("for type '%s', --token is required", instanceType))
 		}


### PR DESCRIPTION
# Description 📣
This PR adds support for reading relay auth secret from ENV for systemd install

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->