### PR TITLE
fix: rename service-log-file -> log-file

### DIFF
--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -424,9 +424,9 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 			util.HandleError(errors.New("Gateway name is required"))
 		}
 
-		serviceLogFile, err := cmd.Flags().GetString("service-log-file")
+		serviceLogFile, err := cmd.Flags().GetString("log-file")
 		if err != nil {
-			util.HandleError(err, "Unable to parse service-log-file flag")
+			util.HandleError(err, "Unable to parse log-file flag")
 		}
 
 		relayName, err := util.GetRelayName(cmd, false, token.Token)
@@ -533,7 +533,7 @@ func init() {
 	gatewaySystemdInstallCmd.Flags().String("name", "", "The name of the gateway")
 	gatewaySystemdInstallCmd.Flags().String("relay", "", "The name of the relay (deprecated, use --target-relay-name)") // Deprecated, use --target-relay-name instead
 	gatewaySystemdInstallCmd.Flags().String("target-relay-name", "", "The name of the relay")
-	gatewaySystemdInstallCmd.Flags().String("service-log-file", "", "The file to write the service logs to. Example: /var/log/infisical/gateway.log. If not provided, logs will not be written to a file.")
+	gatewaySystemdInstallCmd.Flags().String("log-file", "", "The file to write the service logs to. Example: /var/log/infisical/gateway.log. If not provided, logs will not be written to a file.")
 
 	// Gateway relay command flags
 	gatewayRelayCmd.Flags().String("config", "", "Relay config yaml file path")

--- a/packages/cmd/relay.go
+++ b/packages/cmd/relay.go
@@ -206,9 +206,9 @@ var relaySystemdInstallCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse relay-auth-secret flag")
 		}
 
-		serviceLogFile, err := cmd.Flags().GetString("service-log-file")
+		serviceLogFile, err := cmd.Flags().GetString("log-file")
 		if err != nil {
-			util.HandleError(err, "Unable to parse service-log-file flag")
+			util.HandleError(err, "Unable to parse log-file flag")
 		}
 
 		if instanceType == "instance" && relayAuthSecret == "" {
@@ -270,7 +270,7 @@ func init() {
 
 	// systemd install command flags
 	relaySystemdInstallCmd.Flags().String("token", "", "Connect with Infisical using machine identity access token (org type)")
-	relaySystemdInstallCmd.Flags().String("service-log-file", "", "The file to write the service logs to. Example: /var/log/infisical/relay.log. If not provided, logs will not be written to a file.")
+	relaySystemdInstallCmd.Flags().String("log-file", "", "The file to write the service logs to. Example: /var/log/infisical/relay.log. If not provided, logs will not be written to a file.")
 	relaySystemdInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
 	relaySystemdInstallCmd.Flags().String("name", "", "The name of the relay")
 	relaySystemdInstallCmd.Flags().String("host", "", "The IP or hostname for the relay")

--- a/packages/util/systemd.go
+++ b/packages/util/systemd.go
@@ -28,7 +28,7 @@ func WriteSystemdServiceFile(
 	serviceLogFile := filepath.Clean(serviceLogFilePath)
 
 	if !filepath.IsAbs(serviceLogFile) {
-		return fmt.Errorf("service-log-file must be an absolute path: %s", serviceLogFile)
+		return fmt.Errorf("log-file must be an absolute path: %s", serviceLogFile)
 	}
 
 	logDir := filepath.Dir(serviceLogFile)


### PR DESCRIPTION
# Description 📣

Renamed service-log-file to log-file to be more compliant with CLI standards.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->