### PR TITLE
Improve Update Instructions

### DIFF
--- a/.github/workflows/test-update-instructions.yml
+++ b/.github/workflows/test-update-instructions.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.9"
       - name: Run unit tests
         run: go test ./packages/util/ -run TestGetUpdateInstructions -v
 
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.9"
       - name: Build test helper
         run: go build -o update-hint.exe ./test/update-hint
 
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.9"
       - name: Build test helper
         run: go build -o update-hint ./test/update-hint
 
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.9"
       - name: Build test helper
         run: go build -o update-hint ./test/update-hint
 

--- a/.github/workflows/test-update-instructions.yml
+++ b/.github/workflows/test-update-instructions.yml
@@ -1,0 +1,117 @@
+name: Test Update Instructions
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.13"
+      - name: Run unit tests
+        run: go test ./packages/util/ -run TestGetUpdateInstructions -v
+
+  integration-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.13"
+      - name: Build test helper
+        run: go build -o update-hint.exe ./test/update-hint
+
+      - name: Test scoop path detection
+        shell: pwsh
+        run: |
+          $scoopPath = "$env:USERPROFILE\scoop\apps\infisical\current"
+          New-Item -ItemType Directory -Force -Path $scoopPath | Out-Null
+          Copy-Item update-hint.exe "$scoopPath\update-hint.exe"
+          $output = & "$scoopPath\update-hint.exe"
+          Write-Host "Output: $output"
+          if ($output -notmatch "scoop update infisical") {
+            Write-Error "Expected 'scoop update infisical', got: $output"
+            exit 1
+          }
+
+      - name: Test npm path detection
+        shell: pwsh
+        run: |
+          $npmPath = "$env:APPDATA\npm\node_modules\@infisical\cli\bin"
+          New-Item -ItemType Directory -Force -Path $npmPath | Out-Null
+          Copy-Item update-hint.exe "$npmPath\update-hint.exe"
+          $output = & "$npmPath\update-hint.exe"
+          Write-Host "Output: $output"
+          if ($output -notmatch "npm update -g @infisical/cli") {
+            Write-Error "Expected 'npm update -g @infisical/cli', got: $output"
+            exit 1
+          }
+
+      - name: Test winget path detection
+        shell: pwsh
+        run: |
+          $wingetPath = "$env:LOCALAPPDATA\Microsoft\WinGet\Links"
+          New-Item -ItemType Directory -Force -Path $wingetPath | Out-Null
+          Copy-Item update-hint.exe "$wingetPath\update-hint.exe"
+          $output = & "$wingetPath\update-hint.exe"
+          Write-Host "Output: $output"
+          if ($output -notmatch "winget upgrade Infisical.Infisical") {
+            Write-Error "Expected 'winget upgrade Infisical.Infisical', got: $output"
+            exit 1
+          }
+
+  integration-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.13"
+      - name: Build test helper
+        run: go build -o update-hint ./test/update-hint
+
+      - name: Test brew path detection
+        run: |
+          mkdir -p /tmp/homebrew/bin
+          cp update-hint /tmp/homebrew/bin/update-hint
+          output=$(/tmp/homebrew/bin/update-hint)
+          echo "Output: $output"
+          echo "$output" | grep -q "brew update" || (echo "Expected brew instruction, got: $output" && exit 1)
+
+      - name: Test npm path detection (via symlink, as npm installs it)
+        run: |
+          mkdir -p /tmp/node_modules/@infisical/cli/bin /tmp/bin
+          cp update-hint /tmp/node_modules/@infisical/cli/bin/update-hint
+          ln -sf /tmp/node_modules/@infisical/cli/bin/update-hint /tmp/bin/update-hint
+          output=$(/tmp/bin/update-hint)
+          echo "Output: $output"
+          echo "$output" | grep -q "npm update -g @infisical/cli" || (echo "Expected npm instruction, got: $output" && exit 1)
+
+  integration-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.13"
+      - name: Build test helper
+        run: go build -o update-hint ./test/update-hint
+
+      - name: Test apt path detection
+        run: |
+          sudo cp update-hint /usr/bin/update-hint
+          output=$(/usr/bin/update-hint)
+          echo "Output: $output"
+          echo "$output" | grep -q "apt-get" || (echo "Expected apt-get instruction, got: $output" && exit 1)
+
+      - name: Test npm path detection
+        run: |
+          mkdir -p $HOME/.npm-global/lib/node_modules/@infisical/cli/bin
+          cp update-hint $HOME/.npm-global/lib/node_modules/@infisical/cli/bin/update-hint
+          output=$($HOME/.npm-global/lib/node_modules/@infisical/cli/bin/update-hint)
+          echo "Output: $output"
+          echo "$output" | grep -q "npm update -g @infisical/cli" || (echo "Expected npm instruction, got: $output" && exit 1)

