### PR TITLE
chore: fixes pam access command to use account path instead of id [PAM-64] 

### DIFF
--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -772,8 +772,9 @@ type RegisterGatewayResponse struct {
 }
 
 type PAMAccessRequest struct {
-	Duration  string `json:"duration,omitempty"`
-	AccountId string `json:"accountId,omitempty"`
+	Duration    string `json:"duration,omitempty"`
+	AccountPath string `json:"accountPath,omitempty"`
+	ProjectId   string `json:"projectId,omitempty"`
 }
 
 type PAMAccessResponse struct {

--- a/packages/cmd/pam.go
+++ b/packages/cmd/pam.go
@@ -26,16 +26,29 @@ var pamDbCmd = &cobra.Command{
 }
 
 var pamDbAccessAccountCmd = &cobra.Command{
-	Use:                   "access-account <account-name-or-id>",
+	Use:                   "access-account <account-path>",
 	Short:                 "Access PAM database accounts",
 	Long:                  "Access PAM database accounts for Infisical. This starts a local database proxy server that you can use to connect to databases directly.",
-	Example:               "infisical pam db access-account my-postgres-account --duration 4h --port 5432",
+	Example:               "infisical pam db access-account prod/db/my-postgres-account --duration 4h --port 5432 --project-id 1234567890",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		util.RequireLogin()
 
-		accountID := args[0]
+		accountPath := args[0]
+
+		projectID, err := cmd.Flags().GetString("project-id")
+		if err != nil {
+			util.HandleError(err, "Unable to parse project-id flag")
+		}
+
+		if projectID == "" {
+			workspaceFile, err := util.GetWorkSpaceFromFile()
+			if err != nil {
+				util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --project-id flag")
+			}
+			projectID = workspaceFile.WorkspaceId
+		}
 
 		durationStr, err := cmd.Flags().GetString("duration")
 		if err != nil {
@@ -70,7 +83,7 @@ var pamDbAccessAccountCmd = &cobra.Command{
 			loggedInUserDetails = util.EstablishUserLoginSession()
 		}
 
-		pam.StartDatabaseLocalProxy(loggedInUserDetails.UserCredentials.JTWToken, accountID, durationStr, port)
+		pam.StartDatabaseLocalProxy(loggedInUserDetails.UserCredentials.JTWToken, accountPath, projectID, durationStr, port)
 	},
 }
 
@@ -83,16 +96,16 @@ var pamSshCmd = &cobra.Command{
 }
 
 var pamSshAccessAccountCmd = &cobra.Command{
-	Use:                   "access-account <account-name-or-id>",
+	Use:                   "access-account <account-path>",
 	Short:                 "Start SSH session to PAM account",
 	Long:                  "Start an SSH session to a PAM-managed SSH account. This command automatically launches an SSH client connected through the Infisical Gateway.",
-	Example:               "infisical pam ssh access-account <account-id> --duration 2h",
+	Example:               "infisical pam ssh access-account prod/ssh/my-ssh-account --duration 2h --project-id 1234567890",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		util.RequireLogin()
 
-		accountID := args[0]
+		accountPath := args[0]
 
 		durationStr, err := cmd.Flags().GetString("duration")
 		if err != nil {
@@ -103,6 +116,19 @@ var pamSshAccessAccountCmd = &cobra.Command{
 		_, err = time.ParseDuration(durationStr)
 		if err != nil {
 			util.HandleError(err, "Invalid duration format. Use formats like '1h', '30m', '2h30m'")
+		}
+
+		projectID, err := cmd.Flags().GetString("project-id")
+		if err != nil {
+			util.HandleError(err, "Unable to parse project-id flag")
+		}
+
+		if projectID == "" {
+			workspaceFile, err := util.GetWorkSpaceFromFile()
+			if err != nil {
+				util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --project-id flag")
+			}
+			projectID = workspaceFile.WorkspaceId
 		}
 
 		log.Debug().Msg("PAM SSH Access: Trying to fetch credentials using logged in details")
@@ -122,7 +148,7 @@ var pamSshAccessAccountCmd = &cobra.Command{
 			loggedInUserDetails = util.EstablishUserLoginSession()
 		}
 
-		pam.StartSSHLocalProxy(loggedInUserDetails.UserCredentials.JTWToken, accountID, durationStr)
+		pam.StartSSHLocalProxy(loggedInUserDetails.UserCredentials.JTWToken, accountPath, projectID, durationStr)
 	},
 }
 
@@ -130,9 +156,11 @@ func init() {
 	pamDbCmd.AddCommand(pamDbAccessAccountCmd)
 	pamDbAccessAccountCmd.Flags().String("duration", "1h", "Duration for database access session (e.g., '1h', '30m', '2h30m')")
 	pamDbAccessAccountCmd.Flags().Int("port", 0, "Port for the local database proxy server (0 for auto-assign)")
+	pamDbAccessAccountCmd.Flags().String("project-id", "", "Project ID of the account to access")
 
 	pamSshCmd.AddCommand(pamSshAccessAccountCmd)
 	pamSshAccessAccountCmd.Flags().String("duration", "1h", "Duration for SSH access session (e.g., '1h', '30m', '2h30m')")
+	pamSshAccessAccountCmd.Flags().String("project-id", "", "Project ID of the account to access")
 
 	pamCmd.AddCommand(pamDbCmd)
 	pamCmd.AddCommand(pamSshCmd)

--- a/packages/pam/local/database-proxy.go
+++ b/packages/pam/local/database-proxy.go
@@ -30,8 +30,8 @@ const (
 	ALPNInfisicalPAMCancellation ALPN = "infisical-pam-session-cancellation"
 )
 
-func StartDatabaseLocalProxy(accessToken string, accountID string, durationStr string, port int) {
-	log.Info().Msgf("Starting database proxy for account ID: %s", accountID)
+func StartDatabaseLocalProxy(accessToken string, accountPath string, projectID string, durationStr string, port int) {
+	log.Info().Msgf("Starting database proxy for account: %s", accountPath)
 	log.Info().Msgf("Session duration: %s", durationStr)
 
 	httpClient := resty.New()
@@ -39,8 +39,9 @@ func StartDatabaseLocalProxy(accessToken string, accountID string, durationStr s
 	httpClient.SetHeader("User-Agent", "infisical-cli")
 
 	pamRequest := api.PAMAccessRequest{
-		Duration:  durationStr,
-		AccountId: accountID,
+		Duration:    durationStr,
+		AccountPath: accountPath,
+		ProjectId:   projectID,
 	}
 
 	pamResponse, err := api.CallPAMAccess(httpClient, pamRequest)
@@ -84,9 +85,9 @@ func StartDatabaseLocalProxy(accessToken string, accountID string, durationStr s
 	}
 
 	if port == 0 {
-		fmt.Printf("Database proxy started for account %s with duration %s on port %d (auto-assigned)\n", accountID, duration.String(), proxy.port)
+		fmt.Printf("Database proxy started for account %s with duration %s on port %d (auto-assigned)\n", accountPath, duration.String(), proxy.port)
 	} else {
-		fmt.Printf("Database proxy started for account %s with duration %s on port %d\n", accountID, duration.String(), proxy.port)
+		fmt.Printf("Database proxy started for account %s with duration %s on port %d\n", accountPath, duration.String(), proxy.port)
 	}
 
 	username, ok := pamResponse.Metadata["username"]
@@ -104,7 +105,7 @@ func StartDatabaseLocalProxy(accessToken string, accountID string, durationStr s
 		util.HandleError(fmt.Errorf("PAM response metadata is missing 'accountName'"), "Failed to start proxy server")
 		return
 	}
-	accountPath, ok := pamResponse.Metadata["accountPath"]
+	accountPathMetadata, ok := pamResponse.Metadata["accountPath"]
 	if !ok {
 		util.HandleError(fmt.Errorf("PAM response metadata is missing 'accountPath'"), "Failed to start proxy server")
 		return
@@ -115,7 +116,7 @@ func StartDatabaseLocalProxy(accessToken string, accountID string, durationStr s
 	fmt.Printf("**********************************************************************\n")
 	fmt.Printf("                  Database Proxy Session Started!                  \n")
 	fmt.Printf("----------------------------------------------------------------------\n")
-	fmt.Printf("Accessing account %s at folder path %s\n", accountName, accountPath)
+	fmt.Printf("Accessing account %s at folder path %s\n", accountName, accountPathMetadata)
 	fmt.Printf("\n")
 	fmt.Printf("You can now connect to your database using this connection string:\n")
 

--- a/packages/pam/local/ssh-proxy.go
+++ b/packages/pam/local/ssh-proxy.go
@@ -27,14 +27,15 @@ type SSHProxyServer struct {
 	sshProcess      *exec.Cmd
 }
 
-func StartSSHLocalProxy(accessToken string, accountID string, durationStr string) {
+func StartSSHLocalProxy(accessToken string, accountPath string, projectID string, durationStr string) {
 	httpClient := resty.New()
 	httpClient.SetAuthToken(accessToken)
 	httpClient.SetHeader("User-Agent", "infisical-cli")
 
 	pamRequest := api.PAMAccessRequest{
-		Duration:  durationStr,
-		AccountId: accountID,
+		Duration:    durationStr,
+		AccountPath: accountPath,
+		ProjectId:   projectID,
 	}
 
 	pamResponse, err := api.CallPAMAccess(httpClient, pamRequest)


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->