### PR TITLE
Added login func call on unauthorized export command invoke

### DIFF
--- a/packages/cmd/export.go
+++ b/packages/cmd/export.go
@@ -119,6 +119,11 @@ var exportCmd = &cobra.Command{
 				if err != nil {
 					util.HandleError(err)
 				}
+
+				if loggedInUserDetails.LoginExpired {
+					loggedInUserDetails = util.EstablishUserLoginSession()
+				}
+
 				accessToken = loggedInUserDetails.UserCredentials.JTWToken
 			}
 


### PR DESCRIPTION
# Description 📣
When the user is unauthorized and passed a `--template` flag to the `export` command. It failed due to no validation of the `loggedInUserDetails.LoginExpired` value. 

Fixes #114 

https://github.com/Infisical/cli/blob/ba904b4f96dba0d43a281776f290323d6891a037/packages/cmd/export.go#L118-L122
<img width="2017" height="384" alt="image" src="https://github.com/user-attachments/assets/34a93792-6525-4e64-bbc0-9f9a8e69f1da" />

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

1. Revoke the cli token from [Personal Settings](https://app.infisical.com/personal-settings)
2. Try to export env with a template
    ```sh
    # This should fail (Old build)
    infisical export --template=/path/to/template
    ```
3. Try to build and export env with the new binary
    ```sh
    # This should invoke login successfully (New fix)
    go build -o infisical . && ./infisical export --template=./template
    ```
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->