### PR TITLE
feat(proxy): Add support for secret update using SSE

### DIFF
--- a/.github/workflows/run-cli-e2e-tests.yml
+++ b/.github/workflows/run-cli-e2e-tests.yml
@@ -39,6 +39,7 @@ jobs:
         working-directory: ./e2e
         env:
           INFISICAL_BACKEND_DIR: ${{ github.workspace }}/infisical/backend
+          INFISICAL_LICENSE_KEY: ${{ secrets.INFISICAL_LICENSE_KEY }}
           INFISICAL_CLI_EXECUTABLE: ${{ github.workspace }}/infisical-cli
           CLI_E2E_DEFAULT_RUN_METHOD: subprocess
 
@@ -65,6 +66,7 @@ jobs:
         run: go test -v -timeout 30m -count=1 github.com/infisical/cli/e2e-tests/agent
         working-directory: ./e2e
         env:
+          INFISICAL_LICENSE_KEY: ${{ secrets.INFISICAL_LICENSE_KEY }}
           INFISICAL_BACKEND_DIR: ${{ github.workspace }}/infisical/backend
           INFISICAL_CLI_EXECUTABLE: ${{ github.workspace }}/infisical-cli
           CLI_E2E_DEFAULT_RUN_METHOD: subprocess
@@ -100,6 +102,7 @@ jobs:
         working-directory: ./e2e
         env:
           INFISICAL_BACKEND_DIR: ${{ github.workspace }}/infisical/backend
+          INFISICAL_LICENSE_KEY: ${{ secrets.INFISICAL_LICENSE_KEY }}
           INFISICAL_CLI_EXECUTABLE: ${{ github.workspace }}/infisical-cli
           CLI_E2E_DEFAULT_RUN_METHOD: subprocess
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ infisical-merge
 test/infisical-merge
 .DS_Store
 
+infisical
+
 
 /agent-testing

--- a/e2e/packages/infisical/compose.go
+++ b/e2e/packages/infisical/compose.go
@@ -228,6 +228,7 @@ func (s *Stack) ApiUrl(ctx context.Context) (string, error) {
 
 func BackendOptionsFromEnv() BackendOptions {
 	backendDir, found := os.LookupEnv("INFISICAL_BACKEND_DIR")
+	fmt.Println("backendDir", backendDir)
 	if !found {
 		panic("INFISICAL_BACKEND_DIR not set, in order fo the e2e tests to work, you need to set the INFISICAL_BACKEND_DIR environment variable to the path of the backend directory, e.g. /Users/your-username/code/infisical/backend")
 	}

--- a/e2e/packages/infisical/compose.go
+++ b/e2e/packages/infisical/compose.go
@@ -228,7 +228,6 @@ func (s *Stack) ApiUrl(ctx context.Context) (string, error) {
 
 func BackendOptionsFromEnv() BackendOptions {
 	backendDir, found := os.LookupEnv("INFISICAL_BACKEND_DIR")
-	fmt.Println("backendDir", backendDir)
 	if !found {
 		panic("INFISICAL_BACKEND_DIR not set, in order fo the e2e tests to work, you need to set the INFISICAL_BACKEND_DIR environment variable to the path of the backend directory, e.g. /Users/your-username/code/infisical/backend")
 	}

--- a/e2e/packages/infisical/compose.go
+++ b/e2e/packages/infisical/compose.go
@@ -301,6 +301,14 @@ func WithPebbleService() StackOption {
 }
 
 func WithBackendService(options BackendOptions) StackOption {
+
+	licenseKey, found := os.LookupEnv("INFISICAL_LICENSE_KEY")
+	if !found {
+		log.Println("INFISICAL_LICENSE_KEY not set, continuing without licensing.")
+	} else {
+		log.Println("INFISICAL_LICENSE_KEY set, continuing with licensing.")
+	}
+
 	return func(s *Stack) {
 		if s.Project.Services == nil {
 			s.Project.Services = types.Services{}
@@ -329,6 +337,7 @@ func WithBackendService(options BackendOptions) StackOption {
 				"SITE_URL=http://localhost:8080",
 				"OTEL_TELEMETRY_COLLECTION_ENABLED=false",
 				"ENABLE_MSSQL_SECRET_ROTATION_ENCRYPT=true",
+				"LICENSE_KEY=" + licenseKey,
 			}),
 			Volumes: []types.ServiceVolumeConfig{
 				{Source: filepath.Join(options.BackendDir, "src"), Target: "/app/src", Type: types.VolumeTypeBind},

--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -90,7 +90,7 @@ func startProxy(t *testing.T, ctx context.Context, infisicalURL string, config P
 }
 
 // setupProxyTest sets up the common test
-func setupProxyTest(t *testing.T, ctx context.Context, proxyConfig ProxyTestConfig) (*helpers.InfisicalService, *proxyHelpers.ProxyTestHelper, *helpers.Command, string, string) {
+func setupProxyTest(t *testing.T, ctx context.Context, proxyConfig ProxyTestConfig) (*helpers.InfisicalService, *proxyHelpers.ProxyTestHelper, *helpers.Command, string, string, helpers.MachineIdentity) {
 	infisical := helpers.NewInfisicalService().Up(t, ctx)
 
 	// create machine identity with token auth (and universal auth if SSE is enabled)
@@ -145,14 +145,14 @@ func setupProxyTest(t *testing.T, ctx context.Context, proxyConfig ProxyTestConf
 	// create test helper with both proxy and direct API clients
 	helper := proxyHelpers.NewProxyTestHelper(t, proxyURL, infisical.ApiUrl(t), identityToken, projectID)
 
-	return infisical, helper, proxyCmd, identityToken, proxyURL
+	return infisical, helper, proxyCmd, identityToken, proxyURL, identity
 }
 
 func TestProxy_CacheHitMiss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -209,7 +209,7 @@ func TestProxy_MutationPurging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	initialSecret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
 		Prefix: "MUTATION_TEST_",
@@ -281,7 +281,7 @@ func TestProxy_DeleteMutationPurging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -338,7 +338,7 @@ func TestProxy_TokenInvalidation(t *testing.T) {
 	config := DefaultProxyTestConfig()
 	config.AccessTokenCheckInterval = "2s"
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, config)
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, config)
 
 	// create and cache a secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -377,7 +377,7 @@ func TestProxy_HighAvailability(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	infisical, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	infisical, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create and cache a secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -451,7 +451,7 @@ func TestProxy_BackgroundRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test initialSecret
 	initialSecret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -520,7 +520,7 @@ func TestProxy_MultipleSecrets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, _, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	var secrets []proxyHelpers.Secret
 	for i := 0; i < 3; i++ {
@@ -557,7 +557,7 @@ func TestProxy_SingleSecretEndpoint(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -591,7 +591,7 @@ func TestProxy_SSECacheUpdate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
+	_, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
 
 	// wait for SSE manager initialization
 	result := helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
@@ -687,7 +687,7 @@ func TestProxy_SSEConnectionRecovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	infisical, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
+	infisical, helper, proxyCmd, _, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
 
 	// create and cache a secret to trigger SSE subscription
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -777,7 +777,7 @@ func TestProxy_SSEMultipleProjects(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	infisical, helper1, proxyCmd, identityToken, proxyURL := setupProxyTest(t, ctx, SSEProxyTestConfig())
+	infisical, helper1, proxyCmd, identityToken, proxyURL, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
 
 	// create a second project using the same identity
 	bearerAuth, err := securityprovider.NewSecurityProviderBearerToken(identityToken)
@@ -883,123 +883,4 @@ func TestProxy_SSEMultipleProjects(t *testing.T) {
 		}
 	}
 	require.True(t, foundOriginal, "Original secret not found in project 2")
-}
-
-func TestProxy_SSEPollingFallbackRecovery(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	infisical, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
-
-	// create and cache a secret to trigger SSE subscription
-	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
-		Prefix: "SSE_POLLING_RECOVERY_",
-	})
-	helper.CreateSecretWithApi(ctx, secret)
-
-	slog.Info("Caching secret via proxy")
-	resp1 := helper.GetSecretsWithProxy(ctx)
-	require.Equal(t, http.StatusOK, resp1.StatusCode())
-	require.NotEmpty(t, resp1.JSON200.Secrets)
-
-	// wait for SSE connection established
-	result := helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
-		EnsureCmdRunning: proxyCmd,
-		ExpectedString:   "SSE connection established",
-		Timeout:          30 * time.Second,
-	})
-	require.Equal(t, helpers.WaitSuccess, result)
-
-	// stop the Infisical backend to break SSE connection
-	slog.Info("Stopping Infisical backend to break SSE connection")
-	backendContainer, err := infisical.Compose().ServiceContainer(ctx, "backend")
-	require.NoError(t, err)
-	err = backendContainer.Stop(ctx, nil)
-	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		state, err := backendContainer.State(ctx)
-		if err != nil {
-			return false
-		}
-		return !state.Running
-	}, 60*time.Second, 200*time.Millisecond, "Backend container should have stopped")
-	slog.Info("Backend stopped")
-
-	// wait for SSE connection loss
-	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
-		EnsureCmdRunning: proxyCmd,
-		ExpectedString:   "SSE connection lost",
-		Timeout:          30 * time.Second,
-	})
-	require.Equal(t, helpers.WaitSuccess, result, "SSE connection loss should be detected")
-
-	// wait for SSE retries to exhaust and polling fallback to start (~62s worst case with backoff)
-	slog.Info("Waiting for SSE retries to exhaust and polling fallback to start")
-	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
-		EnsureCmdRunning: proxyCmd,
-		ExpectedString:   "transitioning to polling fallback",
-		Timeout:          180 * time.Second,
-	})
-	require.Equal(t, helpers.WaitSuccess, result, "Should transition to polling fallback after retries exhausted")
-
-	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
-		EnsureCmdRunning: proxyCmd,
-		ExpectedString:   "Starting polling fallback for project",
-		Timeout:          10 * time.Second,
-	})
-	require.Equal(t, helpers.WaitSuccess, result, "Polling fallback loop should start")
-
-	// restart the Infisical backend
-	slog.Info("Restarting Infisical backend")
-	err = backendContainer.Start(ctx)
-	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		state, err := backendContainer.State(ctx)
-		if err != nil {
-			return false
-		}
-		return state.Running
-	}, 60*time.Second, 200*time.Millisecond, "Backend container should have restarted")
-	slog.Info("Backend restarted")
-
-	// trigger EnsureSubscription by making a request — detects polling, attempts SSE reconnection
-	slog.Info("Fetching secrets to trigger SSE reconnection from polling mode")
-	respAfterRestart := helper.GetSecretsWithProxy(ctx)
-	require.Equal(t, http.StatusOK, respAfterRestart.StatusCode())
-
-	// wait for SSE to re-establish (second occurrence after reconnection from polling)
-	slog.Info("Waiting for SSE reconnection from polling mode")
-	waitResult := helpers.WaitFor(t, helpers.WaitForOptions{
-		EnsureCmdRunning: proxyCmd,
-		Timeout:          120 * time.Second,
-		Interval:         1 * time.Second,
-		Condition: func() helpers.ConditionResult {
-			if strings.Count(proxyCmd.Stderr(), "SSE connection established") >= 2 {
-				return helpers.ConditionSuccess
-			}
-			return helpers.ConditionWait
-		},
-	})
-	require.Equal(t, helpers.WaitSuccess, waitResult, "SSE should reconnect from polling fallback")
-
-	// verify polling was cancelled after SSE recovery
-	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
-		EnsureCmdRunning: proxyCmd,
-		ExpectedString:   "cancelled polling fallback",
-		Timeout:          30 * time.Second,
-	})
-	require.Equal(t, helpers.WaitSuccess, result, "Polling should be cancelled after SSE recovery")
-
-	// verify proxy is still functional
-	slog.Info("Verifying proxy still works after SSE recovery from polling")
-	respFinal := helper.GetSecretsWithProxy(ctx)
-	require.Equal(t, http.StatusOK, respFinal.StatusCode())
-	require.True(t, proxyCmd.IsRunning(), "Proxy should still be running")
-
-	// tear down compose stack for clean state in subsequent tests
-	slog.Info("Tearing down compose stack for clean state")
-	err = infisical.DownWithForce(ctx)
-	require.NoError(t, err, "Failed to tear down compose stack")
 }

--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -66,7 +66,7 @@ func startProxy(t *testing.T, ctx context.Context, infisicalURL string, config P
 	}
 
 	if config.UseSSE {
-		args = append(args, "--use-sse")
+		args = append(args, "--event-subscription-enabled")
 		args = append(args, "--client-id", config.ClientID)
 		args = append(args, "--client-secret", config.ClientSecret)
 	}
@@ -883,4 +883,123 @@ func TestProxy_SSEMultipleProjects(t *testing.T) {
 		}
 	}
 	require.True(t, foundOriginal, "Original secret not found in project 2")
+}
+
+func TestProxy_SSEPollingFallbackRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	infisical, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
+
+	// create and cache a secret to trigger SSE subscription
+	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		Prefix: "SSE_POLLING_RECOVERY_",
+	})
+	helper.CreateSecretWithApi(ctx, secret)
+
+	slog.Info("Caching secret via proxy")
+	resp1 := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp1.StatusCode())
+	require.NotEmpty(t, resp1.JSON200.Secrets)
+
+	// wait for SSE connection established
+	result := helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE connection established",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// stop the Infisical backend to break SSE connection
+	slog.Info("Stopping Infisical backend to break SSE connection")
+	backendContainer, err := infisical.Compose().ServiceContainer(ctx, "backend")
+	require.NoError(t, err)
+	err = backendContainer.Stop(ctx, nil)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		state, err := backendContainer.State(ctx)
+		if err != nil {
+			return false
+		}
+		return !state.Running
+	}, 60*time.Second, 200*time.Millisecond, "Backend container should have stopped")
+	slog.Info("Backend stopped")
+
+	// wait for SSE connection loss
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE connection lost",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result, "SSE connection loss should be detected")
+
+	// wait for SSE retries to exhaust and polling fallback to start (~62s worst case with backoff)
+	slog.Info("Waiting for SSE retries to exhaust and polling fallback to start")
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "transitioning to polling fallback",
+		Timeout:          180 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result, "Should transition to polling fallback after retries exhausted")
+
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "Starting polling fallback for project",
+		Timeout:          10 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result, "Polling fallback loop should start")
+
+	// restart the Infisical backend
+	slog.Info("Restarting Infisical backend")
+	err = backendContainer.Start(ctx)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		state, err := backendContainer.State(ctx)
+		if err != nil {
+			return false
+		}
+		return state.Running
+	}, 60*time.Second, 200*time.Millisecond, "Backend container should have restarted")
+	slog.Info("Backend restarted")
+
+	// trigger EnsureSubscription by making a request — detects polling, attempts SSE reconnection
+	slog.Info("Fetching secrets to trigger SSE reconnection from polling mode")
+	respAfterRestart := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, respAfterRestart.StatusCode())
+
+	// wait for SSE to re-establish (second occurrence after reconnection from polling)
+	slog.Info("Waiting for SSE reconnection from polling mode")
+	waitResult := helpers.WaitFor(t, helpers.WaitForOptions{
+		EnsureCmdRunning: proxyCmd,
+		Timeout:          120 * time.Second,
+		Interval:         1 * time.Second,
+		Condition: func() helpers.ConditionResult {
+			if strings.Count(proxyCmd.Stderr(), "SSE connection established") >= 2 {
+				return helpers.ConditionSuccess
+			}
+			return helpers.ConditionWait
+		},
+	})
+	require.Equal(t, helpers.WaitSuccess, waitResult, "SSE should reconnect from polling fallback")
+
+	// verify polling was cancelled after SSE recovery
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "cancelled polling fallback",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result, "Polling should be cancelled after SSE recovery")
+
+	// verify proxy is still functional
+	slog.Info("Verifying proxy still works after SSE recovery from polling")
+	respFinal := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, respFinal.StatusCode())
+	require.True(t, proxyCmd.IsRunning(), "Proxy should still be running")
+
+	// tear down compose stack for clean state in subsequent tests
+	slog.Info("Tearing down compose stack for clean state")
+	err = infisical.DownWithForce(ctx)
+	require.NoError(t, err, "Failed to tear down compose stack")
 }

--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,9 @@ type ProxyTestConfig struct {
 	TLSKeyFile                   string
 	AccessTokenCheckInterval     string
 	StaticSecretsRefreshInterval string
+	UseSSE                       bool
+	ClientID                     string
+	ClientSecret                 string
 }
 
 // DefaultProxyTestConfig returns default test configuration
@@ -35,6 +39,13 @@ func DefaultProxyTestConfig() ProxyTestConfig {
 		AccessTokenCheckInterval:     "5s",
 		StaticSecretsRefreshInterval: "5s",
 	}
+}
+
+// SSEProxyTestConfig returns test configuration with SSE enabled
+func SSEProxyTestConfig() ProxyTestConfig {
+	config := DefaultProxyTestConfig()
+	config.UseSSE = true
+	return config
 }
 
 // startProxy starts the proxy command and returns it
