### PR TITLE
fix(alpine): lock linux docker image to 3.22.2

### DIFF
--- a/docker/alpine
+++ b/docker/alpine
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.22.2
 RUN apk add --no-cache tini
 
 ## Upgrade OpenSSL libraries to mitigate known vulnerabilities as the current Alpine image has not been patched yet.


### PR DESCRIPTION
# Description 📣

Lock alpine docker image version to 3.22.2 as newer versions are failing with goreleaser

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->