### PR TITLE
fix: npm release failing 

### DIFF
--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -65,17 +65,6 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: npm version ${{ env.CLI_VERSION }} --allow-same-version --no-git-tag-version
 
-      - name: Setup NPM
-        working-directory: ${{ env.working-directory }}
-        run: |
-          echo 'registry="https://registry.npmjs.org/"' > ./.npmrc
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ./.npmrc
-
-          echo 'registry="https://registry.npmjs.org/"' > ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Pack NPM
         working-directory: ${{ env.working-directory }}
         run: npm pack
@@ -83,9 +72,6 @@ jobs:
       - name: Publish NPM
         working-directory: ${{ env.working-directory }}
         run: npm publish --tarball=./infisical-sdk-${{github.ref_name}} --access public --registry=https://registry.npmjs.org/
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   goreleaser:
     runs-on: ubuntu-latest-8-cores


### PR DESCRIPTION
# Description 📣

Added NPM trusted publisher which uses OIDC auth to avoid having a static access token with a TTL.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->