### PR TITLE
feat(agent): revoke credentials on shutdown

### DIFF
--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -1233,7 +1233,7 @@ var agentCmd = &cobra.Command{
 
 		tokenRefreshNotifier := make(chan bool)
 		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, os.Interrupt)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 		filePaths := agentConfig.Sinks
 


### PR DESCRIPTION
# Description 📣

This PR allows for the agent to self-revoke managed credentials (currently dynamic secret leases and access tokens are supported). There's a new flag called `revoke-credentials-on-shutdown` (default to false), which dictates this behavior.

Additionally I also fixed multiple dynamic secret leases being treated as one single lease. We had a check like this before:

```go
	for _, lease := range d.leases {
		if lease.SecretPath == secretPath && lease.Environment == environment && lease.ProjectSlug == projectSlug && lease.Slug == slug {
			return &lease
		}
	}
```

Which wasn't factoring in template ID's. This means if you have multiple dynamic secret templates using the same dynamic secret, it would treat all those templates as the same. This has also been resolved in this PR.

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->