@@ -52,6 +63,12 @@ func startProxy(t *testing.T, ctx context.Context, infisicalURL string, config P
 	if config.TLSEnabled && config.TLSCertFile != "" && config.TLSKeyFile != "" {
 		args = append(args, "--tls-cert-file", config.TLSCertFile)
 		args = append(args, "--tls-key-file", config.TLSKeyFile)
+	}
+
+	if config.UseSSE {
+		args = append(args, "--use-sse")
+		args = append(args, "--client-id", config.ClientID)
+		args = append(args, "--client-secret", config.ClientSecret)
 	}
 
 	proxyCmd := helpers.Command{
@@ -73,13 +90,24 @@ func startProxy(t *testing.T, ctx context.Context, infisicalURL string, config P
 }
 
 // setupProxyTest sets up the common test
-func setupProxyTest(t *testing.T, ctx context.Context, proxyConfig ProxyTestConfig) (*helpers.InfisicalService, *proxyHelpers.ProxyTestHelper, *helpers.Command) {
+func setupProxyTest(t *testing.T, ctx context.Context, proxyConfig ProxyTestConfig) (*helpers.InfisicalService, *proxyHelpers.ProxyTestHelper, *helpers.Command, string, string) {
 	infisical := helpers.NewInfisicalService().Up(t, ctx)
 
-	// create machine identity with token auth
-	identity := infisical.CreateMachineIdentity(t, ctx, helpers.WithTokenAuth())
+	// create machine identity with token auth (and universal auth if SSE is enabled)
+	identityOpts := []helpers.MachineIdentityOption{helpers.WithTokenAuth()}
+	if proxyConfig.UseSSE {
+		identityOpts = append(identityOpts, helpers.WithUniversalAuth())
+	}
+	identity := infisical.CreateMachineIdentity(t, ctx, identityOpts...)
 	require.NotNil(t, identity.TokenAuthToken)
 	identityToken := *identity.TokenAuthToken
+
+	if proxyConfig.UseSSE {
+		require.NotNil(t, identity.UniversalAuthClientId)
+		require.NotNil(t, identity.UniversalAuthClientSecret)
+		proxyConfig.ClientID = *identity.UniversalAuthClientId
+		proxyConfig.ClientSecret = *identity.UniversalAuthClientSecret
+	}
 
 	// create API client with identity token to create the project
 	bearerAuth, err := securityprovider.NewSecurityProviderBearerToken(identityToken)
@@ -117,14 +145,14 @@ func setupProxyTest(t *testing.T, ctx context.Context, proxyConfig ProxyTestConf
 	// create test helper with both proxy and direct API clients
 	helper := proxyHelpers.NewProxyTestHelper(t, proxyURL, infisical.ApiUrl(t), identityToken, projectID)
 
-	return infisical, helper, proxyCmd
+	return infisical, helper, proxyCmd, identityToken, proxyURL
 }
 
 func TestProxy_CacheHitMiss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -181,7 +209,7 @@ func TestProxy_MutationPurging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	initialSecret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
 		Prefix: "MUTATION_TEST_",
@@ -253,7 +281,7 @@ func TestProxy_DeleteMutationPurging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -310,7 +338,7 @@ func TestProxy_TokenInvalidation(t *testing.T) {
 	config := DefaultProxyTestConfig()
 	config.AccessTokenCheckInterval = "2s"
 
-	_, helper, proxyCmd := setupProxyTest(t, ctx, config)
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, config)
 
 	// create and cache a secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -349,7 +377,7 @@ func TestProxy_HighAvailability(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	infisical, helper, proxyCmd := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	infisical, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create and cache a secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -423,7 +451,7 @@ func TestProxy_BackgroundRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test initialSecret
 	initialSecret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -492,7 +520,7 @@ func TestProxy_MultipleSecrets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, _, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	var secrets []proxyHelpers.Secret
 	for i := 0; i < 3; i++ {
@@ -529,7 +557,7 @@ func TestProxy_SingleSecretEndpoint(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	_, helper, proxyCmd := setupProxyTest(t, ctx, DefaultProxyTestConfig())
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, DefaultProxyTestConfig())
 
 	// create a test secret
 	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
@@ -558,3 +586,303 @@ func TestProxy_SingleSecretEndpoint(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp2.StatusCode())
 }
+
+func TestProxy_SSECacheUpdate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	_, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
+
+	// wait for SSE manager initialization
+	result := helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE manager initialized",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// create secret via API (not proxy)
+	initialSecret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		Prefix: "SSE_UPDATE_TEST_",
+	})
+	helper.CreateSecretWithApi(ctx, initialSecret)
+
+	// fetch via proxy -> cache miss, now cached
+	slog.Info("Fetching secret via proxy (expecting cache miss)")
+	resp1 := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp1.StatusCode())
+	require.NotNil(t, resp1.JSON200)
+
+	var foundInitial bool
+	for _, s := range resp1.JSON200.Secrets {
+		if s.SecretKey == initialSecret.SecretKey {
+			assert.Equal(t, initialSecret.SecretValue, s.SecretValue)
+			foundInitial = true
+			break
+		}
+	}
+	require.True(t, foundInitial, "Initial secret not found in response")
+
+	// fetch again -> cache hit
+	helper.GetSecretsWithProxy(ctx)
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "Cache hit",
+		Timeout:          10 * time.Second,
+		Interval:         200 * time.Millisecond,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// wait for SSE connection (demand-driven, triggered by first fetch)
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE connection established",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// update secret via API (not proxy) -> SSE event fires
+	slog.Info("Updating secret via API (expecting SSE event)")
+	updatedSecret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		PresetName: initialSecret.SecretKey,
+	})
+	helper.UpdateSecretWithApi(ctx, updatedSecret)
+
+	// wait for SSE event processing
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "Processing SSE event",
+		Timeout:          15 * time.Second,
+		Interval:         500 * time.Millisecond,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// wait for refetch to complete
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE refetch completed",
+		Timeout:          15 * time.Second,
+		Interval:         500 * time.Millisecond,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// fetch via proxy -> should return updated value (repopulated by SSE refetch)
+	slog.Info("Fetching secret via proxy after SSE update")
+	resp3 := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp3.StatusCode())
+	require.NotNil(t, resp3.JSON200)
+
+	var foundUpdated bool
+	for _, s := range resp3.JSON200.Secrets {
+		if s.SecretKey == initialSecret.SecretKey {
+			assert.Equal(t, updatedSecret.SecretValue, s.SecretValue, "Cache should reflect SSE-driven update")
+			foundUpdated = true
+			break
+		}
+	}
+	require.True(t, foundUpdated, "Updated secret not found after SSE event")
+}
+
+func TestProxy_SSEConnectionRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	infisical, helper, proxyCmd, _, _ := setupProxyTest(t, ctx, SSEProxyTestConfig())
+
+	// create and cache a secret to trigger SSE subscription
+	secret := helper.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		Prefix: "SSE_RECOVERY_",
+	})
+	helper.CreateSecretWithApi(ctx, secret)
+
+	slog.Info("Caching secret via proxy")
+	resp1 := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp1.StatusCode())
+	require.NotEmpty(t, resp1.JSON200.Secrets)
+
+	// wait for SSE connection established
+	result := helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE connection established",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// stop the Infisical backend container (SSE connection drops)
+	slog.Info("Stopping Infisical backend to break SSE connection")
+	backendContainer, err := infisical.Compose().ServiceContainer(ctx, "backend")
+	require.NoError(t, err)
+	err = backendContainer.Stop(ctx, nil)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		state, err := backendContainer.State(ctx)
+		if err != nil {
+			return false
+		}
+		return !state.Running
+	}, 60*time.Second, 200*time.Millisecond, "Backend container should have stopped")
+	slog.Info("Backend stopped")
+
+	// wait for SSE connection loss
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE connection lost",
+		Timeout:          30 * time.Second,
+	})
+	require.Equal(t, helpers.WaitSuccess, result, "SSE connection loss should be detected")
+
+	// restart the backend container
+	slog.Info("Restarting Infisical backend")
+	err = backendContainer.Start(ctx)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		state, err := backendContainer.State(ctx)
+		if err != nil {
+			return false
+		}
+		return state.Running
+	}, 60*time.Second, 200*time.Millisecond, "Backend container should have restarted")
+	slog.Info("Backend restarted")
+
+	// wait for SSE reconnection (second occurrence of "SSE connection established")
+	slog.Info("Waiting for SSE reconnection")
+	waitResult := helpers.WaitFor(t, helpers.WaitForOptions{
+		EnsureCmdRunning: proxyCmd,
+		Timeout:          120 * time.Second,
+		Interval:         2 * time.Second,
+		Condition: func() helpers.ConditionResult {
+			if strings.Count(proxyCmd.Stderr(), "SSE connection established") >= 2 {
+				return helpers.ConditionSuccess
+			}
+			return helpers.ConditionWait
+		},
+	})
+	require.Equal(t, helpers.WaitSuccess, waitResult, "SSE should reconnect after backend restart")
+
+	// verify proxy is still functional
+	slog.Info("Verifying proxy still works after SSE reconnection")
+	resp2 := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp2.StatusCode())
+
+	require.True(t, proxyCmd.IsRunning(), "Proxy should still be running")
+
+	// tear down compose stack for clean state in subsequent tests
+	slog.Info("Tearing down compose stack for clean state")
+	err = infisical.DownWithForce(ctx)
+	require.NoError(t, err, "Failed to tear down compose stack")
+}
+
+func TestProxy_SSEMultipleProjects(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	infisical, helper1, proxyCmd, identityToken, proxyURL := setupProxyTest(t, ctx, SSEProxyTestConfig())
+
+	// create a second project using the same identity
+	bearerAuth, err := securityprovider.NewSecurityProviderBearerToken(identityToken)
+	require.NoError(t, err)
+
+	identityClient, err := client.NewClientWithResponses(
+		infisical.ApiUrl(t),
+		client.WithHTTPClient(&http.Client{}),
+		client.WithRequestEditorFn(bearerAuth.Intercept),
+	)
+	require.NoError(t, err)
+
+	projectType := client.SecretManager
+	project2Resp, err := identityClient.CreateProjectWithResponse(ctx, client.CreateProjectJSONRequestBody{
+		ProjectName: "proxy-sse-test-2-" + helpers.RandomSlug(2),
+		Type:        &projectType,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, project2Resp.StatusCode(), "Failed to create project 2: %s", string(project2Resp.Body))
+	project2ID := project2Resp.JSON200.Project.Id
+	slog.Info("Created project 2", "id", project2ID)
+
+	// create helper2 for project 2, pointed at the same proxy
+	helper2 := proxyHelpers.NewProxyTestHelper(t, proxyURL, infisical.ApiUrl(t), identityToken, project2ID)
+
+	// create secrets in each project
+	secret1 := helper1.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		Prefix: "SSE_MULTI_P1_",
+	})
+	helper1.CreateSecretWithApi(ctx, secret1)
+
+	secret2 := helper2.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		Prefix: "SSE_MULTI_P2_",
+	})
+	helper2.CreateSecretWithApi(ctx, secret2)
+
+	// fetch from each project via proxy -> triggers SSE subscription for each
+	slog.Info("Fetching secrets from project 1 via proxy")
+	resp1 := helper1.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp1.StatusCode())
+
+	slog.Info("Fetching secrets from project 2 via proxy")
+	resp2 := helper2.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp2.StatusCode())
+
+	// verify two separate SSE connections established (one per project)
+	slog.Info("Waiting for two SSE connections to be established")
+	waitResult := helpers.WaitFor(t, helpers.WaitForOptions{
+		EnsureCmdRunning: proxyCmd,
+		Timeout:          30 * time.Second,
+		Interval:         1 * time.Second,
+		Condition: func() helpers.ConditionResult {
+			if strings.Count(proxyCmd.Stderr(), "SSE connection established") >= 2 {
+				return helpers.ConditionSuccess
+			}
+			return helpers.ConditionWait
+		},
+	})
+	require.Equal(t, helpers.WaitSuccess, waitResult, "Two SSE connections should be established")
+
+	// update secret in project 1 via API
+	slog.Info("Updating secret in project 1 via API")
+	updatedSecret1 := helper1.GenerateSecret(proxyHelpers.GenerateSecretOptions{
+		PresetName: secret1.SecretKey,
+	})
+	helper1.UpdateSecretWithApi(ctx, updatedSecret1)
+
+	// wait for SSE event processing
+	result := helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
+		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE refetch completed",
+		Timeout:          15 * time.Second,
+		Interval:         500 * time.Millisecond,
+	})
+	require.Equal(t, helpers.WaitSuccess, result)
+
+	// verify project 1 has updated value
+	slog.Info("Verifying project 1 has updated value")
+	resp1After := helper1.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp1After.StatusCode())
+
+	var foundUpdated bool
+	for _, s := range resp1After.JSON200.Secrets {
+		if s.SecretKey == secret1.SecretKey {
+			assert.Equal(t, updatedSecret1.SecretValue, s.SecretValue, "Project 1 secret should be updated via SSE")
+			foundUpdated = true
+			break
+		}
+	}
+	require.True(t, foundUpdated, "Updated secret not found in project 1")
+
+	// verify project 2 still has original value (not invalidated)
+	slog.Info("Verifying project 2 still has original value")
+	resp2After := helper2.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, resp2After.StatusCode())
+
+	var foundOriginal bool
+	for _, s := range resp2After.JSON200.Secrets {
+		if s.SecretKey == secret2.SecretKey {
+			assert.Equal(t, secret2.SecretValue, s.SecretValue, "Project 2 secret should be unchanged")
+			foundOriginal = true
+			break
+		}
+	}
+	require.True(t, foundOriginal, "Original secret not found in project 2")
+}
+

--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -746,25 +746,24 @@ func TestProxy_SSEConnectionRecovery(t *testing.T) {
 	}, 60*time.Second, 200*time.Millisecond, "Backend container should have restarted")
 	slog.Info("Backend restarted")
 
-	// wait for SSE reconnection (second occurrence of "SSE connection established")
-	slog.Info("Waiting for SSE reconnection")
-	waitResult := helpers.WaitFor(t, helpers.WaitForOptions{
+	// trigger normal client traffic so EnsureSubscription can recreate SSE if retries were exhausted
+	slog.Info("Fetching secrets after backend restart to trigger SSE re-subscription")
+	respAfterRestart := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, respAfterRestart.StatusCode())
+
+	// wait for SSE re-subscription after the fetch trigger
+	slog.Info("Waiting for SSE re-subscription after fetch trigger")
+	result = helpers.WaitForStderr(t, helpers.WaitForStderrOptions{
 		EnsureCmdRunning: proxyCmd,
+		ExpectedString:   "SSE connection established",
 		Timeout:          120 * time.Second,
-		Interval:         2 * time.Second,
-		Condition: func() helpers.ConditionResult {
-			if strings.Count(proxyCmd.Stderr(), "SSE connection established") >= 2 {
-				return helpers.ConditionSuccess
-			}
-			return helpers.ConditionWait
-		},
 	})
-	require.Equal(t, helpers.WaitSuccess, waitResult, "SSE should reconnect after backend restart")
+	require.Equal(t, helpers.WaitSuccess, result, "SSE should re-subscribe after backend restart and a trigger fetch")
 
 	// verify proxy is still functional
 	slog.Info("Verifying proxy still works after SSE reconnection")
-	resp2 := helper.GetSecretsWithProxy(ctx)
-	require.Equal(t, http.StatusOK, resp2.StatusCode())
+	respAfterReconnect := helper.GetSecretsWithProxy(ctx)
+	require.Equal(t, http.StatusOK, respAfterReconnect.StatusCode())
 
 	require.True(t, proxyCmd.IsRunning(), "Proxy should still be running")
 
@@ -885,4 +884,3 @@ func TestProxy_SSEMultipleProjects(t *testing.T) {
 	}
 	require.True(t, foundOriginal, "Original secret not found in project 2")
 }
-

