### PR TITLE
fix(util): map ID and comment fields in secret transformation

### DIFF
--- a/packages/util/secrets.go
+++ b/packages/util/secrets.go
@@ -65,7 +65,17 @@ func GetPlainTextSecretsViaServiceToken(fullServiceToken string, environment str
 	plainTextSecrets := []models.SingleEnvironmentVariable{}
 
 	for _, secret := range rawSecrets.Secrets {
-		plainTextSecrets = append(plainTextSecrets, models.SingleEnvironmentVariable{Key: secret.SecretKey, Value: secret.SecretValue, Type: secret.Type, WorkspaceId: secret.Workspace, SkipMultilineEncoding: secret.SkipMultilineEncoding, Tags: secret.Tags})
+		plainTextSecrets = append(plainTextSecrets, models.SingleEnvironmentVariable{
+			Key:                   secret.SecretKey,
+			WorkspaceId:           secret.Workspace,
+			Value:                 secret.SecretValue,
+			Type:                  secret.Type,
+			ID:                    secret.ID,
+			Comment:               secret.SecretComment,
+			SecretPath:            secret.SecretPath,
+			SkipMultilineEncoding: secret.SkipMultilineEncoding,
+			Tags:                  secret.Tags,
+		})
 	}
 
 	if includeImports {
@@ -110,7 +120,17 @@ func GetPlainTextSecretsV3(accessToken string, workspaceId string, environmentNa
 	plainTextSecrets := []models.SingleEnvironmentVariable{}
 
 	for _, secret := range rawSecrets.Secrets {
-		plainTextSecrets = append(plainTextSecrets, models.SingleEnvironmentVariable{Key: secret.SecretKey, Value: secret.SecretValue, Type: secret.Type, WorkspaceId: secret.Workspace, SecretPath: secret.SecretPath, SkipMultilineEncoding: secret.SkipMultilineEncoding, Tags: secret.Tags})
+		plainTextSecrets = append(plainTextSecrets, models.SingleEnvironmentVariable{
+			Key:                   secret.SecretKey,
+			WorkspaceId:           secret.Workspace,
+			Value:                 secret.SecretValue,
+			Type:                  secret.Type,
+			ID:                    secret.ID,
+			Comment:               secret.SecretComment,
+			SecretPath:            secret.SecretPath,
+			SkipMultilineEncoding: secret.SkipMultilineEncoding,
+			Tags:                  secret.Tags,
+		})
 	}
 
 	if includeImports {
@@ -239,6 +259,8 @@ func InjectRawImportedSecret(secrets []models.SingleEnvironmentVariable, importe
 					Value:       sec.SecretValue,
 					Type:        sec.Type,
 					ID:          sec.ID,
+					Comment:     sec.SecretComment,
+					SecretPath:  importSec.SecretPath,
 				})
 				hasOverriden[sec.SecretKey] = true
 			}


### PR DESCRIPTION
Map `ID`, `Comment`, and `SecretPath` when converting raw secrets to `models.SingleEnvironmentVariable` in the agent secret listing flow.

# Description 📣

Problem: Agent template `secret`/`listSecrets` drops `id`, `comment`, and sometimes `secretPath`, despite the raw secrets API including them.
Solution: Map `ID`, `Comment`, and `SecretPath` from raw secrets when converting to `models.SingleEnvironmentVariable`.
Changes: Update `GetPlainTextSecretsViaServiceToken`, `GetPlainTextSecretsV3`, and `InjectRawImportedSecret` to include these fields in the transformed output.

Fixes #103

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️


```sh
go build -o infisical.exe .

# Write universal auth credentials to local files used by the agent
Set-Content -Path .\client-id -Value <YOUR_CLIENT_ID>
Set-Content -Path .\client-secret -Value <YOUR_CLIENT_SECRET>

# Generate a template that prints metadata (ID/Comment) from listSecrets
@'
{{- with secret "<PROJECT_ID>" "<ENV_SLUG>" "/" }}
{{- range . }}
key={{ .Key }}
id={{ .ID }}
comment={{ .Comment }}
{{- end }}
{{- end }}
'@ | Set-Content -Path .\template-list-secrets.tmpl

# Minimal agent config with a single template render target
@'
infisical:
  address: "https://app.infisical.com/"
  exit-after-auth: true
auth:
  type: "universal-auth"
  config:
    client-id: "./client-id"
    client-secret: "./client-secret"
    remove_client_secret_on_read: false
sinks:
  - type: "file"
    config:
      path: "access-token"
templates:
  - source-path: "./template-list-secrets.tmpl"
    destination-path: "./out.env"
    config:
      polling-interval: 5s
'@ | Set-Content -Path .\agent-config.local.yaml

# Run agent and confirm rendered output includes non-empty id/comment
.\infisical.exe agent --config .\agent-config.local.yaml
# Confirm .\out.env contains non-empty id/comment for a secret with a comment.
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->
