### PR TITLE
feat: add development mode handling for gateway registration and host key validation

### DIFF
--- a/packages/gateway-v2/gateway.go
+++ b/packages/gateway-v2/gateway.go
@@ -374,7 +374,7 @@ func (g *Gateway) registerGateway() error {
 		return fmt.Errorf("failed to register gateway: %v", err)
 	}
 
-	if util.CLI_VERSION == "devel" {
+	if util.CLI_VERSION == "devel" && certResp.RelayHost == "host.docker.internal" {
 		certResp.RelayHost = "127.0.0.1"
 	}
 
@@ -511,6 +511,7 @@ func (g *Gateway) createHostKeyCallback() ssh.HostKeyCallback {
 
 		// no host cert check when in dev mode
 		if util.CLI_VERSION == "devel" {
+			fmt.Println("Gateway running in development mode, skipping host certificate validation")
 			return nil
 		}
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Enables the `relay` and `gateway` commands on localhost using a local instance of infisical on the `--domain `flag.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

Run the gateway and relay commands like:

```
 go run main.go relay start \
   --host=host.docker.internal \
   --name=local-relay \
   --auth-method=universal-auth \
   --client-id=... \
   --client-secret=... \
   --domain=http://localhost:8080
```

`go run main.go gateway start --name=local-gateway --relay=local-relay --domain=http://localhost:8080 --token=...`

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->