### PR TITLE
fix(login): redirect informational messages to stderr

### DIFF
--- a/packages/cmd/login.go
+++ b/packages/cmd/login.go
@@ -258,15 +258,16 @@ var loginCmd = &cobra.Command{
 				return
 			}
 
+			stderrWriter := util.GetStderrWriter()
 			whilte := color.New(color.FgGreen)
 			boldWhite := whilte.Add(color.Bold)
 			time.Sleep(time.Second * 1)
-			boldWhite.Printf(">>>> Welcome to Infisical!")
-			boldWhite.Printf(" You are now logged in as %v <<<< \n", userCredentialsToBeStored.Email)
+			boldWhite.Fprintf(stderrWriter, ">>>> Welcome to Infisical!")
+			boldWhite.Fprintf(stderrWriter, " You are now logged in as %v <<<< \n", userCredentialsToBeStored.Email)
 
 			plainBold := color.New(color.Bold)
 
-			plainBold.Println("\nQuick links")
+			plainBold.Fprintln(stderrWriter, "\nQuick links")
 			util.PrintlnStderr("- Learn to inject secrets into your application at https://infisical.com/docs/cli/usage")
 			util.PrintlnStderr("- Stuck? Join our slack for quick support https://infisical.com/slack")
 		} else {
@@ -302,14 +303,15 @@ var loginCmd = &cobra.Command{
 				return
 			}
 
+			stderrWriter := util.GetStderrWriter()
 			boldGreen := color.New(color.FgGreen).Add(color.Bold)
 			boldPlain := color.New(color.Bold)
 			time.Sleep(time.Second * 1)
-			boldGreen.Printf(">>>> Successfully authenticated with %s!\n\n", formatAuthMethod(loginMethod))
+			boldGreen.Fprintf(stderrWriter, ">>>> Successfully authenticated with %s!\n\n", formatAuthMethod(loginMethod))
 			boldPlain.Printf("Access Token:\n%v", credential.AccessToken)
 
 			plainBold := color.New(color.Bold)
-			plainBold.Println("\n\nYou can use this access token to authenticate through other commands in the CLI.")
+			plainBold.Fprintln(stderrWriter, "\n\nYou can use this access token to authenticate through other commands in the CLI.")
 
 		}
 	},
@@ -488,7 +490,7 @@ func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, shouldPr
 		boldWhite := whilte.Add(color.Bold)
 		time.Sleep(time.Second * 1)
 		if shouldPrintInfo {
-			boldWhite.Printf("[INFO] Using domain '%s' from domain flag or INFISICAL_API_URL environment variable\n", parsedDomain)
+			boldWhite.Fprintf(util.GetStderrWriter(), "[INFO] Using domain '%s' from domain flag or INFISICAL_API_URL environment variable\n", parsedDomain)
 		}
 
 		return true, nil


### PR DESCRIPTION
Moves [INFO], welcome, and success messages from stdout to stderr in the login command so that `infisical login --plain` output is not polluted by non-data messages. The access token remains on stdout.

Resolves Infisical/cli#121

# Description 📣

When running `infisical login --plain`, informational messages like the `[INFO] Using domain ...` notice, the welcome banner, and the "Quick links" header were printed to **stdout** via `color.Printf()` / `color.Println()`. This pollutes the output for scripts and CI/CD pipelines that capture stdout to extract the token.

This PR redirects all informational messages to **stderr** using `color.Fprintf(stderrWriter, ...)`, while keeping actual data output (the access token) on stdout.

### Changes

| Location | Message | Before | After |
|---|---|---|---|
| `usePresetDomain()` | `[INFO] Using domain '...'` | `Printf` (stdout) | `Fprintf(stderr)` |
| User login | Welcome banner + "Quick links" header | `Printf`/`Println` (stdout) | `Fprintf`/`Fprintln(stderr)` |
| Machine identity login | Success banner + usage hint | `Printf`/`Println` (stdout) | `Fprintf`/`Fprintln(stderr)` |

**Not changed:** `boldPlain.Printf("Access Token:\n%v", ...)` stays on stdout — it's actual data output.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🔧

```sh
# User login: verify token on stdout, messages on stderr
infisical login --plain 2>/dev/null
# Should output ONLY the JWT token, no [INFO] or welcome text

# Verify informational messages still appear on stderr
infisical login --plain 2>&1 1>/dev/null
# Should show welcome/info messages

# Machine identity login
infisical login --method=universal-auth --plain 2>/dev/null
# Should output ONLY the access token

# Domain override via env var
INFISICAL_API_URL=https://self-hosted.example.com infisical login --plain 2>/dev/null
# [INFO] message should NOT appear on stdout
```
