### PR TITLE
feat: add 48h delay for the upgrade cli warning

### DIFF
--- a/packages/util/check-for-update.go
+++ b/packages/util/check-for-update.go
@@ -25,40 +25,42 @@ func CheckForUpdateWithWriter(w io.Writer) {
 	if checkEnv := os.Getenv("INFISICAL_DISABLE_UPDATE_CHECK"); checkEnv != "" {
 		return
 	}
-	latestVersion, publishedAt, isUrgent, err := getLatestTag("Infisical", "cli")
+	latestVersion, _, isUrgent, err := getLatestTag("Infisical", "cli")
 	if err != nil {
 		log.Debug().Err(err)
 		// do nothing and continue
 		return
 	}
 
-	// Only prompt if the release is at least 48 hours old, unless it's marked as urgent
-	hoursSinceRelease := time.Since(publishedAt).Hours()
-	if !isUrgent && hoursSinceRelease < 48 {
+	if latestVersion == CLI_VERSION {
 		return
 	}
 
-	if latestVersion != CLI_VERSION {
-		yellow := color.New(color.FgYellow).SprintFunc()
-		blue := color.New(color.FgCyan).SprintFunc()
-		black := color.New(color.FgBlack).SprintFunc()
+	// Only prompt if the user's current version is at least 48 hours old, unless urgent.
+	// This avoids nagging users who recently updated.
+	currentVersionPublishedAt, err := getReleasePublishedAt("Infisical", "cli", CLI_VERSION)
+	if err == nil && !isUrgent && time.Since(currentVersionPublishedAt).Hours() < 48 {
+		return
+	}
 
-		msg := fmt.Sprintf("%s %s %s %s",
-			yellow("A new release of infisical is available:"),
-			blue(CLI_VERSION),
-			black("->"),
-			blue(latestVersion),
-		)
+	yellow := color.New(color.FgYellow).SprintFunc()
+	blue := color.New(color.FgCyan).SprintFunc()
+	black := color.New(color.FgBlack).SprintFunc()
 
+	msg := fmt.Sprintf("%s %s %s %s",
+		yellow("A new release of infisical is available:"),
+		blue(CLI_VERSION),
+		black("->"),
+		blue(latestVersion),
+	)
+
+	fmt.Fprintln(w, msg)
+
+	updateInstructions := GetUpdateInstructions()
+
+	if updateInstructions != "" {
+		msg = fmt.Sprintf("\n%s\n", GetUpdateInstructions())
 		fmt.Fprintln(w, msg)
-
-		updateInstructions := GetUpdateInstructions()
-
-		if updateInstructions != "" {
-			msg = fmt.Sprintf("\n%s\n", GetUpdateInstructions())
-			fmt.Fprintln(w, msg)
-		}
-
 	}
 }
 
@@ -125,6 +127,40 @@ func getLatestTag(repoOwner string, repoName string) (string, time.Time, bool, e
 	version := strings.TrimPrefix(releaseDetails.TagName, tag_prefix)
 
 	return version, publishedAt, isUrgent, nil
+}
+
+func getReleasePublishedAt(repoOwner string, repoName string, version string) (time.Time, error) {
+	tag := "v" + version
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", repoOwner, repoName, tag)
+	resp, err := http.Get(url)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if resp.StatusCode != 200 {
+		return time.Time{}, errors.New(fmt.Sprintf("gitHub API returned status code %d", resp.StatusCode))
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var releaseDetails struct {
+		PublishedAt string `json:"published_at"`
+	}
+
+	if err := json.Unmarshal(body, &releaseDetails); err != nil {
+		return time.Time{}, fmt.Errorf("failed to unmarshal github response: %w", err)
+	}
+
+	publishedAt, err := time.Parse(time.RFC3339, releaseDetails.PublishedAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse release time: %w", err)
+	}
+
+	return publishedAt, nil
 }
 
 func GetUpdateInstructions() string {


### PR DESCRIPTION
# Description 📣

Reduces CLI update notification frequency by only prompting users when a new release is at least 48 hours old. This prevents excessive notifications for very recent releases while still keeping users informed about updates.

Additionally, adds support for urgent releases via a `#urgent` tag in the release notes body, which bypasses the 48-hour delay for critical updates that need immediate user attention.

## Changes

- Add 48-hour release age threshold before showing update prompts
- Parse `published_at` timestamp from GitHub API response
- Add `#urgent` tag detection in release body to bypass the delay
- Update `getLatestTag` return signature to include parsed timestamp and urgency flag
- Remove unused commented-out `daysSinceDate` function

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Manual testing:

```sh
# Build the CLI
go build -o infisical-test .

# Run and verify update message appears (release is >48h old)
./infisical-test help 2>&1 >/dev/null
# Output: A new release of infisical is available: devel -> 0.43.47
```

The update prompt correctly appears because the latest release (v0.43.47) is more than 48 hours old. Urgent release behavior can be tested by adding `#urgent` to a release's body.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