--- a/packages/util/check-for-update.go
+++ b/packages/util/check-for-update.go
@@ -342,7 +342,7 @@ func getUpdateInstructions(goos string, execPath string) string {
 		if strings.Contains(p, "winget") {
 			return "To update, run: winget upgrade Infisical.Infisical"
 		}
-		return "To update, run: scoop update infisical"
+		return ""
 	case "linux":
 		if isNpm {
 			return "To update, run: npm update -g @infisical/cli"

--- a/packages/util/check-for-update.go
+++ b/packages/util/check-for-update.go
@@ -309,13 +309,44 @@ func getReleasePublishedAt(repoOwner string, repoName string, version string) (t
 }
 
 func GetUpdateInstructions() string {
-	os := runtime.GOOS
-	switch os {
+	execPath, err := os.Executable()
+	if err != nil {
+		execPath = ""
+	}
+	if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
+		execPath = resolved
+	}
+	return getUpdateInstructions(runtime.GOOS, execPath)
+}
+
+func getUpdateInstructions(goos string, execPath string) string {
+	p := strings.ToLower(execPath)
+	isNpm := strings.Contains(p, "node_modules")
+
+	switch goos {
 	case "darwin":
-		return "To update, run: brew update && brew upgrade infisical"
+		if isNpm {
+			return "To update, run: npm update -g @infisical/cli"
+		}
+		if strings.Contains(p, "/homebrew/") || strings.Contains(p, "/cellar/") {
+			return "To update, run: brew update && brew upgrade infisical"
+		}
+		return ""
 	case "windows":
+		if isNpm {
+			return "To update, run: npm update -g @infisical/cli"
+		}
+		if strings.Contains(p, "scoop") {
+			return "To update, run: scoop update infisical"
+		}
+		if strings.Contains(p, "winget") {
+			return "To update, run: winget upgrade Infisical.Infisical"
+		}
 		return "To update, run: scoop update infisical"
 	case "linux":
+		if isNpm {
+			return "To update, run: npm update -g @infisical/cli"
+		}
 		pkgManager := getLinuxPackageManager()
 		switch pkgManager {
 		case "apt-get":

--- a/packages/util/check-for-update_test.go
+++ b/packages/util/check-for-update_test.go
@@ -17,6 +17,106 @@ func init() {
 	color.NoColor = true
 }
 
+func TestGetUpdateInstructions(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		execPath    string
+		expected    string
+		expectEmpty bool // true means assert empty result (vs. skipping runtime-dependent cases)
+	}{
+		// darwin
+		{
+			name:     "darwin brew",
+			goos:     "darwin",
+			execPath: "/opt/homebrew/bin/infisical",
+			expected: "brew update && brew upgrade infisical",
+		},
+		{
+			name:     "darwin npm",
+			goos:     "darwin",
+			execPath: "/opt/homebrew/lib/node_modules/@infisical/cli/bin/infisical",
+			expected: "npm update -g @infisical/cli",
+		},
+		{
+			name:     "darwin cellar",
+			goos:     "darwin",
+			execPath: "/usr/local/Cellar/infisical/0.1.0/bin/infisical",
+			expected: "brew update && brew upgrade infisical",
+		},
+		{
+			name:        "darwin nix returns empty",
+			goos:        "darwin",
+			execPath:    "/nix/store/abc123-infisical/bin/infisical",
+			expectEmpty: true,
+		},
+		{
+			name:        "darwin direct binary returns empty",
+			goos:        "darwin",
+			execPath:    "/usr/local/bin/infisical",
+			expectEmpty: true,
+		},
+
+		// windows
+		{
+			name:     "windows scoop",
+			goos:     "windows",
+			execPath: `C:\Users\user\scoop\apps\infisical\current\infisical.exe`,
+			expected: "scoop update infisical",
+		},
+		{
+			name:     "windows npm",
+			goos:     "windows",
+			execPath: `C:\Users\user\AppData\Roaming\npm\node_modules\@infisical\cli\bin\infisical.exe`,
+			expected: "npm update -g @infisical/cli",
+		},
+		{
+			name:     "windows winget",
+			goos:     "windows",
+			execPath: `C:\Users\user\AppData\Local\Microsoft\WinGet\Links\infisical.exe`,
+			expected: "winget upgrade Infisical.Infisical",
+		},
+		{
+			name:     "windows unknown defaults to scoop",
+			goos:     "windows",
+			execPath: `C:\infisical\infisical.exe`,
+			expected: "scoop update infisical",
+		},
+
+		// linux
+		{
+			name:     "linux apt",
+			goos:     "linux",
+			execPath: "/usr/bin/infisical",
+			expected: "", // apt detection is runtime — tested in integration
+		},
+		{
+			name:     "linux npm",
+			goos:     "linux",
+			execPath: "/home/user/.npm-global/lib/node_modules/@infisical/cli/bin/infisical",
+			expected: "npm update -g @infisical/cli",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getUpdateInstructions(tt.goos, tt.execPath)
+			if tt.expectEmpty {
+				if result != "" {
+					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+			if tt.expected == "" {
+				return // skip runtime-dependent cases
+			}
+			if !strings.Contains(result, tt.expected) {
+				t.Errorf("expected %q to contain %q", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIsCacheFresh(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/packages/util/check-for-update_test.go
+++ b/packages/util/check-for-update_test.go
@@ -77,10 +77,10 @@ func TestGetUpdateInstructions(t *testing.T) {
 			expected: "winget upgrade Infisical.Infisical",
 		},
 		{
-			name:     "windows unknown defaults to scoop",
-			goos:     "windows",
-			execPath: `C:\infisical\infisical.exe`,
-			expected: "scoop update infisical",
+			name:        "windows unknown returns empty",
+			goos:        "windows",
+			execPath:    `C:\infisical\infisical.exe`,
+			expectEmpty: true,
 		},
 
 		// linux

--- a/test/update-hint/main.go
+++ b/test/update-hint/main.go
@@ -1,0 +1,14 @@
+// Helper binary for integration testing of update hint path detection.
+// Prints the update instruction for the current executable path and OS,
+// without making any network calls.
+package main
+
+import (
+	"fmt"
+
+	"github.com/Infisical/infisical-merge/packages/util"
+)
+
+func main() {
+	fmt.Println(util.GetUpdateInstructions())
+}


### PR DESCRIPTION
# Description 📣

Fixes incorrect update instructions shown to users based on their install method. Previously, the update hint was hardcoded per OS — for example, Windows users who installed via npm would always see `scoop update infisical` regardless of how they actually installed the CLI.

This PR refactors `GetUpdateInstructions()` to detect the install method at runtime by inspecting the executable path via `os.Executable()` + `filepath.EvalSymlinks()`. Symlink resolution is explicitly handled to cover macOS and Linux where package managers like npm create symlinks in `$PATH` pointing to the real binary inside `node_modules`.

**Before:**
```
Windows → always: scoop update infisical
macOS   → always: brew update && brew upgrade infisical
```

**After:**
```
Windows + npm    → npm update -g @infisical/cli
Windows + scoop  → scoop update infisical
Windows + winget → winget upgrade Infisical.Infisical
macOS + npm      → npm update -g @infisical/cli
macOS + brew     → brew update && brew upgrade infisical
Linux + npm      → npm update -g @infisical/cli
Linux + apt/yum/apk/yay → (unchanged)
```

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
Added unit tests covering all install method/OS combinations, and multi-OS integration tests that build a test helper binary, place it at real install paths (including via symlink to simulate npm's behavior), and assert the correct instruction is returned.

**Run unit tests:**
```sh
go test ./packages/util/ -run TestGetUpdateInstructions -v
```

**Run integration tests locally (macOS):**
```sh
go build -o update-hint ./test/update-hint

# brew (default)
mkdir -p /tmp/homebrew/bin
cp update-hint /tmp/homebrew/bin/update-hint
/tmp/homebrew/bin/update-hint
# → To update, run: brew update && brew upgrade infisical

# npm via symlink (as npm installs it)
mkdir -p /tmp/node_modules/@infisical/cli/bin /tmp/bin
cp update-hint /tmp/node_modules/@infisical/cli/bin/update-hint
ln -sf /tmp/node_modules/@infisical/cli/bin/update-hint /tmp/bin/update-hint
/tmp/bin/update-hint
# → To update, run: npm update -g @infisical/cli
```

CI runs automatically on `ubuntu-latest`, `macos-latest`, and `windows-latest` via `.github/workflows/test-update-instructions.yml`, covering npm, brew, scoop, winget, and apt detection on their respective platforms.

Sample CI ran successfully: https://github.com/pangeran-bottor/cli/actions/runs/22317820293


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->