### PR TITLE
fix(cert-manager): await profile slug resolution before certificate issuance

### DIFF
--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -2502,32 +2502,32 @@ func (tm *AgentManager) MonitorCertificates(ctx context.Context) {
 		time.Sleep(1 * time.Second)
 	}
 
-	const maxIssuanceAttempts = 3
 	for _, cert := range tm.certificates {
 		cert := cert
 		displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
-		var lastErr error
-		for attempt := 1; attempt <= maxIssuanceAttempts; attempt++ {
+		maxRetries := cert.Certificate.Lifecycle.MaxFailureRetries
+		retryForever := maxRetries == 0
+
+		baseDelay := 2 * time.Second
+		if d, err := parseDurationWithDays(cert.Certificate.Lifecycle.FailureRetryInterval); err == nil && d > 0 {
+			baseDelay = d
+		}
+
+		const maxBackoff = 5 * time.Minute
+		for attempt := 1; retryForever || attempt <= maxRetries; attempt++ {
 			if err := tm.IssueCertificate(cert.ID, &cert.Certificate); err != nil {
-				lastErr = err
 				log.Error().
 					Str("Certificate", displayName).
 					Int("attempt", attempt).
-					Int("maxAttempts", maxIssuanceAttempts).
 					Msgf("initial certificate issuance failed: %v", err)
-				if attempt < maxIssuanceAttempts {
-					backoff := time.Duration(1<<uint(attempt-1)) * 2 * time.Second
-					time.Sleep(backoff)
+				backoff := baseDelay * time.Duration(1<<uint(min(attempt-1, 8)))
+				if backoff > maxBackoff {
+					backoff = maxBackoff
 				}
+				time.Sleep(backoff)
 			} else {
-				lastErr = nil
 				break
 			}
-		}
-		if lastErr != nil {
-			log.Error().
-				Str("Certificate", displayName).
-				Msgf("all %d issuance attempts failed, will retry on next renewal check", maxIssuanceAttempts)
 		}
 	}
 

--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -1092,7 +1092,6 @@ type AgentManager struct {
 	newAccessTokenNotificationChan  chan bool
 	cachedUniversalAuthClientSecret string
 	templateFirstRenderOnce         map[int]*sync.Once // Track first render per template
-	certificateFirstIssueOnce       map[int]*sync.Once // Track first issue per certificate
 	exitAfterAuth                   bool
 	revokeCredentialsOnShutdown     bool
 
@@ -1131,13 +1130,11 @@ func NewAgentManager(options NewAgentMangerOptions) *AgentManager {
 
 	certificates := make([]CertificateWithID, len(options.Certificates))
 	certificateStates := make(map[int]*CertificateState)
-	certificateFirstIssueOnce := make(map[int]*sync.Once)
 	for i, certificate := range options.Certificates {
 		certificates[i] = CertificateWithID{ID: i + 1, Certificate: certificate}
 		certificateStates[i+1] = &CertificateState{
 			Status: "pending",
 		}
-		certificateFirstIssueOnce[i+1] = &sync.Once{}
 	}
 
 	agentManager := &AgentManager{
@@ -1145,8 +1142,6 @@ func NewAgentManager(options NewAgentMangerOptions) *AgentManager {
 		templates:                 templates,
 		certificates:              certificates,
 		certificateStates:         certificateStates,
-		certificateFirstIssueOnce: certificateFirstIssueOnce,
-
 		authConfigBytes: options.AuthConfigBytes,
 		authStrategy:    options.AuthStrategy,
 		retryConfig:     options.RetryConfig,
@@ -2507,13 +2502,33 @@ func (tm *AgentManager) MonitorCertificates(ctx context.Context) {
 		time.Sleep(1 * time.Second)
 	}
 
+	const maxIssuanceAttempts = 3
 	for _, cert := range tm.certificates {
-		tm.certificateFirstIssueOnce[cert.ID].Do(func() {
+		cert := cert
+		displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
+		var lastErr error
+		for attempt := 1; attempt <= maxIssuanceAttempts; attempt++ {
 			if err := tm.IssueCertificate(cert.ID, &cert.Certificate); err != nil {
-				displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
-				log.Error().Str("Certificate", displayName).Msgf("initial certificate issuance failed: %v", err)
+				lastErr = err
+				log.Error().
+					Str("Certificate", displayName).
+					Int("attempt", attempt).
+					Int("maxAttempts", maxIssuanceAttempts).
+					Msgf("initial certificate issuance failed: %v", err)
+				if attempt < maxIssuanceAttempts {
+					backoff := time.Duration(1<<uint(attempt-1)) * 2 * time.Second
+					time.Sleep(backoff)
+				}
+			} else {
+				lastErr = nil
+				break
 			}
-		})
+		}
+		if lastErr != nil {
+			log.Error().
+				Str("Certificate", displayName).
+				Msgf("all %d issuance attempts failed, will retry on next renewal check", maxIssuanceAttempts)
+		}
 	}
 
 	for {
@@ -3116,38 +3131,6 @@ var agentCmd = &cobra.Command{
 
 		go tm.ManageTokenLifecycle()
 
-		if len(agentConfig.Certificates) > 0 {
-			go func() {
-				for {
-					if tm.getTokenUnsafe() != "" {
-						break
-					}
-					time.Sleep(100 * time.Millisecond)
-				}
-
-				httpClient, err := tm.createAuthenticatedClient()
-				if err != nil {
-					log.Error().Msgf("failed to create authenticated client for name resolution: %v", err)
-					return
-				}
-
-				err = resolveCertificateNameReferences(&agentConfig.Certificates, httpClient)
-				if err != nil {
-					log.Error().Msgf("failed to resolve certificate name references: %v", err)
-					return
-				}
-
-				for i := range tm.certificates {
-					for j := range agentConfig.Certificates {
-						if tm.certificates[i].ID == j+1 {
-							tm.certificates[i].Certificate = agentConfig.Certificates[j]
-							break
-						}
-					}
-				}
-			}()
-		}
-
 		var monitoredTemplatesFinished atomic.Int32
 
 		// when all templates have finished rendering once, we delete the unused leases from the cache.
@@ -3178,8 +3161,38 @@ var agentCmd = &cobra.Command{
 		}
 
 		if len(tm.certificates) > 0 {
-			log.Info().Msg("certificate management engine starting...")
-			go tm.MonitorCertificates(ctx)
+			go func() {
+				for {
+					if tm.getTokenUnsafe() != "" {
+						break
+					}
+					time.Sleep(100 * time.Millisecond)
+				}
+
+				httpClient, err := tm.createAuthenticatedClient()
+				if err != nil {
+					log.Error().Msgf("failed to create authenticated client for name resolution: %v", err)
+					return
+				}
+
+				err = resolveCertificateNameReferences(&agentConfig.Certificates, httpClient)
+				if err != nil {
+					log.Error().Msgf("failed to resolve certificate name references: %v", err)
+					return
+				}
+
+				for i := range tm.certificates {
+					for j := range agentConfig.Certificates {
+						if tm.certificates[i].ID == j+1 {
+							tm.certificates[i].Certificate = agentConfig.Certificates[j]
+							break
+						}
+					}
+				}
+
+				log.Info().Msg("certificate management engine starting...")
+				tm.MonitorCertificates(ctx)
+			}()
 		}
 
 		for {
@@ -3366,7 +3379,7 @@ var certManagerAgentCmd = &cobra.Command{
 
 		go tm.ManageTokenLifecycle()
 
-		if len(agentConfig.Certificates) > 0 {
+		if len(tm.certificates) > 0 {
 			go func() {
 				for {
 					if tm.getTokenUnsafe() != "" {
@@ -3395,12 +3408,10 @@ var certManagerAgentCmd = &cobra.Command{
 						}
 					}
 				}
-			}()
-		}
 
-		if len(tm.certificates) > 0 {
-			log.Info().Msg("certificate management engine starting...")
-			go tm.MonitorCertificates(ctx)
+				log.Info().Msg("certificate management engine starting...")
+				tm.MonitorCertificates(ctx)
+			}()
 		}
 
 		for {

--- a/packages/cmd/agent_cert_resolution_test.go
+++ b/packages/cmd/agent_cert_resolution_test.go
@@ -4,14 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/Infisical/infisical-merge/packages/api"
 	"github.com/Infisical/infisical-merge/packages/config"
+	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +34,7 @@ func TestResolveCertificateNameReferences(t *testing.T) {
 					Slug: projectSlug,
 				})
 			case r.URL.Path == "/v1/cert-manager/certificate-profiles/slug/"+profileSlug:
-				require.Equal(t, projectID, r.URL.Query().Get("projectId"))
+				assert.Equal(t, projectID, r.URL.Query().Get("projectId"))
 				json.NewEncoder(w).Encode(api.GetCertificateProfileResponse{
 					CertificateProfile: api.CertificateProfile{
 						ID:        profileID,
@@ -64,27 +63,28 @@ func TestResolveCertificateNameReferences(t *testing.T) {
 	assert.Equal(t, profileID, certs[0].ProfileID)
 }
 
-func TestSlugResolutionCompletesBeforeIssuance(t *testing.T) {
+// TestConcurrentIssuanceBlocksOnSlugResolution simulates the race
+// condition that existed before the fix: slug resolution and certificate
+// issuance starting concurrently. The mock server delays the slug
+// resolution response by 200ms. A goroutine fires the issuance POST
+// immediately (mimicking the old MonitorCertificates goroutine). The
+// server rejects any issuance POST that arrives before slug resolution
+// has completed, proving the ordering guarantee matters.
+func TestConcurrentIssuanceBlocksOnSlugResolution(t *testing.T) {
 	const (
-		projectSlug    = "infra-z-c-pk"
-		projectID      = "proj-uuid-aaaa"
-		profileSlug    = "crdb"
-		profileID      = "profile-uuid-bbbb"
-		slugDelay      = 200 * time.Millisecond
+		projectSlug = "infra-z-c-pk"
+		projectID   = "proj-uuid-aaaa"
+		profileSlug = "crdb"
+		profileID   = "profile-uuid-bbbb"
+		slugDelay   = 200 * time.Millisecond
 	)
 
-	var (
-		mu              sync.Mutex
-		requestOrder    []string
-		slugResolved    atomic.Bool
-	)
+	var slugResolved atomic.Bool
+	var issuanceReceivedBeforeResolution atomic.Bool
 
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			mu.Lock()
-			requestOrder = append(requestOrder, r.Method+" "+r.URL.Path)
-			mu.Unlock()
 
 			switch {
 			case r.URL.Path == "/v1/projects/slug/"+projectSlug:
@@ -106,14 +106,23 @@ func TestSlugResolutionCompletesBeforeIssuance(t *testing.T) {
 				})
 
 			case r.URL.Path == "/v1/cert-manager/certificates":
-				assert.True(t, slugResolved.Load(),
-					"cert issuance POST fired before slug resolution completed")
-
+				if !slugResolved.Load() {
+					issuanceReceivedBeforeResolution.Store(true)
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					json.NewEncoder(w).Encode(map[string]string{
+						"message": "Invalid uuid",
+					})
+					return
+				}
 				var req api.IssueCertificateRequest
 				json.NewDecoder(r.Body).Decode(&req)
-				assert.Equal(t, profileID, req.ProfileID,
-					"profileId should be the resolved UUID, not the slug")
-
+				if req.ProfileID != profileID {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					json.NewEncoder(w).Encode(map[string]string{
+						"message": "Invalid uuid",
+					})
+					return
+				}
 				json.NewEncoder(w).Encode(api.CertificateResponse{
 					Certificate: &api.CertificateData{
 						CertificateID: "cert-id-1",
@@ -147,44 +156,71 @@ func TestSlugResolutionCompletesBeforeIssuance(t *testing.T) {
 
 	httpClient := resty.New()
 
+	// Simulate the fixed code path: resolve first, then issue.
+	// This mirrors the merged goroutine in certManagerAgentCmd.
 	err := resolveCertificateNameReferences(&certs, httpClient)
 	require.NoError(t, err)
-	require.Equal(t, profileID, certs[0].ProfileID,
-		"ProfileID must be set after resolution")
+	require.Equal(t, profileID, certs[0].ProfileID)
 
 	request := api.IssueCertificateRequest{
 		ProfileID: certs[0].ProfileID,
+		Attributes: &api.CertificateAttributes{
+			CommonName: "node",
+			TTL:        "2160h",
+		},
 	}
-	if certs[0].Attributes != nil {
-		request.Attributes = &api.CertificateAttributes{
-			CommonName: certs[0].Attributes.CommonName,
-			TTL:        certs[0].Attributes.TTL,
-		}
-	}
-
 	resp, err := api.CallIssueCertificate(httpClient, request)
 	require.NoError(t, err)
 	require.NotNil(t, resp.Certificate)
 
-	mu.Lock()
-	order := make([]string, len(requestOrder))
-	copy(order, requestOrder)
-	mu.Unlock()
+	assert.False(t, issuanceReceivedBeforeResolution.Load(),
+		"issuance POST must not arrive before slug resolution completes")
 
-	require.GreaterOrEqual(t, len(order), 3,
-		"expected at least 3 requests (project slug, profile slug, issue cert)")
+	// Now simulate the OLD buggy code path: fire issuance concurrently
+	// with resolution. The server should reject it because slug
+	// resolution hasn't completed when the POST arrives.
+	slugResolved.Store(false)
+	issuanceReceivedBeforeResolution.Store(false)
 
-	var profileIdx, issueIdx int
-	for i, req := range order {
-		if req == "GET /v1/cert-manager/certificate-profiles/slug/"+profileSlug {
-			profileIdx = i
-		}
-		if req == "POST /v1/cert-manager/certificates" {
-			issueIdx = i
-		}
+	unresolvedCerts := []AgentCertificateConfig{
+		{
+			ProjectName: projectSlug,
+			ProfileName: profileSlug,
+			Attributes: &CertificateAttributes{
+				CommonName: "node",
+				TTL:        "2160h",
+			},
+		},
 	}
-	assert.Less(t, profileIdx, issueIdx,
-		"profile slug resolution must complete before certificate issuance")
+
+	earlyIssuanceFailed := make(chan bool, 1)
+
+	// Goroutine 1: start resolving (takes 200ms due to server delay)
+	go func() {
+		resolveClient := resty.New()
+		resolveCertificateNameReferences(&unresolvedCerts, resolveClient)
+	}()
+
+	// Goroutine 2: fire issuance immediately with unresolved slug
+	// (ProfileID is still empty — mimics old MonitorCertificates)
+	go func() {
+		issueClient := resty.New()
+		earlyReq := api.IssueCertificateRequest{
+			ProfileID: unresolvedCerts[0].ProfileID,
+			Attributes: &api.CertificateAttributes{
+				CommonName: "node",
+				TTL:        "2160h",
+			},
+		}
+		_, err := api.CallIssueCertificate(issueClient, earlyReq)
+		earlyIssuanceFailed <- (err != nil)
+	}()
+
+	failed := <-earlyIssuanceFailed
+	assert.True(t, failed,
+		"issuance with unresolved ProfileID should fail (422)")
+	assert.True(t, issuanceReceivedBeforeResolution.Load(),
+		"server should have seen the issuance POST before slug resolution finished")
 }
 
 func TestResolveCertificateNameReferences_MultipleProfiles(t *testing.T) {

--- a/packages/cmd/agent_cert_resolution_test.go
+++ b/packages/cmd/agent_cert_resolution_test.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/Infisical/infisical-merge/packages/api"
+	"github.com/Infisical/infisical-merge/packages/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCertificateNameReferences(t *testing.T) {
+	const (
+		projectSlug = "my-project"
+		projectID   = "proj-uuid-1234"
+		profileSlug = "crdb"
+		profileID   = "profile-uuid-5678"
+	)
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/v1/projects/slug/"+projectSlug:
+				json.NewEncoder(w).Encode(api.Project{
+					ID:   projectID,
+					Name: "My Project",
+					Slug: projectSlug,
+				})
+			case r.URL.Path == "/v1/cert-manager/certificate-profiles/slug/"+profileSlug:
+				require.Equal(t, projectID, r.URL.Query().Get("projectId"))
+				json.NewEncoder(w).Encode(api.GetCertificateProfileResponse{
+					CertificateProfile: api.CertificateProfile{
+						ID:        profileID,
+						Name:      profileSlug,
+						ProjectID: projectID,
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	orig := config.INFISICAL_URL
+	config.INFISICAL_URL = server.URL
+	t.Cleanup(func() { config.INFISICAL_URL = orig })
+
+	certs := []AgentCertificateConfig{
+		{ProjectName: projectSlug, ProfileName: profileSlug},
+	}
+
+	httpClient := resty.New()
+	err := resolveCertificateNameReferences(&certs, httpClient)
+	require.NoError(t, err)
+	assert.Equal(t, profileID, certs[0].ProfileID)
+}
+
+func TestSlugResolutionCompletesBeforeIssuance(t *testing.T) {
+	const (
+		projectSlug    = "infra-z-c-pk"
+		projectID      = "proj-uuid-aaaa"
+		profileSlug    = "crdb"
+		profileID      = "profile-uuid-bbbb"
+		slugDelay      = 200 * time.Millisecond
+	)
+
+	var (
+		mu              sync.Mutex
+		requestOrder    []string
+		slugResolved    atomic.Bool
+	)
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			mu.Lock()
+			requestOrder = append(requestOrder, r.Method+" "+r.URL.Path)
+			mu.Unlock()
+
+			switch {
+			case r.URL.Path == "/v1/projects/slug/"+projectSlug:
+				json.NewEncoder(w).Encode(api.Project{
+					ID:   projectID,
+					Name: "Infra Project",
+					Slug: projectSlug,
+				})
+
+			case r.URL.Path == "/v1/cert-manager/certificate-profiles/slug/"+profileSlug:
+				time.Sleep(slugDelay)
+				slugResolved.Store(true)
+				json.NewEncoder(w).Encode(api.GetCertificateProfileResponse{
+					CertificateProfile: api.CertificateProfile{
+						ID:        profileID,
+						Name:      profileSlug,
+						ProjectID: projectID,
+					},
+				})
+
+			case r.URL.Path == "/v1/cert-manager/certificates":
+				assert.True(t, slugResolved.Load(),
+					"cert issuance POST fired before slug resolution completed")
+
+				var req api.IssueCertificateRequest
+				json.NewDecoder(r.Body).Decode(&req)
+				assert.Equal(t, profileID, req.ProfileID,
+					"profileId should be the resolved UUID, not the slug")
+
+				json.NewEncoder(w).Encode(api.CertificateResponse{
+					Certificate: &api.CertificateData{
+						CertificateID: "cert-id-1",
+						SerialNumber:  "serial-1",
+						Certificate:   "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+						PrivateKey:    "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+					},
+				})
+
+			default:
+				http.NotFound(w, r)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	orig := config.INFISICAL_URL
+	config.INFISICAL_URL = server.URL
+	t.Cleanup(func() { config.INFISICAL_URL = orig })
+
+	certs := []AgentCertificateConfig{
+		{
+			ProjectName: projectSlug,
+			ProfileName: profileSlug,
+			Attributes: &CertificateAttributes{
+				CommonName: "node",
+				TTL:        "2160h",
+			},
+		},
+	}
+
+	httpClient := resty.New()
+
+	err := resolveCertificateNameReferences(&certs, httpClient)
+	require.NoError(t, err)
+	require.Equal(t, profileID, certs[0].ProfileID,
+		"ProfileID must be set after resolution")
+
+	request := api.IssueCertificateRequest{
+		ProfileID: certs[0].ProfileID,
+	}
+	if certs[0].Attributes != nil {
+		request.Attributes = &api.CertificateAttributes{
+			CommonName: certs[0].Attributes.CommonName,
+			TTL:        certs[0].Attributes.TTL,
+		}
+	}
+
+	resp, err := api.CallIssueCertificate(httpClient, request)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Certificate)
+
+	mu.Lock()
+	order := make([]string, len(requestOrder))
+	copy(order, requestOrder)
+	mu.Unlock()
+
+	require.GreaterOrEqual(t, len(order), 3,
+		"expected at least 3 requests (project slug, profile slug, issue cert)")
+
+	var profileIdx, issueIdx int
+	for i, req := range order {
+		if req == "GET /v1/cert-manager/certificate-profiles/slug/"+profileSlug {
+			profileIdx = i
+		}
+		if req == "POST /v1/cert-manager/certificates" {
+			issueIdx = i
+		}
+	}
+	assert.Less(t, profileIdx, issueIdx,
+		"profile slug resolution must complete before certificate issuance")
+}
+
+func TestResolveCertificateNameReferences_MultipleProfiles(t *testing.T) {
+	const (
+		projectSlug = "multi-project"
+		projectID   = "proj-uuid-multi"
+	)
+
+	profiles := map[string]string{
+		"profile-a": "uuid-aaaa",
+		"profile-b": "uuid-bbbb",
+		"profile-c": "uuid-cccc",
+	}
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/v1/projects/slug/"+projectSlug:
+				json.NewEncoder(w).Encode(api.Project{
+					ID:   projectID,
+					Name: "Multi Project",
+					Slug: projectSlug,
+				})
+			default:
+				for slug, id := range profiles {
+					path := "/v1/cert-manager/certificate-profiles/slug/" + slug
+					if r.URL.Path == path {
+						json.NewEncoder(w).Encode(
+							api.GetCertificateProfileResponse{
+								CertificateProfile: api.CertificateProfile{
+									ID:        id,
+									Name:      slug,
+									ProjectID: projectID,
+								},
+							},
+						)
+						return
+					}
+				}
+				http.NotFound(w, r)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	orig := config.INFISICAL_URL
+	config.INFISICAL_URL = server.URL
+	t.Cleanup(func() { config.INFISICAL_URL = orig })
+
+	certs := []AgentCertificateConfig{
+		{ProjectName: projectSlug, ProfileName: "profile-a"},
+		{ProjectName: projectSlug, ProfileName: "profile-b"},
+		{ProjectName: projectSlug, ProfileName: "profile-c"},
+	}
+
+	httpClient := resty.New()
+	err := resolveCertificateNameReferences(&certs, httpClient)
+	require.NoError(t, err)
+
+	for i, cert := range certs {
+		expected := profiles[cert.ProfileName]
+		assert.Equal(t, expected, cert.ProfileID,
+			"cert[%d] ProfileID mismatch", i)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix race condition where certificate issuance POST fires before profile slug-to-UUID resolution completes, sending the raw slug as `profileId` and getting a 422
- Merge the slug resolution and certificate monitoring goroutines into a single sequential flow (resolve first, then monitor) in both the `cert-manager agent` and regular `agent` commands
- Reuse existing `lifecycle.max-failure-retries` and `lifecycle.failure-retry-interval` config for initial issuance retries (previously only used for renewal). Default `max-failure-retries: 0` retries indefinitely with exponential backoff capped at 5 minutes

## Bug

The cert-manager agent had a race condition where `POST /api/v1/cert-manager/certificates` fired before the `GET /api/v1/cert-manager/certificate-profiles/slug/{slug}` response returned. This caused the agent to send the profile-name slug string (e.g. `"crdb"`) as the `profileId` field instead of the resolved UUID, resulting in a 422:

```json
{"validation":"uuid","code":"invalid_string","message":"Invalid uuid","path":["profileId"]}
```

### Evidence from server-side logs

The Infisical server received these requests from the same client, 75ms apart:

| Timestamp (ms) | Request ID | Request |
|---|---|---|
| 1775781765199 | req-LiX9p3LQCBiYXr | GET /api/v1/cert-manager/certificate-profiles/slug/crdb |
| 1775781765274 | req-u181LmbJP98hwB | POST /api/v1/cert-manager/certificates (profileId="crdb") |
| 1775781765293 | req-u181LmbJP98hwB | 422 response — Invalid uuid |

The slug lookup hadn't returned yet when the cert issuance request was sent.

## Behavior change

The existing `lifecycle.max-failure-retries` and `lifecycle.failure-retry-interval` config fields now also apply to **initial** certificate issuance, not just renewal. Previously, a failed initial issuance was never retried (the agent was permanently broken until restarted). Now:

- `max-failure-retries: 0` (default) → retry indefinitely with exponential backoff
- `max-failure-retries: N` → retry up to N times then stop
- `failure-retry-interval` → base delay for exponential backoff (default 2s, capped at 5m)

A follow-up docs PR can be opened to document this behavior change.

## Test plan

- [x] `TestResolveCertificateNameReferences` — verifies slug resolution populates `ProfileID` with the UUID
- [x] `TestConcurrentIssuanceBlocksOnSlugResolution` — fires issuance concurrently with a delayed slug resolution, verifies the server rejects the early POST with unresolved ProfileID, proving the ordering guarantee matters
- [x] `TestResolveCertificateNameReferences_MultipleProfiles` — verifies resolution works for multiple certificates with different profiles
- [x] Full project builds cleanly (`go build ./...`)