--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -68,7 +68,7 @@ func startProxy(t *testing.T, ctx context.Context, infisicalURL string, config P
 	}
 
 	if config.UseSSE {
-		args = append(args, "--event-subscription-enabled")
+		args = append(args, "--enable-event-subscriptions")
 		args = append(args, "--client-id", config.ClientID)
 		args = append(args, "--client-secret", config.ClientSecret)
 		if config.PollingFallbackInterval != "" {

--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -26,6 +26,7 @@ type ProxyTestConfig struct {
 	TLSKeyFile                   string
 	AccessTokenCheckInterval     string
 	StaticSecretsRefreshInterval string
+	PollingFallbackInterval      string
 	UseSSE                       bool
 	ClientID                     string
 	ClientSecret                 string
@@ -45,6 +46,7 @@ func DefaultProxyTestConfig() ProxyTestConfig {
 func SSEProxyTestConfig() ProxyTestConfig {
 	config := DefaultProxyTestConfig()
 	config.UseSSE = true
+	config.PollingFallbackInterval = "10s"
 	return config
 }
 
@@ -69,6 +71,9 @@ func startProxy(t *testing.T, ctx context.Context, infisicalURL string, config P
 		args = append(args, "--event-subscription-enabled")
 		args = append(args, "--client-id", config.ClientID)
 		args = append(args, "--client-secret", config.ClientSecret)
+		if config.PollingFallbackInterval != "" {
+			args = append(args, "--polling-fallback-interval", config.PollingFallbackInterval)
+		}
 	}
 
 	proxyCmd := helpers.Command{

--- a/e2e/util/helpers.go
+++ b/e2e/util/helpers.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -263,6 +265,29 @@ func WithUniversalAuth() MachineIdentityOption {
 
 		i.UniversalAuthClientSecret = &csResp.JSON200.ClientSecret
 	}
+}
+
+func (s *InfisicalService) UpdateMachineIdentityRole(t *testing.T, ctx context.Context, identityId string, role string) {
+	apiUrl := s.ApiUrl(t)
+	url := fmt.Sprintf("%s/api/v1/identities/%s", apiUrl, identityId)
+
+	body, err := json.Marshal(map[string]string{"role": role})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.provisionResult.Token)
+
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300,
+		"Failed to update identity role to '%s', status %d: %s", role, resp.StatusCode, string(respBody))
+
+	slog.Info("Updated machine identity role", "identityId", identityId, "role", role)
 }
 
 type RunMethod string

--- a/e2e/util/helpers.go
+++ b/e2e/util/helpers.go
@@ -165,8 +165,10 @@ func (s *InfisicalService) ApiUrl(t *testing.T) string {
 }
 
 type MachineIdentity struct {
-	Id             string
-	TokenAuthToken *string
+	Id                        string
+	TokenAuthToken            *string
+	UniversalAuthClientId     *string
+	UniversalAuthClientSecret *string
 }
 
 type MachineIdentityOption func(*testing.T, context.Context, *InfisicalService, *MachineIdentity)
@@ -225,6 +227,41 @@ func WithTokenAuth() MachineIdentityOption {
 		require.Equal(t, http.StatusOK, updateResp.StatusCode())
 
 		i.TokenAuthToken = &tokenResp.JSON200.AccessToken
+	}
+}
+
+func WithUniversalAuth() MachineIdentityOption {
+	return func(t *testing.T, ctx context.Context, s *InfisicalService, i *MachineIdentity) {
+		c := s.apiClient
+
+		ttl := 2592000
+		maxTTL := 2592000
+		numUses := 0
+
+		attachResp, err := c.AttachUniversalAuthWithResponse(ctx, i.Id, client.AttachUniversalAuthJSONRequestBody{
+			AccessTokenTTL:          &ttl,
+			AccessTokenMaxTTL:       &maxTTL,
+			AccessTokenNumUsesLimit: &numUses,
+			AccessTokenTrustedIps: &[]struct {
+				IpAddress string `json:"ipAddress"`
+			}{
+				{IpAddress: "0.0.0.0/0"},
+				{IpAddress: "::/0"},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, attachResp.StatusCode(), "Failed to attach universal auth: %s", string(attachResp.Body))
+		require.NotNil(t, attachResp.JSON200)
+
+		clientId := attachResp.JSON200.IdentityUniversalAuth.ClientId
+		i.UniversalAuthClientId = &clientId
+
+		csResp, err := c.CreateUniversalAuthClientSecretWithResponse(ctx, i.Id, client.CreateUniversalAuthClientSecretJSONRequestBody{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, csResp.StatusCode(), "Failed to create universal auth client secret: %s", string(csResp.Body))
+		require.NotNil(t, csResp.JSON200)
+
+		i.UniversalAuthClientSecret = &csResp.JSON200.ClientSecret
 	}
 }
 

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -134,7 +134,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 
 	useSSE, err := cmd.Flags().GetBool("event-subscription-enabled")
 	if err != nil {
-		util.HandleError(err, "Unable to parse use-sse flag")
+		util.HandleError(err, "Unable to parse event-subscription-enabled flag")
 	}
 
 	clientId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "client-id", []string{util.INFISICAL_UNIVERSAL_AUTH_CLIENT_ID_NAME}, "")
@@ -148,7 +148,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	}
 
 	if useSSE && (clientId == "" || clientSecret == "") {
-		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --use-sse is enabled. Set via flags or INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET environment variables.")
+		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --event-subscription-enabled is enabled. Set via flags or INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET environment variables.")
 	}
 
 	domainURL, err := url.Parse(domain)
@@ -447,12 +447,9 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 
 				cache.Set(cacheKey, r, cachedResp, token, indexEntry)
 
-				if useSSE {
-					if sseManager != nil {
-						log.Info().Str("projectId", indexEntry.ProjectId).Msg("Ensuring SSE subscription for project")
-						// this will start the subscription using SSE for the project
-						sseManager.EnsureSubscription(indexEntry.ProjectId)
-					}
+				if useSSE && sseManager != nil {
+					log.Info().Str("projectId", indexEntry.ProjectId).Str("envSlug", indexEntry.EnvironmentSlug).Msg("Ensuring SSE subscription for project")
+					sseManager.EnsureSubscription(indexEntry.ProjectId, indexEntry.EnvironmentSlug)
 				}
 
 				log.Debug().

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -124,14 +124,9 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		util.PrintErrorMessageAndExit(fmt.Sprintf("Invalid static-secrets-refresh-interval format '%s'. Use formats like 30m, 1h, 1d", staticSecretsRefreshIntervalStr))
 	}
 
-	useServerSentEvents, err := cmd.Flags().GetBool("use-server-sent-events")
+	useSSE, err := cmd.Flags().GetBool("use-sse")
 	if err != nil {
-		util.HandleError(err, "Unable to parse use-server-sent-events flag")
-	}
-
-	machineIdentityToken, err := cmd.Flags().GetString("machine-identity-token")
-	if err != nil {
-		util.HandleError(err, "Unable to parse machine-identity-token flag")
+		util.HandleError(err, "Unable to parse use-sse flag")
 	}
 
 	clientId, err := cmd.Flags().GetString("client-id")
@@ -144,8 +139,8 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse client-secret flag")
 	}
 
-	if useServerSentEvents && machineIdentityToken == "" {
-		util.PrintErrorMessageAndExit("--machine-identity-token is required when --use-server-sent-events is enabled")
+	if useSSE && (clientId == "" || clientSecret == "") {
+		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --use-sse is enabled")
 	}
 
 	domainURL, err := url.Parse(domain)
@@ -199,6 +194,14 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		log.Info().Msg("Dev mode enabled: debug endpoint available at /_debug/cache")
 	}
 
+	var sseManager *proxy.SSEManager
+	var sseAuthState *proxy.SSEAuthState
+	if useSSE {
+		sseAuthState = proxy.NewSSEAuthState(clientId, clientSecret, domainURL)
+		sseManager = proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState, cache.NewSSESecretCacheFunc())
+		log.Info().Msg("SSE manager initialized for demand-driven cache updates")
+	}
+
 	proxyHandler := func(w http.ResponseWriter, r *http.Request) {
 		// Skip debug endpoints - they're handled by mux
 		if strings.HasPrefix(r.URL.Path, "/_debug/") {
@@ -214,26 +217,9 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		// -- Cache Check --
 
 		if isCacheable && token != "" {
-			cacheKey := proxy.GenerateCacheKey(r.Method, r.URL.Path, r.URL.RawQuery, token)
-
-			if cachedResp, found := cache.Get(cacheKey); found {
-				log.Info().
-					Str("hash", cacheKey).
-					Msg("Cache hit")
-
-				proxy.CopyHeaders(w.Header(), cachedResp.Header)
-				w.WriteHeader(cachedResp.StatusCode)
-				_, err := io.Copy(w, cachedResp.Body)
-				if err != nil {
-					log.Error().Err(err).Msg("Failed to copy cached response body")
-					return
-				}
+			if served := serveCachedResponse(w, r, cache, token, sseAuthState); served {
 				return
 			}
-
-			log.Info().
-				Str("hash", cacheKey).
-				Msg("Cache miss")
 		}
 
 		// -- Proxy Request --
@@ -452,6 +438,11 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 
 				cache.Set(cacheKey, r, cachedResp, token, indexEntry)
 
+				if sseManager != nil {
+					// this will start the subscription using SSE for the project
+					sseManager.EnsureSubscription(indexEntry.ProjectId)
+				}
+
 				log.Debug().
 					Str("method", r.Method).
 					Str("path", r.URL.Path).
@@ -497,12 +488,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	resyncCtx, resyncCancel := context.WithCancel(context.Background())
 	defer resyncCancel()
 
-	go proxy.StartBackgroundLoops(resyncCtx, cache, domainURL, httpClient, evictionStrategy, accessTokenCheckInterval, staticSecretsRefreshInterval, useServerSentEvents)
-
-	if useServerSentEvents {
-		go proxy.StartSSEListener(resyncCtx, cache, domainURL, machineIdentityToken, streamingClient, clientId, clientSecret)
-		log.Info().Msg("SSE listener started for real-time cache invalidation")
-	}
+	go proxy.StartBackgroundLoops(resyncCtx, cache, domainURL, httpClient, evictionStrategy, accessTokenCheckInterval, staticSecretsRefreshInterval, useSSE)
 
 	// Handle graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -592,6 +578,42 @@ func printCacheDebug(cmd *cobra.Command, args []string) {
 	fmt.Println(string(output))
 }
 
+// serveCachedResponse looks up the cache for the request, first using the
+// caller's token and then, if SSE is active, using the SSE machine-identity
+// token. Returns true if a cached response was written to w.
+func serveCachedResponse(w http.ResponseWriter, r *http.Request, c *proxy.Cache, token string, sseAuthState *proxy.SSEAuthState) bool {
+	cacheKey := proxy.GenerateCacheKey(r.Method, r.URL.Path, r.URL.RawQuery, token)
+
+	if cachedResp, found := c.Get(cacheKey); found {
+		log.Info().Str("hash", cacheKey).Msg("Cache hit")
+		writeCachedResponse(w, cachedResp)
+		return true
+	}
+
+	if sseAuthState != nil {
+		sseToken := sseAuthState.GetToken()
+		if sseToken != token {
+			sseCacheKey := proxy.GenerateCacheKey(r.Method, r.URL.Path, r.URL.RawQuery, sseToken)
+			if cachedResp, found := c.Get(sseCacheKey); found {
+				log.Info().Str("hash", sseCacheKey).Msg("Cache hit (SSE token)")
+				writeCachedResponse(w, cachedResp)
+				return true
+			}
+		}
+	}
+
+	log.Info().Str("hash", cacheKey).Msg("Cache miss")
+	return false
+}
+
+func writeCachedResponse(w http.ResponseWriter, cachedResp *http.Response) {
+	proxy.CopyHeaders(w.Header(), cachedResp.Header)
+	w.WriteHeader(cachedResp.StatusCode)
+	if _, err := io.Copy(w, cachedResp.Body); err != nil {
+		log.Error().Err(err).Msg("Failed to copy cached response body")
+	}
+}
+
 func isStreamingEndpoint(path string) bool {
 	return strings.HasPrefix(path, "/api/v1/events/")
 }
@@ -605,8 +627,8 @@ func init() {
 	proxyStartCmd.Flags().String("tls-cert-file", "", "The path to the TLS certificate file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().String("tls-key-file", "", "The path to the TLS key file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().Bool("tls-enabled", true, "Whether to enable TLS for the proxy server. Defaults to true")
-	proxyStartCmd.Flags().Bool("use-server-sent-events", false, "Enable SSE (Server-Sent Events) mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled and --client-id/--client-secret are required.")
-	proxyStartCmd.Flags().String("client-id", "", "Machine identity client ID for universal auth (required when --use-sse is enabled)")
+	proxyStartCmd.Flags().Bool("use-sse", false, "Enable SSE (Server-Sent Events) mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled and --client-id/--client-secret are required.")
+	proxyStartCmd.Flags().String("client-id", "", "Universal auth client ID for SSE (required when --use-sse is enabled)")
 	proxyStartCmd.Flags().String("client-secret", "", "Machine identity client secret for universal auth (required when --use-sse is enabled)")
 
 	proxyDebugCmd.Flags().String("listen-address", "localhost:8081", "The address where the proxy server is listening. Defaults to localhost:8081")

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -142,9 +142,9 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		util.PrintErrorMessageAndExit(fmt.Sprintf("Invalid polling-fallback-interval format '%s'. Use formats like 1m, 5m, 10m", pollingFallbackIntervalStr))
 	}
 
-	useSSE, err := cmd.Flags().GetBool("event-subscription-enabled")
+	useSSE, err := cmd.Flags().GetBool("enable-event-subscriptions")
 	if err != nil {
-		util.HandleError(err, "Unable to parse event-subscription-enabled flag")
+		util.HandleError(err, "Unable to parse enable-event-subscriptions flag")
 	}
 
 	clientId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "client-id", []string{util.INFISICAL_UNIVERSAL_AUTH_CLIENT_ID_NAME}, "")
@@ -158,7 +158,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	}
 
 	if useSSE && (clientId == "" || clientSecret == "") {
-		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --event-subscription-enabled is enabled. Set via flags or INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET environment variables.")
+		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --enable-event-subscriptions is enabled. Set via flags or INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET environment variables.")
 	}
 
 	domainURL, err := url.Parse(domain)
@@ -633,10 +633,10 @@ func init() {
 	proxyStartCmd.Flags().String("tls-cert-file", "", "The path to the TLS certificate file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().String("tls-key-file", "", "The path to the TLS key file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().Bool("tls-enabled", true, "Whether to enable TLS for the proxy server. Defaults to true")
-	proxyStartCmd.Flags().Bool("event-subscription-enabled", false, "Enable Event Subscription mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled. If event subscriptions are unavailable, the proxy will fall back to a polling mechanism.  `--client id` and `--client-secret` are required when this is set to true ")
+	proxyStartCmd.Flags().Bool("enable-event-subscriptions", false, "Enable Event Subscription mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled. If event subscriptions are unavailable, the proxy will fall back to a polling mechanism.  `--client id` and `--client-secret` are required when this is set to true ")
 	proxyStartCmd.Flags().String("client-id", "", "Machine identity universal auth client ID. This is required when using event subscriptions.")
 	proxyStartCmd.Flags().String("client-secret", "", "Machine identity universal auth client secret. This is required when using event subscriptions.")
-	proxyStartCmd.Flags().String("polling-fallback-interval", "10m", "How often to poll for secret changes when SSE is unavailable (e.g., 1m, 5m). Defaults to 5m. Only used when --event-subscription-enabled is set.")
+	proxyStartCmd.Flags().String("polling-fallback-interval", "10m", "How often to poll for secret changes when SSE is unavailable (e.g., 1m, 5m). Defaults to 5m. Only used when --enable-event-subscriptions is set.")
 
 	proxyDebugCmd.Flags().String("listen-address", "localhost:8081", "The address where the proxy server is listening. Defaults to localhost:8081")
 

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -124,6 +124,30 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		util.PrintErrorMessageAndExit(fmt.Sprintf("Invalid static-secrets-refresh-interval format '%s'. Use formats like 30m, 1h, 1d", staticSecretsRefreshIntervalStr))
 	}
 
+	useServerSentEvents, err := cmd.Flags().GetBool("use-server-sent-events")
+	if err != nil {
+		util.HandleError(err, "Unable to parse use-server-sent-events flag")
+	}
+
+	machineIdentityToken, err := cmd.Flags().GetString("machine-identity-token")
+	if err != nil {
+		util.HandleError(err, "Unable to parse machine-identity-token flag")
+	}
+
+	clientId, err := cmd.Flags().GetString("client-id")
+	if err != nil {
+		util.HandleError(err, "Unable to parse client-id flag")
+	}
+
+	clientSecret, err := cmd.Flags().GetString("client-secret")
+	if err != nil {
+		util.HandleError(err, "Unable to parse client-secret flag")
+	}
+
+	if useServerSentEvents && machineIdentityToken == "" {
+		util.PrintErrorMessageAndExit("--machine-identity-token is required when --use-server-sent-events is enabled")
+	}
+
 	domainURL, err := url.Parse(domain)
 	if err != nil {
 		util.HandleError(err, fmt.Sprintf("Invalid domain URL: %s", domain))
@@ -473,7 +497,12 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	resyncCtx, resyncCancel := context.WithCancel(context.Background())
 	defer resyncCancel()
 
-	go proxy.StartBackgroundLoops(resyncCtx, cache, domainURL, httpClient, evictionStrategy, accessTokenCheckInterval, staticSecretsRefreshInterval)
+	go proxy.StartBackgroundLoops(resyncCtx, cache, domainURL, httpClient, evictionStrategy, accessTokenCheckInterval, staticSecretsRefreshInterval, useServerSentEvents)
+
+	if useServerSentEvents {
+		go proxy.StartSSEListener(resyncCtx, cache, domainURL, machineIdentityToken, streamingClient, clientId, clientSecret)
+		log.Info().Msg("SSE listener started for real-time cache invalidation")
+	}
 
 	// Handle graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -576,6 +605,9 @@ func init() {
 	proxyStartCmd.Flags().String("tls-cert-file", "", "The path to the TLS certificate file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().String("tls-key-file", "", "The path to the TLS key file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().Bool("tls-enabled", true, "Whether to enable TLS for the proxy server. Defaults to true")
+	proxyStartCmd.Flags().Bool("use-server-sent-events", false, "Enable SSE (Server-Sent Events) mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled and --client-id/--client-secret are required.")
+	proxyStartCmd.Flags().String("client-id", "", "Machine identity client ID for universal auth (required when --use-sse is enabled)")
+	proxyStartCmd.Flags().String("client-secret", "", "Machine identity client secret for universal auth (required when --use-sse is enabled)")
 
 	proxyDebugCmd.Flags().String("listen-address", "localhost:8081", "The address where the proxy server is listening. Defaults to localhost:8081")
 

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -439,6 +439,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 				cache.Set(cacheKey, r, cachedResp, token, indexEntry)
 
 				if sseManager != nil {
+					log.Info().Str("projectId", indexEntry.ProjectId).Msg("Ensuring SSE subscription for project")
 					// this will start the subscription using SSE for the project
 					sseManager.EnsureSubscription(indexEntry.ProjectId)
 				}
@@ -591,11 +592,18 @@ func serveCachedResponse(w http.ResponseWriter, r *http.Request, c *proxy.Cache,
 	}
 
 	if sseAuthState != nil {
-		sseToken := sseAuthState.GetToken()
-		if sseToken != token {
-			sseCacheKey := proxy.GenerateCacheKey(r.Method, r.URL.Path, r.URL.RawQuery, sseToken)
+		queryParams := r.URL.Query()
+		projectId := queryParams.Get("projectId")
+		if projectId == "" {
+			projectId = queryParams.Get("workspaceId")
+		}
+		environment := queryParams.Get("environment")
+		secretName := proxy.ExtractSecretNameFromPath(r.URL.Path)
+
+		if projectId != "" && environment != "" && secretName != "" {
+			sseCacheKey := proxy.GenerateSSECacheKey(projectId, environment, secretName)
 			if cachedResp, found := c.Get(sseCacheKey); found {
-				log.Info().Str("hash", sseCacheKey).Msg("Cache hit (SSE token)")
+				log.Info().Str("hash", sseCacheKey).Msg("Cache hit (SSE)")
 				writeCachedResponse(w, cachedResp)
 				return true
 			}

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -57,12 +57,12 @@ var proxyDebugCmd = &cobra.Command{
 	Hidden:                true,
 }
 
-func initializeSSEManager(ctx context.Context, clientId, clientSecret string, cache *proxy.Cache, domainURL *url.URL, streamingClient *http.Client, httpClient *http.Client) (*proxy.SSEManager, error) {
+func initializeSSEManager(ctx context.Context, clientId, clientSecret string, cache *proxy.Cache, domainURL *url.URL, streamingClient *http.Client, httpClient *http.Client, pollingFallbackInterval time.Duration) (*proxy.SSEManager, error) {
 	sseAuthState, err := proxy.NewSSEAuthState(clientId, clientSecret, domainURL, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	return proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState), nil
+	return proxy.NewSSEManager(ctx, cache, domainURL, streamingClient, httpClient, sseAuthState, pollingFallbackInterval), nil
 }
 
 func startProxyServer(cmd *cobra.Command, args []string) {
@@ -130,6 +130,16 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	staticSecretsRefreshInterval, err := util.ParseTimeDurationString(staticSecretsRefreshIntervalStr, true)
 	if err != nil {
 		util.PrintErrorMessageAndExit(fmt.Sprintf("Invalid static-secrets-refresh-interval format '%s'. Use formats like 30m, 1h, 1d", staticSecretsRefreshIntervalStr))
+	}
+
+	pollingFallbackIntervalStr, err := cmd.Flags().GetString("polling-fallback-interval")
+	if err != nil {
+		util.HandleError(err, "Unable to parse polling-fallback-interval flag")
+	}
+
+	pollingFallbackInterval, err := util.ParseTimeDurationString(pollingFallbackIntervalStr, true)
+	if err != nil {
+		util.PrintErrorMessageAndExit(fmt.Sprintf("Invalid polling-fallback-interval format '%s'. Use formats like 1m, 5m, 10m", pollingFallbackIntervalStr))
 	}
 
 	useSSE, err := cmd.Flags().GetBool("event-subscription-enabled")
@@ -204,7 +214,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 
 	var sseManager *proxy.SSEManager
 	if useSSE {
-		sseManager, err = initializeSSEManager(context.Background(), clientId, clientSecret, cache, domainURL, streamingClient, httpClient)
+		sseManager, err = initializeSSEManager(context.Background(), clientId, clientSecret, cache, domainURL, streamingClient, httpClient, pollingFallbackInterval)
 		if err != nil {
 			util.HandleError(err, "Failed to initialize SSE manager")
 		}
@@ -626,6 +636,7 @@ func init() {
 	proxyStartCmd.Flags().Bool("event-subscription-enabled", false, "Enable Event Subscription mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled. If event subscriptions are unavailable, the proxy will fall back to a polling mechanism.  `--client id` and `--client-secret` are required when this is set to true ")
 	proxyStartCmd.Flags().String("client-id", "", "Machine identity universal auth client ID. This is required when using event subscriptions.")
 	proxyStartCmd.Flags().String("client-secret", "", "Machine identity universal auth client secret. This is required when using event subscriptions.")
+	proxyStartCmd.Flags().String("polling-fallback-interval", "10m", "How often to poll for secret changes when SSE is unavailable (e.g., 1m, 5m). Defaults to 5m. Only used when --event-subscription-enabled is set.")
 
 	proxyDebugCmd.Flags().String("listen-address", "localhost:8081", "The address where the proxy server is listening. Defaults to localhost:8081")
 

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -198,7 +198,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	var sseAuthState *proxy.SSEAuthState
 	if useSSE {
 		sseAuthState = proxy.NewSSEAuthState(clientId, clientSecret, domainURL)
-		sseManager = proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState, cache.NewSSESecretCacheFunc())
+		sseManager = proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState)
 		log.Info().Msg("SSE manager initialized for demand-driven cache updates")
 	}
 
@@ -217,7 +217,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		// -- Cache Check --
 
 		if isCacheable && token != "" {
-			if served := serveCachedResponse(w, r, cache, token, sseAuthState); served {
+			if served := serveCachedResponse(w, r, cache, token); served {
 				return
 			}
 		}
@@ -579,35 +579,15 @@ func printCacheDebug(cmd *cobra.Command, args []string) {
 	fmt.Println(string(output))
 }
 
-// serveCachedResponse looks up the cache for the request, first using the
-// caller's token and then, if SSE is active, using the SSE machine-identity
-// token. Returns true if a cached response was written to w.
-func serveCachedResponse(w http.ResponseWriter, r *http.Request, c *proxy.Cache, token string, sseAuthState *proxy.SSEAuthState) bool {
+// serveCachedResponse looks up the cache for the request using the caller's token.
+// Returns true if a cached response was written to w.
+func serveCachedResponse(w http.ResponseWriter, r *http.Request, c *proxy.Cache, token string) bool {
 	cacheKey := proxy.GenerateCacheKey(r.Method, r.URL.Path, r.URL.RawQuery, token)
 
 	if cachedResp, found := c.Get(cacheKey); found {
 		log.Info().Str("hash", cacheKey).Msg("Cache hit")
 		writeCachedResponse(w, cachedResp)
 		return true
-	}
-
-	if sseAuthState != nil {
-		queryParams := r.URL.Query()
-		projectId := queryParams.Get("projectId")
-		if projectId == "" {
-			projectId = queryParams.Get("workspaceId")
-		}
-		environment := queryParams.Get("environment")
-		secretName := proxy.ExtractSecretNameFromPath(r.URL.Path)
-
-		if projectId != "" && environment != "" && secretName != "" {
-			sseCacheKey := proxy.GenerateSSECacheKey(projectId, environment, secretName)
-			if cachedResp, found := c.Get(sseCacheKey); found {
-				log.Info().Str("hash", sseCacheKey).Msg("Cache hit (SSE)")
-				writeCachedResponse(w, cachedResp)
-				return true
-			}
-		}
 	}
 
 	log.Info().Str("hash", cacheKey).Msg("Cache miss")

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -197,7 +197,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	var sseManager *proxy.SSEManager
 	var sseAuthState *proxy.SSEAuthState
 	if useSSE {
-		sseAuthState = proxy.NewSSEAuthState(clientId, clientSecret, domainURL)
+		sseAuthState = proxy.NewSSEAuthState(clientId, clientSecret, domainURL, httpClient)
 		sseManager = proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState)
 		log.Info().Msg("SSE manager initialized for demand-driven cache updates")
 	}

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -57,6 +57,14 @@ var proxyDebugCmd = &cobra.Command{
 	Hidden:                true,
 }
 
+func initializeSSEManager(ctx context.Context, clientId, clientSecret string, cache *proxy.Cache, domainURL *url.URL, streamingClient *http.Client, httpClient *http.Client) (*proxy.SSEManager, error) {
+	sseAuthState, err := proxy.NewSSEAuthState(clientId, clientSecret, domainURL, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState), nil
+}
+
 func startProxyServer(cmd *cobra.Command, args []string) {
 	domain, err := cmd.Flags().GetString("domain")
 	if err != nil {
@@ -124,7 +132,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		util.PrintErrorMessageAndExit(fmt.Sprintf("Invalid static-secrets-refresh-interval format '%s'. Use formats like 30m, 1h, 1d", staticSecretsRefreshIntervalStr))
 	}
 
-	useSSE, err := cmd.Flags().GetBool("use-sse")
+	useSSE, err := cmd.Flags().GetBool("event-subscription-enabled")
 	if err != nil {
 		util.HandleError(err, "Unable to parse use-sse flag")
 	}
@@ -195,10 +203,11 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	}
 
 	var sseManager *proxy.SSEManager
-	var sseAuthState *proxy.SSEAuthState
 	if useSSE {
-		sseAuthState = proxy.NewSSEAuthState(clientId, clientSecret, domainURL, httpClient)
-		sseManager = proxy.NewSSEManager(context.Background(), cache, domainURL, streamingClient, httpClient, sseAuthState)
+		sseManager, err = initializeSSEManager(context.Background(), clientId, clientSecret, cache, domainURL, streamingClient, httpClient)
+		if err != nil {
+			util.HandleError(err, "Failed to initialize SSE manager")
+		}
 		log.Info().Msg("SSE manager initialized for demand-driven cache updates")
 	}
 
@@ -438,10 +447,12 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 
 				cache.Set(cacheKey, r, cachedResp, token, indexEntry)
 
-				if sseManager != nil {
-					log.Info().Str("projectId", indexEntry.ProjectId).Msg("Ensuring SSE subscription for project")
-					// this will start the subscription using SSE for the project
-					sseManager.EnsureSubscription(indexEntry.ProjectId)
+				if useSSE {
+					if sseManager != nil {
+						log.Info().Str("projectId", indexEntry.ProjectId).Msg("Ensuring SSE subscription for project")
+						// this will start the subscription using SSE for the project
+						sseManager.EnsureSubscription(indexEntry.ProjectId)
+					}
 				}
 
 				log.Debug().
@@ -615,9 +626,9 @@ func init() {
 	proxyStartCmd.Flags().String("tls-cert-file", "", "The path to the TLS certificate file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().String("tls-key-file", "", "The path to the TLS key file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().Bool("tls-enabled", true, "Whether to enable TLS for the proxy server. Defaults to true")
-	proxyStartCmd.Flags().Bool("use-sse", false, "Enable SSE (Server-Sent Events) mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled and --client-id/--client-secret are required.")
-	proxyStartCmd.Flags().String("client-id", "", "Universal auth client ID for SSE (env: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID)")
-	proxyStartCmd.Flags().String("client-secret", "", "Machine identity client secret for universal auth (env: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET)")
+	proxyStartCmd.Flags().Bool("event-subscription-enabled", false, "Enable Event Subscription mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled. If event subscriptions are unavailable, the proxy will fall back to a polling mechanism.  `--client id` and `--client-secret` are required when this is set to true ")
+	proxyStartCmd.Flags().String("client-id", "", "Machine identity universal auth client ID. This is required when using event subscriptions.")
+	proxyStartCmd.Flags().String("client-secret", "", "Machine identity universal auth client secret. This is required when using event subscriptions.")
 
 	proxyDebugCmd.Flags().String("listen-address", "localhost:8081", "The address where the proxy server is listening. Defaults to localhost:8081")
 

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -489,7 +489,7 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 	resyncCtx, resyncCancel := context.WithCancel(context.Background())
 	defer resyncCancel()
 
-	go proxy.StartBackgroundLoops(resyncCtx, cache, domainURL, httpClient, evictionStrategy, accessTokenCheckInterval, staticSecretsRefreshInterval, useSSE)
+	proxy.StartBackgroundLoops(resyncCtx, cache, domainURL, httpClient, evictionStrategy, accessTokenCheckInterval, staticSecretsRefreshInterval, useSSE)
 
 	// Handle graceful shutdown
 	sigCh := make(chan os.Signal, 1)

--- a/packages/cmd/proxy.go
+++ b/packages/cmd/proxy.go
@@ -129,18 +129,18 @@ func startProxyServer(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse use-sse flag")
 	}
 
-	clientId, err := cmd.Flags().GetString("client-id")
+	clientId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "client-id", []string{util.INFISICAL_UNIVERSAL_AUTH_CLIENT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse client-id flag")
 	}
 
-	clientSecret, err := cmd.Flags().GetString("client-secret")
+	clientSecret, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "client-secret", []string{util.INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse client-secret flag")
 	}
 
 	if useSSE && (clientId == "" || clientSecret == "") {
-		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --use-sse is enabled")
+		util.PrintErrorMessageAndExit("--client-id and --client-secret are required when --use-sse is enabled. Set via flags or INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET environment variables.")
 	}
 
 	domainURL, err := url.Parse(domain)
@@ -616,8 +616,8 @@ func init() {
 	proxyStartCmd.Flags().String("tls-key-file", "", "The path to the TLS key file for the proxy server. Required when `tls-enabled` is set to true (default)")
 	proxyStartCmd.Flags().Bool("tls-enabled", true, "Whether to enable TLS for the proxy server. Defaults to true")
 	proxyStartCmd.Flags().Bool("use-sse", false, "Enable SSE (Server-Sent Events) mode for real-time cache invalidation. When enabled, the static secrets refresh loop is disabled and --client-id/--client-secret are required.")
-	proxyStartCmd.Flags().String("client-id", "", "Universal auth client ID for SSE (required when --use-sse is enabled)")
-	proxyStartCmd.Flags().String("client-secret", "", "Machine identity client secret for universal auth (required when --use-sse is enabled)")
+	proxyStartCmd.Flags().String("client-id", "", "Universal auth client ID for SSE (env: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID)")
+	proxyStartCmd.Flags().String("client-secret", "", "Machine identity client secret for universal auth (env: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET)")
 
 	proxyDebugCmd.Flags().String("listen-address", "localhost:8081", "The address where the proxy server is listening. Defaults to localhost:8081")
 

--- a/packages/proxy/cache.go
+++ b/packages/proxy/cache.go
@@ -55,6 +55,15 @@ type PathIndexMarker struct {
 	CacheKey string `json:"cacheKey"`
 }
 
+// CollectedCacheEntry holds the metadata of a cache entry collected before purging,
+// so it can be replayed (re-fetched) using the original request and token.
+type CollectedCacheEntry struct {
+	CacheKey   string
+	Request    *CachedRequest
+	Token      string
+	IndexEntry IndexEntry
+}
+
 // Cache is an HTTP response cache fully backed by EncryptedStorage
 type Cache struct {
 	storage *cache.EncryptedStorage
@@ -291,14 +300,6 @@ func ExtractTokenFromRequest(r *http.Request) string {
 // GenerateCacheKey generates a cache key for a request by hashing the method, path, query, and token
 func GenerateCacheKey(method, path, query, token string) string {
 	data := method + path + query + token
-	hash := sha256.Sum256([]byte(data))
-	return hex.EncodeToString(hash[:])
-}
-
-// GenerateSSECacheKey generates a cache key for an SSE-fetched secret using
-// only its logical identity, independent of request shape or token.
-func GenerateSSECacheKey(projectId, environment, secretKey string) string {
-	data := fmt.Sprintf("sse:%s:%s:%s", projectId, environment, secretKey)
 	hash := sha256.Sum256([]byte(data))
 	return hex.EncodeToString(hash[:])
 }
@@ -592,6 +593,60 @@ func (c *Cache) PurgeByMutation(projectID, envSlug, mutationPath string) int {
 	return purgedCount
 }
 
+// CollectAndPurgeByMutation collects cache entries matching the mutation path, then purges them.
+// Returns the collected entries so they can be replayed with their original requests/tokens.
+func (c *Cache) CollectAndPurgeByMutation(projectID, envSlug, mutationPath string) []CollectedCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var collected []CollectedCacheEntry
+
+	prefix := buildPathIndexPrefixForProject(projectID, envSlug)
+	pathKeys, err := c.storage.GetKeysByPrefix(prefix)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get path index keys for collect-and-purge")
+		return collected
+	}
+
+	for _, key := range pathKeys {
+		withoutPrefix := strings.TrimPrefix(key, prefix)
+		parts := strings.SplitN(withoutPrefix, ":", 3)
+		if len(parts) < 3 {
+			continue
+		}
+
+		keySecretPath := strings.ReplaceAll(parts[1], "\\:", ":")
+		keyCacheKey := parts[2]
+
+		if !matchesPath(keySecretPath, mutationPath) {
+			continue
+		}
+
+		// Load the full entry before evicting
+		var entry StoredCacheEntry
+		if err := c.storage.Get(buildEntryKey(keyCacheKey), &entry); err == nil && entry.Request != nil {
+			requestCopy := &CachedRequest{
+				Method:     entry.Request.Method,
+				RequestURI: entry.Request.RequestURI,
+				Headers:    make(http.Header),
+				CachedAt:   entry.Request.CachedAt,
+			}
+			CopyHeaders(requestCopy.Headers, entry.Request.Headers)
+
+			collected = append(collected, CollectedCacheEntry{
+				CacheKey:   keyCacheKey,
+				Request:    requestCopy,
+				Token:      entry.Token,
+				IndexEntry: entry.Index,
+			})
+		}
+
+		c.evictEntryUnsafe(keyCacheKey)
+	}
+
+	return collected
+}
+
 // CompoundPathIndexDebugInfo represents the compound path index structure
 type CompoundPathIndexDebugInfo struct {
 	Token      string                      `json:"token"`
@@ -778,35 +833,3 @@ func (c *Cache) GetDebugInfo() CacheDebugInfo {
 	}
 }
 
-func (c *Cache) NewSSESecretCacheFunc() SSESecretCacheFunc {
-	return func(req *http.Request, resp *http.Response, bodyBytes []byte, event SSEEvent) {
-		cacheKey := GenerateSSECacheKey(event.Data.ProjectId, event.Data.Environment, event.Data.SecretKey)
-
-		secretPath := event.Data.SecretPath
-		if secretPath == "" {
-			secretPath = "/"
-		}
-
-		token := ExtractTokenFromRequest(req)
-
-		indexEntry := IndexEntry{
-			CacheKey:        cacheKey,
-			SecretPath:      secretPath,
-			EnvironmentSlug: event.Data.Environment,
-			ProjectId:       event.Data.ProjectId,
-		}
-
-		cachedResp := &http.Response{
-			StatusCode: resp.StatusCode,
-			Header:     make(http.Header),
-			Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
-		}
-		CopyHeaders(cachedResp.Header, resp.Header)
-
-		c.Set(cacheKey, req, cachedResp, token, indexEntry)
-		log.Info().
-			Str("secretKey", event.Data.SecretKey).
-			Str("cacheKey", cacheKey).
-			Msg("SSE-fetched secret cached successfully")
-	}
-}

--- a/packages/proxy/cache.go
+++ b/packages/proxy/cache.go
@@ -534,6 +534,53 @@ func (c *Cache) RemoveTokenFromIndex(token string) {
 	}
 }
 
+// GetUniqueProjectEnvironments returns unique project+environment pairs from the cache.
+// Returns a map of projectId -> []environmentSlug.
+func (c *Cache) GetUniqueProjectEnvironments() map[string][]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	pathKeys, err := c.storage.GetKeysByPrefix(prefixPath)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get path index keys for project/env extraction")
+		return nil
+	}
+
+	projectEnvSet := make(map[string]map[string]bool)
+
+	for _, key := range pathKeys {
+		// Key format: path:{projectId}:{envSlug}:{tokenHash}:{escapedSecretPath}:{cacheKey}
+		withoutPrefix := strings.TrimPrefix(key, prefixPath)
+
+		projectId, rest, ok := strings.Cut(withoutPrefix, ":")
+		if !ok {
+			log.Error().Str("key", key).Msg("Failed to split path key into projectId and envSlug")
+			continue
+		}
+		envSlug, _, ok := strings.Cut(rest, ":")
+		if !ok {
+			log.Error().Str("key", key).Msg("Failed to split path key into envSlug and rest")
+			continue
+		}
+
+		if projectEnvSet[projectId] == nil {
+			projectEnvSet[projectId] = make(map[string]bool)
+		}
+		projectEnvSet[projectId][envSlug] = true
+	}
+
+	result := make(map[string][]string, len(projectEnvSet))
+	for projectId, envs := range projectEnvSet {
+		slice := make([]string, 0, len(envs))
+		for env := range envs {
+			slice = append(slice, env)
+		}
+		result[projectId] = slice
+	}
+
+	return result
+}
+
 // PurgeByMutation purges cache entries across ALL tokens that match the mutation path
 func (c *Cache) PurgeByMutation(projectID, envSlug, mutationPath string) int {
 	c.mu.Lock()

--- a/packages/proxy/cache.go
+++ b/packages/proxy/cache.go
@@ -372,6 +372,55 @@ func (c *Cache) GetExpiredRequests(cacheTTL time.Duration) map[string]*CachedReq
 	return requests
 }
 
+// GetEntriesForProjectEnv retrieves all cache entries for a given project and environment.
+// Uses the same path index prefix as PurgeByMutation and CollectAndPurgeByMutation.
+func (c *Cache) GetEntriesForProjectEnv(projectId, envSlug string) map[string]*CachedRequest {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	requests := make(map[string]*CachedRequest)
+
+	prefix := buildPathIndexPrefixForProject(projectId, envSlug)
+	pathKeys, err := c.storage.GetKeysByPrefix(prefix)
+	if err != nil {
+		log.Error().Err(err).Str("projectId", projectId).Str("envSlug", envSlug).Msg("Failed to get path index keys for project environment")
+		return requests
+	}
+
+	for _, key := range pathKeys {
+		var marker PathIndexMarker
+		if err := c.storage.Get(key, &marker); err != nil {
+			continue
+		}
+
+		cacheKey := marker.CacheKey
+		if _, exists := requests[cacheKey]; exists {
+			continue
+		}
+
+		var entry StoredCacheEntry
+		if err := c.storage.Get(buildEntryKey(cacheKey), &entry); err != nil {
+			continue
+		}
+
+		if entry.Request == nil {
+			continue
+		}
+
+		requestCopy := &CachedRequest{
+			Method:     entry.Request.Method,
+			RequestURI: entry.Request.RequestURI,
+			Headers:    make(http.Header),
+			CachedAt:   entry.Request.CachedAt,
+		}
+		CopyHeaders(requestCopy.Headers, entry.Request.Headers)
+
+		requests[cacheKey] = requestCopy
+	}
+
+	return requests
+}
+
 func (c *Cache) EvictEntry(cacheKey string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/packages/proxy/cache.go
+++ b/packages/proxy/cache.go
@@ -130,6 +130,18 @@ func IsSecretsEndpoint(path string) bool {
 		path == "/api/v3/secrets" || path == "/api/v4/secrets"
 }
 
+func ExtractSecretNameFromPath(urlPath string) string {
+	for _, prefix := range []string{"/api/v4/secrets/", "/api/v3/secrets/"} {
+		if strings.HasPrefix(urlPath, prefix) {
+			name := strings.TrimPrefix(urlPath, prefix)
+			if name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
 func IsCacheableRequest(path string, method string) bool {
 	if method != http.MethodGet {
 		return false
@@ -279,6 +291,14 @@ func ExtractTokenFromRequest(r *http.Request) string {
 // GenerateCacheKey generates a cache key for a request by hashing the method, path, query, and token
 func GenerateCacheKey(method, path, query, token string) string {
 	data := method + path + query + token
+	hash := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(hash[:])
+}
+
+// GenerateSSECacheKey generates a cache key for an SSE-fetched secret using
+// only its logical identity, independent of request shape or token.
+func GenerateSSECacheKey(projectId, environment, secretKey string) string {
+	data := fmt.Sprintf("sse:%s:%s:%s", projectId, environment, secretKey)
 	hash := sha256.Sum256([]byte(data))
 	return hex.EncodeToString(hash[:])
 }
@@ -760,19 +780,20 @@ func (c *Cache) GetDebugInfo() CacheDebugInfo {
 
 func (c *Cache) NewSSESecretCacheFunc() SSESecretCacheFunc {
 	return func(req *http.Request, resp *http.Response, bodyBytes []byte, event SSEEvent) {
-		token := ExtractTokenFromRequest(req)
-		cacheKey := GenerateCacheKey(req.Method, req.URL.Path, req.URL.RawQuery, token)
+		cacheKey := GenerateSSECacheKey(event.Data.ProjectId, event.Data.Environment, event.Data.SecretKey)
 
-		queryParams := req.URL.Query()
-		projectId := queryParams.Get("projectId")
-		environment := queryParams.Get("environment")
-		secretPath := queryParams.Get("secretPath")
+		secretPath := event.Data.SecretPath
+		if secretPath == "" {
+			secretPath = "/"
+		}
+
+		token := ExtractTokenFromRequest(req)
 
 		indexEntry := IndexEntry{
 			CacheKey:        cacheKey,
 			SecretPath:      secretPath,
-			EnvironmentSlug: environment,
-			ProjectId:       projectId,
+			EnvironmentSlug: event.Data.Environment,
+			ProjectId:       event.Data.ProjectId,
 		}
 
 		cachedResp := &http.Response{
@@ -783,7 +804,7 @@ func (c *Cache) NewSSESecretCacheFunc() SSESecretCacheFunc {
 		CopyHeaders(cachedResp.Header, resp.Header)
 
 		c.Set(cacheKey, req, cachedResp, token, indexEntry)
-		log.Debug().
+		log.Info().
 			Str("secretKey", event.Data.SecretKey).
 			Str("cacheKey", cacheKey).
 			Msg("SSE-fetched secret cached successfully")

--- a/packages/proxy/cache.go
+++ b/packages/proxy/cache.go
@@ -163,6 +163,8 @@ func (c *Cache) Get(cacheKey string) (*http.Response, bool) {
 	return resp, true
 }
 
+// when a new key is added, we need to check if the projectID and the env slug are being tracked in the cache
+// to refactor: every operation that call set, it checkes the values of indexEntry before, this could happen here.
 func (c *Cache) Set(cacheKey string, req *http.Request, resp *http.Response, token string, indexEntry IndexEntry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -534,53 +536,6 @@ func (c *Cache) RemoveTokenFromIndex(token string) {
 	}
 }
 
-// GetUniqueProjectEnvironments returns unique project+environment pairs from the cache.
-// Returns a map of projectId -> []environmentSlug.
-func (c *Cache) GetUniqueProjectEnvironments() map[string][]string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	pathKeys, err := c.storage.GetKeysByPrefix(prefixPath)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to get path index keys for project/env extraction")
-		return nil
-	}
-
-	projectEnvSet := make(map[string]map[string]bool)
-
-	for _, key := range pathKeys {
-		// Key format: path:{projectId}:{envSlug}:{tokenHash}:{escapedSecretPath}:{cacheKey}
-		withoutPrefix := strings.TrimPrefix(key, prefixPath)
-
-		projectId, rest, ok := strings.Cut(withoutPrefix, ":")
-		if !ok {
-			log.Error().Str("key", key).Msg("Failed to split path key into projectId and envSlug")
-			continue
-		}
-		envSlug, _, ok := strings.Cut(rest, ":")
-		if !ok {
-			log.Error().Str("key", key).Msg("Failed to split path key into envSlug and rest")
-			continue
-		}
-
-		if projectEnvSet[projectId] == nil {
-			projectEnvSet[projectId] = make(map[string]bool)
-		}
-		projectEnvSet[projectId][envSlug] = true
-	}
-
-	result := make(map[string][]string, len(projectEnvSet))
-	for projectId, envs := range projectEnvSet {
-		slice := make([]string, 0, len(envs))
-		for env := range envs {
-			slice = append(slice, env)
-		}
-		result[projectId] = slice
-	}
-
-	return result
-}
-
 // PurgeByMutation purges cache entries across ALL tokens that match the mutation path
 func (c *Cache) PurgeByMutation(projectID, envSlug, mutationPath string) int {
 	c.mu.Lock()
@@ -800,5 +755,37 @@ func (c *Cache) GetDebugInfo() CacheDebugInfo {
 		CacheKeys:         cacheKeys,
 		TokenIndex:        tokenIndex,
 		CompoundPathIndex: compoundPathIndex,
+	}
+}
+
+func (c *Cache) NewSSESecretCacheFunc() SSESecretCacheFunc {
+	return func(req *http.Request, resp *http.Response, bodyBytes []byte, event SSEEvent) {
+		token := ExtractTokenFromRequest(req)
+		cacheKey := GenerateCacheKey(req.Method, req.URL.Path, req.URL.RawQuery, token)
+
+		queryParams := req.URL.Query()
+		projectId := queryParams.Get("projectId")
+		environment := queryParams.Get("environment")
+		secretPath := queryParams.Get("secretPath")
+
+		indexEntry := IndexEntry{
+			CacheKey:        cacheKey,
+			SecretPath:      secretPath,
+			EnvironmentSlug: environment,
+			ProjectId:       projectId,
+		}
+
+		cachedResp := &http.Response{
+			StatusCode: resp.StatusCode,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+		}
+		CopyHeaders(cachedResp.Header, resp.Header)
+
+		c.Set(cacheKey, req, cachedResp, token, indexEntry)
+		log.Debug().
+			Str("secretKey", event.Data.SecretKey).
+			Str("cacheKey", cacheKey).
+			Msg("SSE-fetched secret cached successfully")
 	}
 }

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -330,6 +330,8 @@ func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL,
 	if sseEnabled {
 		go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
 	}
+
+	go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
 	go startStaticSecretsRefresh(ctx, cache, domainURL, httpClient, staticSecretsRefreshInterval)
 
 }

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -362,6 +362,7 @@ func runProjectSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http
 }
 
 func startProjectPollingLoop(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, projectId, envSlug string, interval time.Duration, onPollComplete func()) {
+	log.Info().Str("projectId", projectId).Str("envSlug", envSlug).Msg("Starting project polling loop")
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -361,14 +361,19 @@ func runProjectSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http
 		Msg("Project secrets refresh completed")
 }
 
-func startProjectPollingLoop(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, projectId, envSlug string, interval time.Duration) {
+func startProjectPollingLoop(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, projectId, envSlug string, interval time.Duration, onPollComplete func()) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	firstTick := true
 	for {
 		select {
 		case <-ticker.C:
 			runProjectSecretsRefresh(cache, domainURL, httpClient, projectId, envSlug)
+			if !firstTick && onPollComplete != nil {
+				onPollComplete()
+			}
+			firstTick = false
 		case <-ctx.Done():
 			return
 		}

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -289,24 +289,34 @@ func runStaticSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http.
 		Msg("Static secrets refresh completed")
 }
 
-// StartBackgroundLoops starts the background loops for token validation and secrets refresh
-func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, evictionStrategy string, accessTokenCheckInterval time.Duration, staticSecretsRefreshInterval time.Duration) {
+// StartBackgroundLoops starts the background loops for token validation and secrets refresh.
+// When sseEnabled is true, the static secrets refresh loop is disabled (SSE handles cache invalidation).
+func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, evictionStrategy string, accessTokenCheckInterval time.Duration, staticSecretsRefreshInterval time.Duration, serverSentEventsEnabled bool) {
 	tokenTicker := time.NewTicker(accessTokenCheckInterval)
-	secretsTicker := time.NewTicker(staticSecretsRefreshInterval)
 	defer tokenTicker.Stop()
-	defer secretsTicker.Stop()
+
+	var secretsTickerC <-chan time.Time
+	if !serverSentEventsEnabled {
+		secretsTicker := time.NewTicker(staticSecretsRefreshInterval)
+		defer secretsTicker.Stop()
+		secretsTickerC = secretsTicker.C
+	} else {
+		secretsTickerC = make(chan time.Time)
+		log.Info().Msg("Static secrets refresh disabled (SSE mode active)")
+	}
 
 	log.Info().
 		Str("evictionStrategy", evictionStrategy).
 		Str("accessTokenCheckInterval", accessTokenCheckInterval.String()).
 		Str("staticSecretsRefreshInterval", staticSecretsRefreshInterval.String()).
+		Bool("serverSentEventsEnabled", serverSentEventsEnabled).
 		Msg("Background loops started")
 
 	for {
 		select {
 		case <-tokenTicker.C:
 			runAccessTokenValidation(cache, domainURL, httpClient)
-		case <-secretsTicker.C:
+		case <-secretsTickerC:
 			runStaticSecretsRefresh(cache, domainURL, httpClient, staticSecretsRefreshInterval)
 		case <-ctx.Done():
 			log.Info().Msg("Background loops stopped")

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -289,22 +289,37 @@ func runStaticSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http.
 		Msg("Static secrets refresh completed")
 }
 
-// StartBackgroundLoops starts the background loops for token validation and secrets refresh.
-// When sseEnabled is true, the static secrets refresh loop is disabled (SSE handles cache invalidation).
-func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, evictionStrategy string, accessTokenCheckInterval time.Duration, staticSecretsRefreshInterval time.Duration, sseEnabled bool) {
+func startAccessTokenValidation(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, accessTokenCheckInterval time.Duration) {
 	tokenTicker := time.NewTicker(accessTokenCheckInterval)
 	defer tokenTicker.Stop()
 
-	var secretsTickerC <-chan time.Time
-	if !sseEnabled {
-		secretsTicker := time.NewTicker(staticSecretsRefreshInterval)
-		defer secretsTicker.Stop()
-		secretsTickerC = secretsTicker.C
-	} else {
-		secretsTickerC = make(chan time.Time)
-		log.Info().Msg("Static secrets refresh disabled (SSE mode active)")
+	for {
+		select {
+		case <-tokenTicker.C:
+			runAccessTokenValidation(cache, domainURL, httpClient)
+		case <-ctx.Done():
+			return
+		}
 	}
+}
 
+func startStaticSecretsRefresh(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, staticSecretsRefreshInterval time.Duration) {
+	secretsTicker := time.NewTicker(staticSecretsRefreshInterval)
+	defer secretsTicker.Stop()
+
+	for {
+		select {
+		case <-secretsTicker.C:
+			runStaticSecretsRefresh(cache, domainURL, httpClient, staticSecretsRefreshInterval)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// StartBackgroundLoops starts the background loops for token validation and secrets refresh.
+// When sseEnabled is true, the static secrets refresh loop is disabled (SSE handles cache invalidation).
+func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, evictionStrategy string, accessTokenCheckInterval time.Duration, staticSecretsRefreshInterval time.Duration, sseEnabled bool) {
 	log.Info().
 		Str("evictionStrategy", evictionStrategy).
 		Str("accessTokenCheckInterval", accessTokenCheckInterval.String()).
@@ -312,15 +327,9 @@ func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL,
 		Bool("sseEnabled", sseEnabled).
 		Msg("Background loops started")
 
-	for {
-		select {
-		case <-tokenTicker.C:
-			runAccessTokenValidation(cache, domainURL, httpClient)
-		case <-secretsTickerC:
-			runStaticSecretsRefresh(cache, domainURL, httpClient, staticSecretsRefreshInterval)
-		case <-ctx.Done():
-			log.Info().Msg("Background loops stopped")
-			return
-		}
+	if sseEnabled {
+		go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
 	}
+	go startStaticSecretsRefresh(ctx, cache, domainURL, httpClient, staticSecretsRefreshInterval)
+
 }

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -329,9 +329,9 @@ func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL,
 
 	if sseEnabled {
 		go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
+	} else {
+		go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
+		go startStaticSecretsRefresh(ctx, cache, domainURL, httpClient, staticSecretsRefreshInterval)
 	}
-
-	go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
-	go startStaticSecretsRefresh(ctx, cache, domainURL, httpClient, staticSecretsRefreshInterval)
 
 }

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -291,12 +291,12 @@ func runStaticSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http.
 
 // StartBackgroundLoops starts the background loops for token validation and secrets refresh.
 // When sseEnabled is true, the static secrets refresh loop is disabled (SSE handles cache invalidation).
-func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, evictionStrategy string, accessTokenCheckInterval time.Duration, staticSecretsRefreshInterval time.Duration, serverSentEventsEnabled bool) {
+func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, evictionStrategy string, accessTokenCheckInterval time.Duration, staticSecretsRefreshInterval time.Duration, sseEnabled bool) {
 	tokenTicker := time.NewTicker(accessTokenCheckInterval)
 	defer tokenTicker.Stop()
 
 	var secretsTickerC <-chan time.Time
-	if !serverSentEventsEnabled {
+	if !sseEnabled {
 		secretsTicker := time.NewTicker(staticSecretsRefreshInterval)
 		defer secretsTicker.Stop()
 		secretsTickerC = secretsTicker.C
@@ -309,7 +309,7 @@ func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL,
 		Str("evictionStrategy", evictionStrategy).
 		Str("accessTokenCheckInterval", accessTokenCheckInterval.String()).
 		Str("staticSecretsRefreshInterval", staticSecretsRefreshInterval.String()).
-		Bool("serverSentEventsEnabled", serverSentEventsEnabled).
+		Bool("sseEnabled", sseEnabled).
 		Msg("Background loops started")
 
 	for {

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -327,11 +327,8 @@ func StartBackgroundLoops(ctx context.Context, cache *Cache, domainURL *url.URL,
 		Bool("sseEnabled", sseEnabled).
 		Msg("Background loops started")
 
-	if sseEnabled {
-		go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
-	} else {
-		go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
+	go startAccessTokenValidation(ctx, cache, domainURL, httpClient, accessTokenCheckInterval)
+	if !sseEnabled {
 		go startStaticSecretsRefresh(ctx, cache, domainURL, httpClient, staticSecretsRefreshInterval)
 	}
-
 }

--- a/packages/proxy/resync.go
+++ b/packages/proxy/resync.go
@@ -289,6 +289,92 @@ func runStaticSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http.
 		Msg("Static secrets refresh completed")
 }
 
+func runProjectSecretsRefresh(cache *Cache, domainURL *url.URL, httpClient *http.Client, projectId, envSlug string) {
+	log.Info().Str("projectId", projectId).Str("envSlug", envSlug).Msg("Starting project secrets refresh")
+
+	requests := cache.GetEntriesForProjectEnv(projectId, envSlug)
+
+	type orderedEntry struct {
+		cacheKey string
+		request  *CachedRequest
+	}
+	ordered := make([]orderedEntry, 0, len(requests))
+	for key, req := range requests {
+		ordered = append(ordered, orderedEntry{key, req})
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].request.CachedAt.Before(ordered[j].request.CachedAt)
+	})
+
+	refetched := 0
+	evicted := 0
+
+	for _, entry := range ordered {
+		time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
+
+		proxyReq, err := reconstructProxyRequest(domainURL, entry.request)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("cacheKey", entry.cacheKey).
+				Str("requestURI", entry.request.RequestURI).
+				Msg("Failed to parse requestURI during project secrets refresh")
+			continue
+		}
+
+		resp, err := httpClient.Do(proxyReq)
+		if err != nil || (resp != nil && resp.StatusCode >= 500) {
+			if resp != nil {
+				resp.Body.Close()
+			}
+			log.Error().
+				Err(err).
+				Str("cacheKey", entry.cacheKey).
+				Str("requestURI", entry.request.RequestURI).
+				Msg("Network error during project secrets refresh - keeping stale entry (optimistic strategy)")
+			continue
+		}
+
+		refetchedResult, evictedResult, rateLimited, retryAfterSeconds := handleResyncResponse(cache, entry.cacheKey, entry.request.RequestURI, resp)
+		if refetchedResult {
+			refetched++
+		}
+		if evictedResult {
+			evicted++
+		}
+
+		if rateLimited {
+			pauseDuration := time.Duration(retryAfterSeconds+2) * time.Second
+			log.Info().
+				Int("pauseSeconds", retryAfterSeconds+2).
+				Str("projectId", projectId).
+				Msg("Rate limited during project secrets refresh, pausing")
+			time.Sleep(pauseDuration)
+		}
+	}
+
+	log.Info().
+		Str("projectId", projectId).
+		Int("totalEntries", len(requests)).
+		Int("refetched", refetched).
+		Int("evicted", evicted).
+		Msg("Project secrets refresh completed")
+}
+
+func startProjectPollingLoop(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, projectId, envSlug string, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			runProjectSecretsRefresh(cache, domainURL, httpClient, projectId, envSlug)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func startAccessTokenValidation(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, accessTokenCheckInterval time.Duration) {
 	tokenTicker := time.NewTicker(accessTokenCheckInterval)
 	defer tokenTicker.Stop()

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -84,13 +84,15 @@ type SSEAuthState struct {
 	clientId     string
 	clientSecret string
 	domainURL    *url.URL
+	httpClient   *http.Client
 }
 
-func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL) *SSEAuthState {
+func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL, httpClient *http.Client) *SSEAuthState {
 	return &SSEAuthState{
 		clientId:     clientId,
 		clientSecret: clientSecret,
 		domainURL:    domainURL,
+		httpClient:   httpClient,
 	}
 }
 
@@ -109,7 +111,7 @@ func (s *SSEAuthState) SetToken(token string) {
 func (s *SSEAuthState) RefreshToken() (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	newToken, err := CallUniversalAuthLogin(s.domainURL, s.clientId, s.clientSecret)
+	newToken, err := CallUniversalAuthLogin(s.domainURL, s.clientId, s.clientSecret, s.httpClient)
 	if err != nil {
 		return "", err
 	}
@@ -119,7 +121,7 @@ func (s *SSEAuthState) RefreshToken() (string, error) {
 
 // CallUniversalAuthLogin authenticates a machine identity via universal auth.
 // Uses net/http directly (not resty) since the proxy module does not depend on resty.
-func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string) (string, error) {
+func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string, httpClient *http.Client) (string, error) {
 	loginURL := *domainURL
 	loginURL.Path = domainURL.Path + "/api/v1/auth/universal-auth/login/"
 
@@ -140,7 +142,7 @@ func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string) (
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to call universal auth login: %w", err)
 	}

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -96,7 +96,10 @@ func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL, httpClie
 	}
 
 	// ensure we have a valid token
-	authState.RefreshToken()
+	_, err := authState.RefreshToken()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to refresh SSE auth token")
+	}
 
 	return authState
 }
@@ -187,6 +190,7 @@ type SSEManager struct {
 }
 
 func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, resyncHttpClient *http.Client, authState *SSEAuthState) *SSEManager {
+
 	return &SSEManager{
 		connections:      make(map[string]*SSEConnection),
 		cache:            cache,

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -173,15 +173,24 @@ func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string, h
 // SSEConnection represents a single SSE connection for a project.
 // One connection per project tracks all environments automatically.
 type SSEConnection struct {
-	ProjectID string
-	Cancel    context.CancelFunc
+	ProjectID       string
+	EnvironmentSlug string
+	Cancel          context.CancelFunc
+}
+
+type pollingState struct {
+	cancel      context.CancelFunc
+	retryingSSE bool // true while a background SSE reconnection attempt is in progress
 }
 
 // SSEManager manages demand-driven SSE connections. Connections are opened when
 // user requests hit secrets endpoints, not eagerly at startup.
+// When SSE connections fail repeatedly for a project, the manager transitions
+// that project to a polling fallback and tracks it in pollingProjects.
 type SSEManager struct {
 	mu               sync.Mutex
-	connections      map[string]*SSEConnection // keyed by projectID
+	connections      map[string]*SSEConnection // active SSE connections
+	pollingProjects  map[string]*pollingState  // projects in polling fallback
 	cache            *Cache
 	domainURL        *url.URL
 	httpClient       *http.Client // streaming client (no timeout) for SSE connections
@@ -194,6 +203,7 @@ func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpCl
 
 	return &SSEManager{
 		connections:      make(map[string]*SSEConnection),
+		pollingProjects:  make(map[string]*pollingState),
 		cache:            cache,
 		domainURL:        domainURL,
 		httpClient:       httpClient,
@@ -205,8 +215,8 @@ func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpCl
 
 // EnsureSubscription ensures an SSE connection exists for the given projectId.
 // One connection per project tracks all environments, so only the projectId matters.
-// Called from the proxy handler when a secrets request is seen.
-func (m *SSEManager) EnsureSubscription(projectId string) {
+// If the connection is not established, the connection fall back to polling fallback
+func (m *SSEManager) EnsureSubscription(projectId, environmentSlug string) {
 	log.Info().Str("projectId", projectId).Msg("Ensuring SSE subscription for project")
 	if projectId == "" {
 		return
@@ -215,9 +225,20 @@ func (m *SSEManager) EnsureSubscription(projectId string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// connection already exists for that projectId, so we don't need to open a new one
+	// SSE connection already active — nothing to do
 	if m.connections[projectId] != nil {
 		log.Info().Str("projectId", projectId).Msg("SSE connection already exists for project, skipping")
+		return
+	}
+
+	// the project is in polling fallback mode
+	// try to connect using SSE
+	if ps, ok := m.pollingProjects[projectId]; ok {
+		if !ps.retryingSSE {
+			ps.retryingSSE = true
+			log.Info().Str("projectId", projectId).Str("envSlug", environmentSlug).Msg("Project in polling fallback, attempting SSE reconnection in background")
+			go m.attemptSSEReconnection(projectId, environmentSlug)
+		}
 		return
 	}
 
@@ -227,8 +248,9 @@ func (m *SSEManager) EnsureSubscription(projectId string) {
 
 	connCtx, connCancel := context.WithCancel(m.ctx)
 	conn := &SSEConnection{
-		ProjectID: projectId,
-		Cancel:    connCancel,
+		ProjectID:       projectId,
+		EnvironmentSlug: environmentSlug,
+		Cancel:          connCancel,
 	}
 	m.connections[projectId] = conn
 
@@ -236,8 +258,7 @@ func (m *SSEManager) EnsureSubscription(projectId string) {
 }
 
 // runConnection runs a single SSE connection with retry, cache resync, and backoff.
-// After maxRetries consecutive failures the connection is removed so the next user
-// request can re-trigger EnsureSubscription.
+// if the connection is not stablished, the connection fall back to polling fallback
 func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 	const (
 		maxRetries      = 5
@@ -255,14 +276,15 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 
 		connStart := time.Now()
 
-		err := connectSSEForProject(ctx, m.cache, m.domainURL, m.authState, m.httpClient, m.resyncHttpClient, conn.ProjectID)
+		err := connectSSEForProject(ctx, m.cache, m.domainURL, m.authState, m.httpClient, m.resyncHttpClient, m.cancelPollingIfActive, conn.ProjectID)
 		if ctx.Err() != nil {
 			return
 		}
 
-		// Connection stayed up long enough — reset retry counter
+		// Connection stayed up long enough — reset retry counter and cancel polling if active
 		if time.Since(connStart) > healthyDuration {
 			retries = 0
+			m.cancelPollingIfActive(conn.ProjectID)
 		}
 
 		if err == nil {
@@ -270,7 +292,20 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 			continue
 		}
 
-		// Handle auth errors with one re-auth attempt
+		retries++
+		if retries > maxRetries {
+			log.Warn().
+				Str("projectId", conn.ProjectID).
+				Int("maxRetries", maxRetries).
+				Msg("SSE connection retries exhausted, transitioning to polling fallback")
+
+			// the fallback to pooling only happens if the SSE connection is lost for a project
+			m.transitionToPolling(conn.ProjectID, conn.EnvironmentSlug)
+			return
+		}
+
+		// move the retry counter to the top, since it is possible
+		// to the be authenticated, but don't have the necessary roles
 		if isAuthError(err) {
 			log.Warn().Err(err).
 				Str("projectId", conn.ProjectID).
@@ -283,16 +318,7 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 			}
 			log.Error().Str("projectId", conn.ProjectID).
 				Msg("Failed to re-authenticate machine identity")
-		}
 
-		retries++
-		if retries > maxRetries {
-			log.Error().
-				Str("projectId", conn.ProjectID).
-				Int("maxRetries", maxRetries).
-				Msg("SSE connection retries exhausted, removing connection")
-			m.removeConnection(conn.ProjectID)
-			return
 		}
 
 		log.Warn().Err(err).
@@ -301,8 +327,8 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 			Int("maxRetries", maxRetries).
 			Msg("SSE connection lost, resyncing cache before retrying")
 
-		// Resync cache before reconnecting — we may have missed events during the outage
-		runStaticSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, 0)
+		// Resync project cache before reconnecting — we may have missed events during the outage
+		runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, conn.ProjectID, conn.EnvironmentSlug)
 
 		// Exponential backoff with jitter
 		delay := baseDelay * time.Duration(math.Pow(2, float64(retries-1)))
@@ -319,12 +345,77 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 	}
 }
 
-// removeConnection removes a connection from the map so the next user request
-// can re-trigger EnsureSubscription for this project.
-func (m *SSEManager) removeConnection(projectId string) {
+const pollingFallbackInterval = 5 * time.Minute
+
+// transitionToPolling moves a project from SSE mode to polling fallback.
+func (m *SSEManager) transitionToPolling(projectId, environmentSlug string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// Remove SSE connection
 	delete(m.connections, projectId)
+
+	if ps, alreadyPolling := m.pollingProjects[projectId]; alreadyPolling {
+		// Already polling — this was a reconnection attempt that failed
+		ps.retryingSSE = false
+		log.Info().Str("projectId", projectId).Str("envSlug", environmentSlug).
+			Msg("SSE reconnection failed, continuing existing polling fallback")
+		return
+	}
+
+	pollCtx, pollCancel := context.WithCancel(m.ctx)
+	m.pollingProjects[projectId] = &pollingState{
+		cancel:      pollCancel,
+		retryingSSE: false,
+	}
+
+	log.Info().Str("projectId", projectId).Str("envSlug", environmentSlug).
+		Msg("Starting polling fallback for project")
+
+	// Resync the project cache immediately — events might have been missed during the outage
+	go runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug)
+
+	go startProjectPollingLoop(pollCtx, m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug, pollingFallbackInterval)
+}
+
+func (m *SSEManager) cancelPollingIfActive(projectId string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ps, ok := m.pollingProjects[projectId]; ok {
+		ps.cancel()
+		delete(m.pollingProjects, projectId)
+		log.Info().Str("projectId", projectId).Msg("Cancelled polling fallback")
+	}
+
+}
+
+// attemptSSEReconnection tries to re-establish an SSE connection for a project
+// that is currently in polling fallback mode.
+func (m *SSEManager) attemptSSEReconnection(projectId, environmentSlug string) {
+	log.Info().Str("projectId", projectId).Str("envSlug", environmentSlug).Msg("Attempting SSE reconnection from polling fallback")
+
+	m.mu.Lock()
+
+	// Re-check state: if another goroutine already created a connection, bail out
+	if m.connections[projectId] != nil {
+		if ps, ok := m.pollingProjects[projectId]; ok {
+			ps.retryingSSE = false
+		}
+		m.mu.Unlock()
+		return
+	}
+
+	connCtx, connCancel := context.WithCancel(m.ctx)
+	conn := &SSEConnection{
+		ProjectID:       projectId,
+		EnvironmentSlug: environmentSlug,
+		Cancel:          connCancel,
+	}
+	m.connections[projectId] = conn
+	m.mu.Unlock()
+
+	m.runConnection(conn, connCtx)
 }
 
 type sseAuthError struct {
@@ -343,7 +434,7 @@ func isAuthError(err error) bool {
 
 // connectSSEForProject establishes a single SSE connection for one project and processes events.
 // One connection per project tracks all environments automatically.
-func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, resyncHttpClient *http.Client, projectId string) error {
+func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, resyncHttpClient *http.Client, cancelPolling func(projectId string), projectId string) error {
 	subscribeURL := *domainURL
 	subscribeURL.Path = domainURL.Path + "/api/v1/events/subscribe/project-events"
 
@@ -396,6 +487,9 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 	log.Info().
 		Str("projectId", projectId).
 		Msg("SSE connection established")
+
+	// cancel the polling fallback if active
+	cancelPolling(projectId)
 
 	events := make(chan SSEEvent, 10)
 	go parseSSEStream(ctx, resp.Body, projectId, events)

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -76,11 +76,6 @@ type universalAuthLoginResponse struct {
 	TokenType   string `json:"tokenType"`
 }
 
-// SSESecretCacheFunc is a callback invoked after an SSE event fetches a secret from the API.
-// It receives the request, response body, and event data so the caller can cache the result
-// using the same approach as regular proxy requests.
-type SSESecretCacheFunc func(req *http.Request, resp *http.Response, bodyBytes []byte, event SSEEvent)
-
 // SSEAuthState manages authentication state for SSE operations.
 // It holds a reusable token and credentials for re-authentication.
 type SSEAuthState struct {
@@ -181,11 +176,10 @@ type SSEManager struct {
 	httpClient       *http.Client // streaming client (no timeout) for SSE connections
 	resyncHttpClient *http.Client // regular client (with timeout) for cache resync requests
 	authState        *SSEAuthState
-	onSecretFetched  SSESecretCacheFunc
 	ctx              context.Context
 }
 
-func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, resyncHttpClient *http.Client, authState *SSEAuthState, onSecretFetched SSESecretCacheFunc) *SSEManager {
+func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, resyncHttpClient *http.Client, authState *SSEAuthState) *SSEManager {
 	return &SSEManager{
 		connections:      make(map[string]*SSEConnection),
 		cache:            cache,
@@ -193,7 +187,6 @@ func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpCl
 		httpClient:       httpClient,
 		resyncHttpClient: resyncHttpClient,
 		authState:        authState,
-		onSecretFetched:  onSecretFetched,
 		ctx:              ctx,
 	}
 }
@@ -250,7 +243,7 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 
 		connStart := time.Now()
 
-		err := connectSSEForProject(ctx, m.cache, m.domainURL, m.authState, m.httpClient, conn.ProjectID, m.onSecretFetched)
+		err := connectSSEForProject(ctx, m.cache, m.domainURL, m.authState, m.httpClient, m.resyncHttpClient, conn.ProjectID)
 		if ctx.Err() != nil {
 			return
 		}
@@ -338,7 +331,7 @@ func isAuthError(err error) bool {
 
 // connectSSEForProject establishes a single SSE connection for one project and processes events.
 // One connection per project tracks all environments automatically.
-func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, projectId string, onSecretFetched SSESecretCacheFunc) error {
+func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, resyncHttpClient *http.Client, projectId string) error {
 	subscribeURL := *domainURL
 	subscribeURL.Path = domainURL.Path + "/api/v1/events/subscribe/project-events"
 
@@ -403,7 +396,7 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 			if !ok {
 				return fmt.Errorf("SSE stream closed for project %s", projectId)
 			}
-			handleSSEEvent(cache, domainURL, httpClient, authState, event, onSecretFetched)
+			handleSSEEvent(cache, domainURL, resyncHttpClient, event)
 		}
 	}
 }
@@ -464,7 +457,7 @@ func parseSSEStream(ctx context.Context, reader io.Reader, projectId string, eve
 }
 
 // handleSSEEvent processes a single SSE event and performs cache operations.
-func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent, onSecretFetched SSESecretCacheFunc) {
+func handleSSEEvent(cache *Cache, domainURL *url.URL, resyncHttpClient *http.Client, event SSEEvent) {
 	secretPath := event.Data.SecretPath
 	if secretPath == "" {
 		secretPath = "/"
@@ -484,9 +477,11 @@ func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, a
 		log.Info().Int("purgedCount", purged).Msg("Cache entries purged after secret deletion")
 
 	case SSEEventSecretCreate, SSEEventSecretUpdate:
-		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
-		log.Info().Int("purgedCount", purged).Msg("Cache entries purged, refetching...")
-		refetchSecretsAfterSSEEvent(domainURL, httpClient, authState, event, onSecretFetched)
+		collected := cache.CollectAndPurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
+		log.Info().Int("purgedCount", len(collected)).Msg("Cache entries purged, refetching...")
+		if len(collected) > 0 {
+			go refetchSecretsAfterSSEEvent(cache, domainURL, resyncHttpClient, collected)
+		}
 
 	case SSEEventSecretImportMutation:
 		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
@@ -500,81 +495,79 @@ func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, a
 	}
 }
 
-// refetchSecretsAfterSSEEvent fetches the created/updated secret from the Infisical API
-// and delegates caching to the onSecretFetched callback.
-func refetchSecretsAfterSSEEvent(domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent, onSecretFetched SSESecretCacheFunc) {
-	if event.Data.SecretKey == "" {
-		log.Warn().
-			Str("eventType", string(event.EventType)).
-			Msg("SSE event missing secretKey, cannot refetch")
-		return
-	}
+// refetchSecretsAfterSSEEvent replays the original cached requests to repopulate the cache.
+// Each collected entry is re-fetched using its original token and request, preserving
+// per-user cache entries rather than using the SSE machine identity token.
+func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, collectedEntries []CollectedCacheEntry) {
+	refetched := 0
+	failed := 0
 
-	secretPath := event.Data.SecretPath
-	if secretPath == "" {
-		secretPath = "/"
-	}
+	for _, entry := range collectedEntries {
+		// Add jitter to avoid bursts
+		time.Sleep(time.Duration(rand.Intn(500)) * time.Millisecond)
+		proxyReq, err := reconstructProxyRequest(domainURL, entry.Request)
+		if err != nil {
+			log.Error().Err(err).
+				Str("cacheKey", entry.CacheKey).
+				Str("requestURI", entry.Request.RequestURI).
+				Msg("Failed to reconstruct request during SSE refetch")
+			failed++
+			continue
+		}
 
-	// This is performing the same request a user would perform when they access the secret directly
-	resp, req, err := getSecretByName(domainURL, httpClient, authState.GetToken(), event.Data.SecretKey, event.Data.ProjectId, event.Data.Environment, secretPath)
-	if err != nil {
-		log.Error().Err(err).
-			Str("secretKey", event.Data.SecretKey).
-			Msg("Failed to fetch secret after SSE event")
-		return
-	}
-	defer resp.Body.Close()
+		resp, err := httpClient.Do(proxyReq)
+		if err != nil {
+			log.Error().Err(err).
+				Str("cacheKey", entry.CacheKey).
+				Str("requestURI", entry.Request.RequestURI).
+				Msg("Network error during SSE refetch")
+			failed++
+			continue
+		}
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		log.Warn().
-			Int("statusCode", resp.StatusCode).
-			Str("secretKey", event.Data.SecretKey).
-			Str("response", string(body)).
-			Msg("Unexpected status during SSE refetch")
-		return
-	}
+		if resp.StatusCode == http.StatusOK {
+			bodyBytes, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				log.Error().Err(readErr).
+					Str("cacheKey", entry.CacheKey).
+					Msg("Failed to read response body during SSE refetch")
+				failed++
+				continue
+			}
 
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to read refetch response body")
-		return
+			cachedResp := &http.Response{
+				StatusCode: resp.StatusCode,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+			}
+			CopyHeaders(cachedResp.Header, resp.Header)
+
+			cache.Set(entry.CacheKey, proxyReq, cachedResp, entry.Token, entry.IndexEntry)
+			refetched++
+		} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			resp.Body.Close()
+			log.Warn().
+				Int("statusCode", resp.StatusCode).
+				Str("cacheKey", entry.CacheKey).
+				Str("requestURI", entry.Request.RequestURI).
+				Msg("Unauthorized or forbidden status during SSE refetch, skipping cache repopulation")
+			cache.EvictEntry(entry.CacheKey)
+			failed++
+		} else {
+			resp.Body.Close()
+			log.Warn().
+				Int("statusCode", resp.StatusCode).
+				Str("cacheKey", entry.CacheKey).
+				Str("requestURI", entry.Request.RequestURI).
+				Msg("Non-OK status during SSE refetch, skipping cache repopulation")
+			failed++
+		}
 	}
 
 	log.Info().
-		Str("projectId", event.Data.ProjectId).
-		Msg("Refetched secret after SSE event")
-
-	onSecretFetched(req, resp, bodyBytes, event)
-}
-
-func getSecretByName(domainURL *url.URL, httpClient *http.Client, token, secretName, projectId, environment, secretPath string) (*http.Response, *http.Request, error) {
-	secretURL := *domainURL
-	secretURL.Path = domainURL.Path + "/api/v4/secrets/" + url.PathEscape(secretName)
-
-	query := url.Values{}
-	query.Set("projectId", projectId)
-	if environment != "" {
-		query.Set("environment", environment)
-	}
-	if secretPath != "" {
-		query.Set("secretPath", secretPath)
-	}
-
-	secretURL.RawQuery = query.Encode()
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, secretURL.String(), nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create secret fetch request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to fetch secret: %w", err)
-	}
-
-	return resp, req, nil
+		Int("refetched", refetched).
+		Int("failed", failed).
+		Int("total", len(collectedEntries)).
+		Msg("SSE refetch completed")
 }

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -40,13 +41,7 @@ type SSEEventData struct {
 }
 
 type SSESubscriptionRequest struct {
-	ProjectId string                        `json:"projectId"`
-	Register  []SSESubscriptionRegisterItem `json:"register"`
-}
-
-type SSESubscriptionRegisterItem struct {
-	EnvironmentSlug string `json:"environmentSlug"`
-	SecretPath      string `json:"secretPath" default:"/"`
+	ProjectId string `json:"projectId"`
 }
 
 type universalAuthLoginRequest struct {
@@ -60,6 +55,11 @@ type universalAuthLoginResponse struct {
 	TokenType   string `json:"tokenType"`
 }
 
+// SSESecretCacheFunc is a callback invoked after an SSE event fetches a secret from the API.
+// It receives the request, response body, and event data so the caller can cache the result
+// using the same approach as regular proxy requests.
+type SSESecretCacheFunc func(req *http.Request, resp *http.Response, bodyBytes []byte, event SSEEvent)
+
 // SSEAuthState manages authentication state for SSE operations.
 // It holds a reusable token and credentials for re-authentication.
 type SSEAuthState struct {
@@ -70,9 +70,8 @@ type SSEAuthState struct {
 	domainURL    *url.URL
 }
 
-func NewSSEAuthState(token, clientId, clientSecret string, domainURL *url.URL) *SSEAuthState {
+func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL) *SSEAuthState {
 	return &SSEAuthState{
-		token:        token,
 		clientId:     clientId,
 		clientSecret: clientSecret,
 		domainURL:    domainURL,
@@ -102,8 +101,6 @@ func (s *SSEAuthState) RefreshToken() (string, error) {
 	return newToken, nil
 }
 
-var errCacheEmpty = errors.New("cache is empty, no projects/environments to subscribe to")
-
 // CallUniversalAuthLogin authenticates a machine identity via universal auth.
 // Uses net/http directly (not resty) since the proxy module does not depend on resty.
 func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string) (string, error) {
@@ -118,7 +115,16 @@ func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string) (
 		return "", fmt.Errorf("failed to marshal login request: %w", err)
 	}
 
-	resp, err := http.Post(loginURL.String(), "application/json", bytes.NewReader(reqBody))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to call universal auth login: %w", err)
 	}
@@ -137,73 +143,160 @@ func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string) (
 	return loginResp.AccessToken, nil
 }
 
-// StartSSEListener starts the SSE event listener with exponential backoff reconnection.
-// It connects to the Infisical SSE endpoint and processes events to invalidate/refresh the cache.
-// On 401/403, it re-authenticates using the provided client credentials.
-func StartSSEListener(ctx context.Context, cache *Cache, domainURL *url.URL, initialToken string, httpClient *http.Client, clientId, clientSecret string) {
+// SSEConnection represents a single SSE connection for a project.
+// One connection per project tracks all environments automatically.
+type SSEConnection struct {
+	ProjectID string
+	Cancel    context.CancelFunc
+}
+
+// SSEManager manages demand-driven SSE connections. Connections are opened when
+// user requests hit secrets endpoints, not eagerly at startup.
+type SSEManager struct {
+	mu               sync.Mutex
+	connections      map[string]*SSEConnection // keyed by projectID
+	cache            *Cache
+	domainURL        *url.URL
+	httpClient       *http.Client // streaming client (no timeout) for SSE connections
+	resyncHttpClient *http.Client // regular client (with timeout) for cache resync requests
+	authState        *SSEAuthState
+	onSecretFetched  SSESecretCacheFunc
+	ctx              context.Context
+}
+
+func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, resyncHttpClient *http.Client, authState *SSEAuthState, onSecretFetched SSESecretCacheFunc) *SSEManager {
+	return &SSEManager{
+		connections:      make(map[string]*SSEConnection),
+		cache:            cache,
+		domainURL:        domainURL,
+		httpClient:       httpClient,
+		resyncHttpClient: resyncHttpClient,
+		authState:        authState,
+		onSecretFetched:  onSecretFetched,
+		ctx:              ctx,
+	}
+}
+
+// EnsureSubscription ensures an SSE connection exists for the given projectId.
+// One connection per project tracks all environments, so only the projectId matters.
+// Called from the proxy handler when a secrets request is seen.
+func (m *SSEManager) EnsureSubscription(projectId string) {
+	if projectId == "" {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// connection already exists for that projectId, so we don't need to open a new one
+	if m.connections[projectId] != nil {
+		return
+	}
+
+	log.Info().
+		Str("projectId", projectId).
+		Msg("Opening new SSE connection for project")
+
+	connCtx, connCancel := context.WithCancel(m.ctx)
+	conn := &SSEConnection{
+		ProjectID: projectId,
+		Cancel:    connCancel,
+	}
+	m.connections[projectId] = conn
+
+	go m.runConnection(conn, connCtx)
+}
+
+// runConnection runs a single SSE connection with retry, cache resync, and backoff.
+// After maxRetries consecutive failures the connection is removed so the next user
+// request can re-trigger EnsureSubscription.
+func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 	const (
-		baseDelay = 1 * time.Second
-		maxDelay  = 60 * time.Second
+		maxRetries      = 5
+		baseDelay       = 2 * time.Second
+		maxDelay        = 60 * time.Second
+		healthyDuration = 30 * time.Second
 	)
 
-	authState := NewSSEAuthState(initialToken, clientId, clientSecret, domainURL)
-	currentDelay := baseDelay
+	retries := 0
 
 	for {
-		select {
-		case <-ctx.Done():
-			log.Info().Msg("SSE listener stopped")
-			return
-		default:
-		}
-
-		connStart := time.Now()
-		log.Info().Msg("Connecting to SSE event stream...")
-
-		err := connectAndProcessSSE(ctx, cache, domainURL, authState, httpClient)
-
 		if ctx.Err() != nil {
 			return
 		}
 
-		// Reset backoff if connection lasted > 30s (was a real connection, not immediate failure)
-		if time.Since(connStart) > 30*time.Second {
-			currentDelay = baseDelay
-		}
+		connStart := time.Now()
 
-		if err != nil {
-			// Re-authenticate on auth errors
-			if isAuthError(err) {
-				log.Warn().Err(err).Msg("SSE auth error, re-authenticating...")
-				newToken, authErr := authState.RefreshToken()
-				if authErr != nil {
-					log.Error().Err(authErr).Msg("Failed to re-authenticate machine identity")
-				} else {
-					_ = newToken
-					log.Info().Msg("Machine identity re-authenticated successfully")
-					currentDelay = baseDelay
-					continue
-				}
-			}
-
-			log.Error().Err(err).
-				Str("retryIn", currentDelay.String()).
-				Msg("SSE connection failed, will retry")
-		}
-
-		// Exponential backoff with jitter
-		jitter := time.Duration(rand.Int63n(int64(currentDelay) / 2))
-		select {
-		case <-time.After(currentDelay + jitter):
-		case <-ctx.Done():
+		err := connectSSEForProject(ctx, m.cache, m.domainURL, m.authState, m.httpClient, conn.ProjectID, m.onSecretFetched)
+		if ctx.Err() != nil {
 			return
 		}
 
-		currentDelay *= 2
-		if currentDelay > maxDelay {
-			currentDelay = maxDelay
+		// Connection stayed up long enough — reset retry counter
+		if time.Since(connStart) > healthyDuration {
+			retries = 0
+		}
+
+		if err == nil {
+			// Stream closed cleanly, reconnect immediately
+			continue
+		}
+
+		// Handle auth errors with one re-auth attempt
+		if isAuthError(err) {
+			log.Warn().Err(err).
+				Str("projectId", conn.ProjectID).
+				Msg("SSE auth error, re-authenticating...")
+
+			if _, authErr := m.authState.RefreshToken(); authErr == nil {
+				log.Info().Str("projectId", conn.ProjectID).
+					Msg("Machine identity re-authenticated successfully")
+				continue
+			}
+			log.Error().Str("projectId", conn.ProjectID).
+				Msg("Failed to re-authenticate machine identity")
+		}
+
+		retries++
+		if retries > maxRetries {
+			log.Error().
+				Str("projectId", conn.ProjectID).
+				Int("maxRetries", maxRetries).
+				Msg("SSE connection retries exhausted, removing connection")
+			m.removeConnection(conn.ProjectID)
+			return
+		}
+
+		log.Warn().Err(err).
+			Str("projectId", conn.ProjectID).
+			Int("retry", retries).
+			Int("maxRetries", maxRetries).
+			Msg("SSE connection lost, resyncing cache before retrying")
+
+		// Resync cache before reconnecting — we may have missed events during the outage
+		runStaticSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, 0)
+
+		// Exponential backoff with jitter
+		delay := baseDelay * time.Duration(math.Pow(2, float64(retries-1)))
+
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+		jitter := time.Duration(rand.Int63n(int64(delay) / 2))
+		select {
+		case <-time.After(delay + jitter):
+		case <-ctx.Done():
+			return
 		}
 	}
+}
+
+// removeConnection removes a connection from the map so the next user request
+// can re-trigger EnsureSubscription for this project.
+func (m *SSEManager) removeConnection(projectId string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.connections, projectId)
 }
 
 type sseAuthError struct {
@@ -219,59 +312,14 @@ func isAuthError(err error) bool {
 	return errors.As(err, &authErr)
 }
 
-// connectAndProcessSSE establishes SSE connections for all cached projects and blocks until they all disconnect.
-func connectAndProcessSSE(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client) error {
-	projects := cache.GetUniqueProjectEnvironments()
-	if len(projects) == 0 {
-		log.Info().Msg("No cached projects/environments yet, waiting for cache to populate...")
-		return errCacheEmpty
-	}
-
-	// One SSE connection per project and per, since the subscription API is per-project
-	sseCtx, sseCancel := context.WithCancel(ctx)
-	defer sseCancel()
-
-	var wg sync.WaitGroup
-	errCh := make(chan error, len(projects))
-
-	for projectId, envSlugs := range projects {
-		wg.Add(1)
-		go func(projectId string, envSlugs []string) {
-			defer wg.Done()
-			err := connectSSEForProject(sseCtx, cache, domainURL, authState, httpClient, projectId, envSlugs)
-			if err != nil {
-				errCh <- err
-				sseCancel()
-			}
-		}(projectId, envSlugs)
-	}
-
-	wg.Wait()
-	close(errCh)
-
-	// Return the first error
-	for err := range errCh {
-		return err
-	}
-	return nil
-}
-
 // connectSSEForProject establishes a single SSE connection for one project and processes events.
-func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, projectId string, envSlugs []string) error {
+// One connection per project tracks all environments automatically.
+func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, projectId string, onSecretFetched SSESecretCacheFunc) error {
 	subscribeURL := *domainURL
 	subscribeURL.Path = domainURL.Path + "/api/v1/events/subscribe/project-events"
 
-	registerItems := make([]SSESubscriptionRegisterItem, 0, len(envSlugs))
-	for _, env := range envSlugs {
-		registerItems = append(registerItems, SSESubscriptionRegisterItem{
-			EnvironmentSlug: env,
-			SecretPath:      "/",
-		})
-	}
-
 	reqBody, err := json.Marshal(SSESubscriptionRequest{
 		ProjectId: projectId,
-		Register:  registerItems,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal SSE subscription request: %w", err)
@@ -290,7 +338,6 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 
 	log.Info().
 		Str("projectId", projectId).
-		Strs("environments", envSlugs).
 		Msg("Subscribing to SSE events")
 
 	resp, err := httpClient.Do(req)
@@ -304,7 +351,10 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read SSE subscription response body: %w", err)
+		}
 		return fmt.Errorf("SSE subscription returned status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -323,7 +373,7 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 			if !ok {
 				return fmt.Errorf("SSE stream closed for project %s", projectId)
 			}
-			handleSSEEvent(cache, domainURL, httpClient, authState, event)
+			handleSSEEvent(cache, domainURL, httpClient, authState, event, onSecretFetched)
 		}
 	}
 }
@@ -373,7 +423,6 @@ func parseSSEStream(ctx context.Context, reader io.Reader, events chan<- SSEEven
 		} else if strings.HasPrefix(line, "data:") {
 			currentData.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
 		}
-		// Ignore "id:", "retry:", and comment lines (starting with ":")
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -382,7 +431,7 @@ func parseSSEStream(ctx context.Context, reader io.Reader, events chan<- SSEEven
 }
 
 // handleSSEEvent processes a single SSE event and performs cache operations.
-func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent) {
+func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent, onSecretFetched SSESecretCacheFunc) {
 	secretPath := event.Data.SecretPath
 	if secretPath == "" {
 		secretPath = "/"
@@ -404,13 +453,14 @@ func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, a
 	case SSEEventSecretCreate, SSEEventSecretUpdate:
 		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
 		log.Info().Int("purgedCount", purged).Msg("Cache entries purged, refetching...")
-		refetchSecretsAfterSSEEvent(cache, domainURL, httpClient, authState, event)
+		refetchSecretsAfterSSEEvent(domainURL, httpClient, authState, event, onSecretFetched)
 
 	case SSEEventSecretImportMutation:
 		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
 		log.Info().Int("purgedCount", purged).Msg("Cache entries purged after import mutation")
 
 	default:
+		// ping event
 		log.Warn().
 			Str("eventType", string(event.EventType)).
 			Msg("Unknown SSE event type, ignoring")
@@ -418,8 +468,8 @@ func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, a
 }
 
 // refetchSecretsAfterSSEEvent fetches the created/updated secret from the Infisical API
-// and stores it in the cache. Uses the machine identity token from authState.
-func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent) {
+// and delegates caching to the onSecretFetched callback.
+func refetchSecretsAfterSSEEvent(domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent, onSecretFetched SSESecretCacheFunc) {
 	if event.Data.SecretKey == "" {
 		log.Warn().
 			Str("eventType", string(event.EventType)).
@@ -432,7 +482,8 @@ func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *h
 		secretPath = "/"
 	}
 
-	resp, req, err := fetchSecretFromAPI(domainURL, httpClient, authState, event.Data.SecretKey, event.Data.ProjectId, event.Data.Environment, secretPath)
+	// This is performing the same request a user would perform when they access the secret directly
+	resp, req, err := getSecretByName(domainURL, httpClient, authState.GetToken(), event.Data.SecretKey, event.Data.ProjectId, event.Data.Environment, secretPath)
 	if err != nil {
 		log.Error().Err(err).
 			Str("secretKey", event.Data.SecretKey).
@@ -457,56 +508,10 @@ func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *h
 		return
 	}
 
-	token := authState.GetToken()
-	cacheKey := GenerateCacheKey(req.Method, req.URL.Path, req.URL.RawQuery, token)
-
-	cachedResp := &http.Response{
-		StatusCode: resp.StatusCode,
-		Header:     make(http.Header),
-		Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
-	}
-	CopyHeaders(cachedResp.Header, resp.Header)
-
-	// I think this can also be refactored, since this is the same approach another function already uses
-	indexEntry := IndexEntry{
-		CacheKey:        cacheKey,
-		SecretPath:      secretPath,
-		EnvironmentSlug: event.Data.Environment,
-		ProjectId:       event.Data.ProjectId,
-	}
-
-	cache.Set(cacheKey, req, cachedResp, token, indexEntry)
-
-	log.Info().
-		Str("secretKey", event.Data.SecretKey).
-		Str("cacheKey", cacheKey).
-		Msg("Successfully refetched and cached secret after SSE event")
+	onSecretFetched(req, resp, bodyBytes, event)
 }
 
-// fetchSecretFromAPI calls GET /api/v4/secrets/{secretName} with the given parameters.
-// On 401/403 it refreshes the token via authState and retries once.
-// Returns the final HTTP response and the request used (for cache key generation).
-func fetchSecretFromAPI(domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, secretName, projectId, environment, secretPath string) (*http.Response, *http.Request, error) {
-	resp, req, err := doSecretGET(domainURL, httpClient, authState.GetToken(), secretName, projectId, environment, secretPath)
-	if err != nil {
-		return nil, nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		resp.Body.Close()
-		log.Warn().Msg("Auth error during SSE refetch, refreshing token...")
-		if _, authErr := authState.RefreshToken(); authErr != nil {
-			log.Error().Err(authErr).Msg("Failed to refresh token during SSE refetch")
-			return nil, nil, authErr
-		}
-		resp, req, err = doSecretGET(domainURL, httpClient, authState.GetToken(), secretName, projectId, environment, secretPath)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	return resp, req, nil
-}
-
-func doSecretGET(domainURL *url.URL, httpClient *http.Client, token, secretName, projectId, environment, secretPath string) (*http.Response, *http.Request, error) {
+func getSecretByName(domainURL *url.URL, httpClient *http.Client, token, secretName, projectId, environment, secretPath string) (*http.Response, *http.Request, error) {
 	secretURL := *domainURL
 	secretURL.Path = domainURL.Path + "/api/v4/secrets/" + url.PathEscape(secretName)
 

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -375,7 +375,20 @@ func (m *SSEManager) transitionToPolling(projectId, environmentSlug string) {
 	// Resync the project cache immediately — events might have been missed during the outage
 	go runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug)
 
-	go startProjectPollingLoop(pollCtx, m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug, pollingFallbackInterval)
+	// On each polling tick (except the first), attempt SSE reconnection
+	retrySSE := func() {
+		m.mu.Lock()
+		ps, ok := m.pollingProjects[projectId]
+		if !ok || ps.retryingSSE {
+			m.mu.Unlock()
+			return
+		}
+		ps.retryingSSE = true
+		m.mu.Unlock()
+		go m.attemptSSEReconnection(projectId, environmentSlug)
+	}
+
+	go startProjectPollingLoop(pollCtx, m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug, pollingFallbackInterval, retrySSE)
 }
 
 func (m *SSEManager) cancelPollingIfActive(projectId string) {

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -88,12 +88,17 @@ type SSEAuthState struct {
 }
 
 func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL, httpClient *http.Client) *SSEAuthState {
-	return &SSEAuthState{
+	authState := &SSEAuthState{
 		clientId:     clientId,
 		clientSecret: clientSecret,
 		domainURL:    domainURL,
 		httpClient:   httpClient,
 	}
+
+	// ensure we have a valid token
+	authState.RefreshToken()
+
+	return authState
 }
 
 func (s *SSEAuthState) GetToken() string {
@@ -398,7 +403,7 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 			if !ok {
 				return fmt.Errorf("SSE stream closed for project %s", projectId)
 			}
-			handleSSEEvent(cache, domainURL, resyncHttpClient, event)
+			handleSSEEvent(ctx, cache, domainURL, resyncHttpClient, event)
 		}
 	}
 }
@@ -459,7 +464,7 @@ func parseSSEStream(ctx context.Context, reader io.Reader, projectId string, eve
 }
 
 // handleSSEEvent processes a single SSE event and performs cache operations.
-func handleSSEEvent(cache *Cache, domainURL *url.URL, resyncHttpClient *http.Client, event SSEEvent) {
+func handleSSEEvent(ctx context.Context, cache *Cache, domainURL *url.URL, resyncHttpClient *http.Client, event SSEEvent) {
 	secretPath := event.Data.SecretPath
 	if secretPath == "" {
 		secretPath = "/"
@@ -482,7 +487,7 @@ func handleSSEEvent(cache *Cache, domainURL *url.URL, resyncHttpClient *http.Cli
 		collected := cache.CollectAndPurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
 		log.Info().Int("purgedCount", len(collected)).Msg("Cache entries purged, refetching...")
 		if len(collected) > 0 {
-			go refetchSecretsAfterSSEEvent(cache, domainURL, resyncHttpClient, collected)
+			go refetchSecretsAfterSSEEvent(ctx, cache, domainURL, resyncHttpClient, collected)
 		}
 
 	case SSEEventSecretImportMutation:
@@ -500,7 +505,7 @@ func handleSSEEvent(cache *Cache, domainURL *url.URL, resyncHttpClient *http.Cli
 // refetchSecretsAfterSSEEvent replays the original cached requests to repopulate the cache.
 // Each collected entry is re-fetched using its original token and request, preserving
 // per-user cache entries rather than using the SSE machine identity token.
-func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, collectedEntries []CollectedCacheEntry) {
+func refetchSecretsAfterSSEEvent(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, collectedEntries []CollectedCacheEntry) {
 	refetched := 0
 	failed := 0
 
@@ -547,15 +552,6 @@ func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *h
 
 			cache.Set(entry.CacheKey, proxyReq, cachedResp, entry.Token, entry.IndexEntry)
 			refetched++
-		} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			resp.Body.Close()
-			log.Warn().
-				Int("statusCode", resp.StatusCode).
-				Str("cacheKey", entry.CacheKey).
-				Str("requestURI", entry.Request.RequestURI).
-				Msg("Unauthorized or forbidden status during SSE refetch, skipping cache repopulation")
-			cache.EvictEntry(entry.CacheKey)
-			failed++
 		} else {
 			resp.Body.Close()
 			log.Warn().

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -369,7 +369,7 @@ func (m *SSEManager) transitionToPolling(projectId, environmentSlug string) {
 		Msg("Starting polling fallback for project")
 
 	// Resync the project cache immediately — events might have been missed during the outage
-	runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug)
+	go runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug)
 
 	// On each polling tick (except the first), attempt SSE reconnection
 	retrySSE := func() {

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -188,28 +188,29 @@ type pollingState struct {
 // When SSE connections fail repeatedly for a project, the manager transitions
 // that project to a polling fallback and tracks it in pollingProjects.
 type SSEManager struct {
-	mu               sync.Mutex
-	connections      map[string]*SSEConnection // active SSE connections
-	pollingProjects  map[string]*pollingState  // projects in polling fallback
-	cache            *Cache
-	domainURL        *url.URL
-	httpClient       *http.Client // streaming client (no timeout) for SSE connections
-	resyncHttpClient *http.Client // regular client (with timeout) for cache resync requests
-	authState        *SSEAuthState
-	ctx              context.Context
+	mu                      sync.Mutex
+	connections             map[string]*SSEConnection // active SSE connections
+	pollingProjects         map[string]*pollingState  // projects in polling fallback
+	cache                   *Cache
+	domainURL               *url.URL
+	httpClient              *http.Client // streaming client (no timeout) for SSE connections
+	resyncHttpClient        *http.Client // regular client (with timeout) for cache resync requests
+	authState               *SSEAuthState
+	pollingFallbackInterval time.Duration
+	ctx                     context.Context
 }
 
-func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, resyncHttpClient *http.Client, authState *SSEAuthState) *SSEManager {
-
+func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpClient *http.Client, resyncHttpClient *http.Client, authState *SSEAuthState, pollingFallbackInterval time.Duration) *SSEManager {
 	return &SSEManager{
-		connections:      make(map[string]*SSEConnection),
-		pollingProjects:  make(map[string]*pollingState),
-		cache:            cache,
-		domainURL:        domainURL,
-		httpClient:       httpClient,
-		resyncHttpClient: resyncHttpClient,
-		authState:        authState,
-		ctx:              ctx,
+		connections:             make(map[string]*SSEConnection),
+		pollingProjects:         make(map[string]*pollingState),
+		cache:                   cache,
+		domainURL:               domainURL,
+		httpClient:              httpClient,
+		resyncHttpClient:        resyncHttpClient,
+		authState:               authState,
+		pollingFallbackInterval: pollingFallbackInterval,
+		ctx:                     ctx,
 	}
 }
 
@@ -327,9 +328,6 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 			Int("maxRetries", maxRetries).
 			Msg("SSE connection lost, resyncing cache before retrying")
 
-		// Resync project cache before reconnecting — we may have missed events during the outage
-		runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, conn.ProjectID, conn.EnvironmentSlug)
-
 		// Exponential backoff with jitter
 		delay := baseDelay * time.Duration(math.Pow(2, float64(retries-1)))
 
@@ -344,8 +342,6 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 		}
 	}
 }
-
-const pollingFallbackInterval = 5 * time.Minute
 
 // transitionToPolling moves a project from SSE mode to polling fallback.
 func (m *SSEManager) transitionToPolling(projectId, environmentSlug string) {
@@ -373,7 +369,7 @@ func (m *SSEManager) transitionToPolling(projectId, environmentSlug string) {
 		Msg("Starting polling fallback for project")
 
 	// Resync the project cache immediately — events might have been missed during the outage
-	go runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug)
+	runProjectSecretsRefresh(m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug)
 
 	// On each polling tick (except the first), attempt SSE reconnection
 	retrySSE := func() {
@@ -388,7 +384,7 @@ func (m *SSEManager) transitionToPolling(projectId, environmentSlug string) {
 		go m.attemptSSEReconnection(projectId, environmentSlug)
 	}
 
-	go startProjectPollingLoop(pollCtx, m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug, pollingFallbackInterval, retrySSE)
+	go startProjectPollingLoop(pollCtx, m.cache, m.domainURL, m.resyncHttpClient, projectId, environmentSlug, m.pollingFallbackInterval, retrySSE)
 }
 
 func (m *SSEManager) cancelPollingIfActive(projectId string) {

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -40,8 +40,29 @@ type SSEEventData struct {
 	SecretKey   string `json:"secretKey"`
 }
 
+type sseRawMessage struct {
+	ProjectType string            `json:"projectType"`
+	Data        sseRawMessageData `json:"data"`
+}
+
+type sseRawMessageData struct {
+	EventType string           `json:"eventType"`
+	Payload   []ssePayloadItem `json:"payload"`
+}
+
+type ssePayloadItem struct {
+	Environment string `json:"environment"`
+	SecretPath  string `json:"secretPath"`
+	SecretKey   string `json:"secretKey"`
+}
+
+type SSESubscriptionRegisterItem struct {
+	Event SSEEventType `json:"event"`
+}
+
 type SSESubscriptionRequest struct {
-	ProjectId string `json:"projectId"`
+	ProjectId string                        `json:"projectId"`
+	Register  []SSESubscriptionRegisterItem `json:"register"`
 }
 
 type universalAuthLoginRequest struct {
@@ -181,6 +202,7 @@ func NewSSEManager(ctx context.Context, cache *Cache, domainURL *url.URL, httpCl
 // One connection per project tracks all environments, so only the projectId matters.
 // Called from the proxy handler when a secrets request is seen.
 func (m *SSEManager) EnsureSubscription(projectId string) {
+	log.Info().Str("projectId", projectId).Msg("Ensuring SSE subscription for project")
 	if projectId == "" {
 		return
 	}
@@ -190,6 +212,7 @@ func (m *SSEManager) EnsureSubscription(projectId string) {
 
 	// connection already exists for that projectId, so we don't need to open a new one
 	if m.connections[projectId] != nil {
+		log.Info().Str("projectId", projectId).Msg("SSE connection already exists for project, skipping")
 		return
 	}
 
@@ -309,6 +332,7 @@ func (e *sseAuthError) Error() string {
 
 func isAuthError(err error) bool {
 	var authErr *sseAuthError
+
 	return errors.As(err, &authErr)
 }
 
@@ -320,6 +344,12 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 
 	reqBody, err := json.Marshal(SSESubscriptionRequest{
 		ProjectId: projectId,
+		Register: []SSESubscriptionRegisterItem{
+			{Event: SSEEventSecretCreate},
+			{Event: SSEEventSecretUpdate},
+			{Event: SSEEventSecretDelete},
+			{Event: SSEEventSecretImportMutation},
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal SSE subscription request: %w", err)
@@ -363,13 +393,14 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 		Msg("SSE connection established")
 
 	events := make(chan SSEEvent, 10)
-	go parseSSEStream(ctx, resp.Body, events)
+	go parseSSEStream(ctx, resp.Body, projectId, events)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case event, ok := <-events:
+			log.Info().Str("event", fmt.Sprintf("%+v", event)).Msg("DEBUG")
 			if !ok {
 				return fmt.Errorf("SSE stream closed for project %s", projectId)
 			}
@@ -380,12 +411,12 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 
 // parseSSEStream reads from an io.Reader and emits SSEEvent values on a channel.
 // Implements the standard SSE protocol: "event:" lines set the type, "data:" lines set the payload,
-// blank lines delimit events.
-func parseSSEStream(ctx context.Context, reader io.Reader, events chan<- SSEEvent) {
+// blank lines delimit events. The JSON body carries a nested structure with the event type and
+// a payload array; each payload item becomes a separate SSEEvent on the channel.
+func parseSSEStream(ctx context.Context, reader io.Reader, projectId string, events chan<- SSEEvent) {
 	defer close(events)
 
 	scanner := bufio.NewScanner(reader)
-	var currentEvent string
 	var currentData strings.Builder
 
 	for scanner.Scan() {
@@ -398,29 +429,32 @@ func parseSSEStream(ctx context.Context, reader io.Reader, events chan<- SSEEven
 		line := scanner.Text()
 
 		if line == "" {
-			// Blank line = event delimiter
-			if currentData.Len() > 0 && currentEvent != "" {
-				var data SSEEventData
-				if err := json.Unmarshal([]byte(currentData.String()), &data); err != nil {
+			if currentData.Len() > 0 {
+				var raw sseRawMessage
+				if err := json.Unmarshal([]byte(currentData.String()), &raw); err != nil {
 					log.Error().Err(err).
-						Str("eventType", currentEvent).
 						Str("rawData", currentData.String()).
 						Msg("Failed to parse SSE event data")
 				} else {
-					events <- SSEEvent{
-						EventType: SSEEventType(currentEvent),
-						Data:      data,
+					eventType := SSEEventType(raw.Data.EventType)
+					for _, item := range raw.Data.Payload {
+						events <- SSEEvent{
+							EventType: eventType,
+							Data: SSEEventData{
+								Environment: item.Environment,
+								SecretPath:  item.SecretPath,
+								SecretKey:   item.SecretKey,
+								ProjectId:   projectId,
+							},
+						}
 					}
 				}
 			}
-			currentEvent = ""
 			currentData.Reset()
 			continue
 		}
 
-		if strings.HasPrefix(line, "event:") {
-			currentEvent = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-		} else if strings.HasPrefix(line, "data:") {
+		if strings.HasPrefix(line, "data:") {
 			currentData.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
 		}
 	}
@@ -507,6 +541,10 @@ func refetchSecretsAfterSSEEvent(domainURL *url.URL, httpClient *http.Client, au
 		log.Error().Err(err).Msg("Failed to read refetch response body")
 		return
 	}
+
+	log.Info().
+		Str("projectId", event.Data.ProjectId).
+		Msg("Refetched secret after SSE event")
 
 	onSecretFetched(req, resp, bodyBytes, event)
 }

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -87,7 +87,7 @@ type SSEAuthState struct {
 	httpClient   *http.Client
 }
 
-func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL, httpClient *http.Client) *SSEAuthState {
+func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL, httpClient *http.Client) (*SSEAuthState, error) {
 	authState := &SSEAuthState{
 		clientId:     clientId,
 		clientSecret: clientSecret,
@@ -96,12 +96,13 @@ func NewSSEAuthState(clientId, clientSecret string, domainURL *url.URL, httpClie
 	}
 
 	// ensure we have a valid token
-	_, err := authState.RefreshToken()
+	_, err := authState.UniversalAuthLogin()
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to refresh SSE auth token")
+		log.Error().Err(err).Msg("Failed to authenticate machine identity")
+		return nil, err
 	}
 
-	return authState
+	return authState, nil
 }
 
 func (s *SSEAuthState) GetToken() string {
@@ -116,7 +117,7 @@ func (s *SSEAuthState) SetToken(token string) {
 	s.token = token
 }
 
-func (s *SSEAuthState) RefreshToken() (string, error) {
+func (s *SSEAuthState) UniversalAuthLogin() (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	newToken, err := CallUniversalAuthLogin(s.domainURL, s.clientId, s.clientSecret, s.httpClient)
@@ -275,7 +276,7 @@ func (m *SSEManager) runConnection(conn *SSEConnection, ctx context.Context) {
 				Str("projectId", conn.ProjectID).
 				Msg("SSE auth error, re-authenticating...")
 
-			if _, authErr := m.authState.RefreshToken(); authErr == nil {
+			if _, authErr := m.authState.UniversalAuthLogin(); authErr == nil {
 				log.Info().Str("projectId", conn.ProjectID).
 					Msg("Machine identity re-authenticated successfully")
 				continue

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -400,7 +400,6 @@ func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL,
 		case <-ctx.Done():
 			return ctx.Err()
 		case event, ok := <-events:
-			log.Info().Str("event", fmt.Sprintf("%+v", event)).Msg("DEBUG")
 			if !ok {
 				return fmt.Errorf("SSE stream closed for project %s", projectId)
 			}
@@ -561,9 +560,10 @@ func getSecretByName(domainURL *url.URL, httpClient *http.Client, token, secretN
 	if secretPath != "" {
 		query.Set("secretPath", secretPath)
 	}
+
 	secretURL.RawQuery = query.Encode()
 
-	req, err := http.NewRequest(http.MethodGet, secretURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, secretURL.String(), nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create secret fetch request: %w", err)
 	}

--- a/packages/proxy/sse.go
+++ b/packages/proxy/sse.go
@@ -1,0 +1,537 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type SSEEventType string
+
+const (
+	SSEEventSecretCreate         SSEEventType = "secret:create"
+	SSEEventSecretUpdate         SSEEventType = "secret:update"
+	SSEEventSecretDelete         SSEEventType = "secret:delete"
+	SSEEventSecretImportMutation SSEEventType = "secret:import-mutation"
+)
+
+type SSEEvent struct {
+	EventType SSEEventType
+	Data      SSEEventData
+}
+
+type SSEEventData struct {
+	Environment string `json:"environment"`
+	SecretPath  string `json:"secretPath"`
+	ProjectId   string `json:"projectId"`
+	SecretKey   string `json:"secretKey"`
+}
+
+type SSESubscriptionRequest struct {
+	ProjectId string                        `json:"projectId"`
+	Register  []SSESubscriptionRegisterItem `json:"register"`
+}
+
+type SSESubscriptionRegisterItem struct {
+	EnvironmentSlug string `json:"environmentSlug"`
+	SecretPath      string `json:"secretPath" default:"/"`
+}
+
+type universalAuthLoginRequest struct {
+	ClientSecret string `json:"clientSecret"`
+	ClientId     string `json:"clientId"`
+}
+
+type universalAuthLoginResponse struct {
+	AccessToken string `json:"accessToken"`
+	ExpiresIn   int    `json:"expiresIn"`
+	TokenType   string `json:"tokenType"`
+}
+
+// SSEAuthState manages authentication state for SSE operations.
+// It holds a reusable token and credentials for re-authentication.
+type SSEAuthState struct {
+	mu           sync.RWMutex
+	token        string
+	clientId     string
+	clientSecret string
+	domainURL    *url.URL
+}
+
+func NewSSEAuthState(token, clientId, clientSecret string, domainURL *url.URL) *SSEAuthState {
+	return &SSEAuthState{
+		token:        token,
+		clientId:     clientId,
+		clientSecret: clientSecret,
+		domainURL:    domainURL,
+	}
+}
+
+func (s *SSEAuthState) GetToken() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.token
+}
+
+func (s *SSEAuthState) SetToken(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = token
+}
+
+func (s *SSEAuthState) RefreshToken() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	newToken, err := CallUniversalAuthLogin(s.domainURL, s.clientId, s.clientSecret)
+	if err != nil {
+		return "", err
+	}
+	s.token = newToken
+	return newToken, nil
+}
+
+var errCacheEmpty = errors.New("cache is empty, no projects/environments to subscribe to")
+
+// CallUniversalAuthLogin authenticates a machine identity via universal auth.
+// Uses net/http directly (not resty) since the proxy module does not depend on resty.
+func CallUniversalAuthLogin(domainURL *url.URL, clientId, clientSecret string) (string, error) {
+	loginURL := *domainURL
+	loginURL.Path = domainURL.Path + "/api/v1/auth/universal-auth/login/"
+
+	reqBody, err := json.Marshal(universalAuthLoginRequest{
+		ClientId:     clientId,
+		ClientSecret: clientSecret,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal login request: %w", err)
+	}
+
+	resp, err := http.Post(loginURL.String(), "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to call universal auth login: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("universal auth login returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var loginResp universalAuthLoginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return "", fmt.Errorf("failed to decode login response: %w", err)
+	}
+
+	return loginResp.AccessToken, nil
+}
+
+// StartSSEListener starts the SSE event listener with exponential backoff reconnection.
+// It connects to the Infisical SSE endpoint and processes events to invalidate/refresh the cache.
+// On 401/403, it re-authenticates using the provided client credentials.
+func StartSSEListener(ctx context.Context, cache *Cache, domainURL *url.URL, initialToken string, httpClient *http.Client, clientId, clientSecret string) {
+	const (
+		baseDelay = 1 * time.Second
+		maxDelay  = 60 * time.Second
+	)
+
+	authState := NewSSEAuthState(initialToken, clientId, clientSecret, domainURL)
+	currentDelay := baseDelay
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Msg("SSE listener stopped")
+			return
+		default:
+		}
+
+		connStart := time.Now()
+		log.Info().Msg("Connecting to SSE event stream...")
+
+		err := connectAndProcessSSE(ctx, cache, domainURL, authState, httpClient)
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Reset backoff if connection lasted > 30s (was a real connection, not immediate failure)
+		if time.Since(connStart) > 30*time.Second {
+			currentDelay = baseDelay
+		}
+
+		if err != nil {
+			// Re-authenticate on auth errors
+			if isAuthError(err) {
+				log.Warn().Err(err).Msg("SSE auth error, re-authenticating...")
+				newToken, authErr := authState.RefreshToken()
+				if authErr != nil {
+					log.Error().Err(authErr).Msg("Failed to re-authenticate machine identity")
+				} else {
+					_ = newToken
+					log.Info().Msg("Machine identity re-authenticated successfully")
+					currentDelay = baseDelay
+					continue
+				}
+			}
+
+			log.Error().Err(err).
+				Str("retryIn", currentDelay.String()).
+				Msg("SSE connection failed, will retry")
+		}
+
+		// Exponential backoff with jitter
+		jitter := time.Duration(rand.Int63n(int64(currentDelay) / 2))
+		select {
+		case <-time.After(currentDelay + jitter):
+		case <-ctx.Done():
+			return
+		}
+
+		currentDelay *= 2
+		if currentDelay > maxDelay {
+			currentDelay = maxDelay
+		}
+	}
+}
+
+type sseAuthError struct {
+	statusCode int
+}
+
+func (e *sseAuthError) Error() string {
+	return fmt.Sprintf("SSE subscription returned auth error status %d", e.statusCode)
+}
+
+func isAuthError(err error) bool {
+	var authErr *sseAuthError
+	return errors.As(err, &authErr)
+}
+
+// connectAndProcessSSE establishes SSE connections for all cached projects and blocks until they all disconnect.
+func connectAndProcessSSE(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client) error {
+	projects := cache.GetUniqueProjectEnvironments()
+	if len(projects) == 0 {
+		log.Info().Msg("No cached projects/environments yet, waiting for cache to populate...")
+		return errCacheEmpty
+	}
+
+	// One SSE connection per project and per, since the subscription API is per-project
+	sseCtx, sseCancel := context.WithCancel(ctx)
+	defer sseCancel()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(projects))
+
+	for projectId, envSlugs := range projects {
+		wg.Add(1)
+		go func(projectId string, envSlugs []string) {
+			defer wg.Done()
+			err := connectSSEForProject(sseCtx, cache, domainURL, authState, httpClient, projectId, envSlugs)
+			if err != nil {
+				errCh <- err
+				sseCancel()
+			}
+		}(projectId, envSlugs)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// Return the first error
+	for err := range errCh {
+		return err
+	}
+	return nil
+}
+
+// connectSSEForProject establishes a single SSE connection for one project and processes events.
+func connectSSEForProject(ctx context.Context, cache *Cache, domainURL *url.URL, authState *SSEAuthState, httpClient *http.Client, projectId string, envSlugs []string) error {
+	subscribeURL := *domainURL
+	subscribeURL.Path = domainURL.Path + "/api/v1/events/subscribe/project-events"
+
+	registerItems := make([]SSESubscriptionRegisterItem, 0, len(envSlugs))
+	for _, env := range envSlugs {
+		registerItems = append(registerItems, SSESubscriptionRegisterItem{
+			EnvironmentSlug: env,
+			SecretPath:      "/",
+		})
+	}
+
+	reqBody, err := json.Marshal(SSESubscriptionRequest{
+		ProjectId: projectId,
+		Register:  registerItems,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal SSE subscription request: %w", err)
+	}
+
+	token := authState.GetToken()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, subscribeURL.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("failed to create SSE subscription request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	log.Info().
+		Str("projectId", projectId).
+		Strs("environments", envSlugs).
+		Msg("Subscribing to SSE events")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("SSE connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return &sseAuthError{statusCode: resp.StatusCode}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("SSE subscription returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	log.Info().
+		Str("projectId", projectId).
+		Msg("SSE connection established")
+
+	events := make(chan SSEEvent, 10)
+	go parseSSEStream(ctx, resp.Body, events)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-events:
+			if !ok {
+				return fmt.Errorf("SSE stream closed for project %s", projectId)
+			}
+			handleSSEEvent(cache, domainURL, httpClient, authState, event)
+		}
+	}
+}
+
+// parseSSEStream reads from an io.Reader and emits SSEEvent values on a channel.
+// Implements the standard SSE protocol: "event:" lines set the type, "data:" lines set the payload,
+// blank lines delimit events.
+func parseSSEStream(ctx context.Context, reader io.Reader, events chan<- SSEEvent) {
+	defer close(events)
+
+	scanner := bufio.NewScanner(reader)
+	var currentEvent string
+	var currentData strings.Builder
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		line := scanner.Text()
+
+		if line == "" {
+			// Blank line = event delimiter
+			if currentData.Len() > 0 && currentEvent != "" {
+				var data SSEEventData
+				if err := json.Unmarshal([]byte(currentData.String()), &data); err != nil {
+					log.Error().Err(err).
+						Str("eventType", currentEvent).
+						Str("rawData", currentData.String()).
+						Msg("Failed to parse SSE event data")
+				} else {
+					events <- SSEEvent{
+						EventType: SSEEventType(currentEvent),
+						Data:      data,
+					}
+				}
+			}
+			currentEvent = ""
+			currentData.Reset()
+			continue
+		}
+
+		if strings.HasPrefix(line, "event:") {
+			currentEvent = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		} else if strings.HasPrefix(line, "data:") {
+			currentData.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+		// Ignore "id:", "retry:", and comment lines (starting with ":")
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Error().Err(err).Msg("SSE stream scanner error")
+	}
+}
+
+// handleSSEEvent processes a single SSE event and performs cache operations.
+func handleSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent) {
+	secretPath := event.Data.SecretPath
+	if secretPath == "" {
+		secretPath = "/"
+	}
+
+	log.Info().
+		Str("eventType", string(event.EventType)).
+		Str("projectId", event.Data.ProjectId).
+		Str("environment", event.Data.Environment).
+		Str("secretPath", secretPath).
+		Str("secretKey", event.Data.SecretKey).
+		Msg("Processing SSE event")
+
+	switch event.EventType {
+	case SSEEventSecretDelete:
+		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
+		log.Info().Int("purgedCount", purged).Msg("Cache entries purged after secret deletion")
+
+	case SSEEventSecretCreate, SSEEventSecretUpdate:
+		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
+		log.Info().Int("purgedCount", purged).Msg("Cache entries purged, refetching...")
+		refetchSecretsAfterSSEEvent(cache, domainURL, httpClient, authState, event)
+
+	case SSEEventSecretImportMutation:
+		purged := cache.PurgeByMutation(event.Data.ProjectId, event.Data.Environment, secretPath)
+		log.Info().Int("purgedCount", purged).Msg("Cache entries purged after import mutation")
+
+	default:
+		log.Warn().
+			Str("eventType", string(event.EventType)).
+			Msg("Unknown SSE event type, ignoring")
+	}
+}
+
+// refetchSecretsAfterSSEEvent fetches the created/updated secret from the Infisical API
+// and stores it in the cache. Uses the machine identity token from authState.
+func refetchSecretsAfterSSEEvent(cache *Cache, domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, event SSEEvent) {
+	if event.Data.SecretKey == "" {
+		log.Warn().
+			Str("eventType", string(event.EventType)).
+			Msg("SSE event missing secretKey, cannot refetch")
+		return
+	}
+
+	secretPath := event.Data.SecretPath
+	if secretPath == "" {
+		secretPath = "/"
+	}
+
+	resp, req, err := fetchSecretFromAPI(domainURL, httpClient, authState, event.Data.SecretKey, event.Data.ProjectId, event.Data.Environment, secretPath)
+	if err != nil {
+		log.Error().Err(err).
+			Str("secretKey", event.Data.SecretKey).
+			Msg("Failed to fetch secret after SSE event")
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		log.Warn().
+			Int("statusCode", resp.StatusCode).
+			Str("secretKey", event.Data.SecretKey).
+			Str("response", string(body)).
+			Msg("Unexpected status during SSE refetch")
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read refetch response body")
+		return
+	}
+
+	token := authState.GetToken()
+	cacheKey := GenerateCacheKey(req.Method, req.URL.Path, req.URL.RawQuery, token)
+
+	cachedResp := &http.Response{
+		StatusCode: resp.StatusCode,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+	}
+	CopyHeaders(cachedResp.Header, resp.Header)
+
+	// I think this can also be refactored, since this is the same approach another function already uses
+	indexEntry := IndexEntry{
+		CacheKey:        cacheKey,
+		SecretPath:      secretPath,
+		EnvironmentSlug: event.Data.Environment,
+		ProjectId:       event.Data.ProjectId,
+	}
+
+	cache.Set(cacheKey, req, cachedResp, token, indexEntry)
+
+	log.Info().
+		Str("secretKey", event.Data.SecretKey).
+		Str("cacheKey", cacheKey).
+		Msg("Successfully refetched and cached secret after SSE event")
+}
+
+// fetchSecretFromAPI calls GET /api/v4/secrets/{secretName} with the given parameters.
+// On 401/403 it refreshes the token via authState and retries once.
+// Returns the final HTTP response and the request used (for cache key generation).
+func fetchSecretFromAPI(domainURL *url.URL, httpClient *http.Client, authState *SSEAuthState, secretName, projectId, environment, secretPath string) (*http.Response, *http.Request, error) {
+	resp, req, err := doSecretGET(domainURL, httpClient, authState.GetToken(), secretName, projectId, environment, secretPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		resp.Body.Close()
+		log.Warn().Msg("Auth error during SSE refetch, refreshing token...")
+		if _, authErr := authState.RefreshToken(); authErr != nil {
+			log.Error().Err(authErr).Msg("Failed to refresh token during SSE refetch")
+			return nil, nil, authErr
+		}
+		resp, req, err = doSecretGET(domainURL, httpClient, authState.GetToken(), secretName, projectId, environment, secretPath)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return resp, req, nil
+}
+
+func doSecretGET(domainURL *url.URL, httpClient *http.Client, token, secretName, projectId, environment, secretPath string) (*http.Response, *http.Request, error) {
+	secretURL := *domainURL
+	secretURL.Path = domainURL.Path + "/api/v4/secrets/" + url.PathEscape(secretName)
+
+	query := url.Values{}
+	query.Set("projectId", projectId)
+	if environment != "" {
+		query.Set("environment", environment)
+	}
+	if secretPath != "" {
+		query.Set("secretPath", secretPath)
+	}
+	secretURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, secretURL.String(), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create secret fetch request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch secret: %w", err)
+	}
+
+	return resp, req, nil
+}


### PR DESCRIPTION
# Description 📣
Allow support to update secrets using SSE (server sent events)

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

- Created a new secret management project
- Create a universal identity machine policy
- Start the proxy pointing to the server (default port is 8080) 
- Create some secrets using the interface 
- Try to fetch using the API (check the bash code below)
- Update the secret using the interface
- Check the SSE connection was opened (check the logs) 
- Try to fetch it again (using the API) 
- Check the request was cached. 


```sh
curl --location 'http://localhost:8081/api/v4/secrets/test?type=shared&projectId=66b56e25-7db3-49c3-8014-f96407852d54&environment=prod' \
--header 'Authorization: Bearer tokwn'
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->