### PR TITLE
feat: gateway enrollment token flow

### DIFF
--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -48,6 +48,7 @@ const (
 	operationCallRegisterOrgRelay                  = "CallRegisterOrgRelay"
 	operationCallGetOrgRelays                      = "CallGetOrgRelays"
 	operationCallRegisterGateway                   = "CallRegisterGateway"
+	operationCallEnrollGateway                     = "CallEnrollGateway"
 	operationCallPAMAccess                         = "CallPAMAccess"
 	operationCallPAMAccessApprovalRequest          = "CallPAMAccessApprovalRequest"
 	operationCallPAMSessionCredentials             = "CallPAMSessionCredentials"
@@ -910,6 +911,26 @@ func CallRegisterGateway(httpClient *resty.Client, request RegisterGatewayReques
 
 	if response.IsError() {
 		return RegisterGatewayResponse{}, NewAPIErrorWithResponse(operationCallRegisterGateway, response, nil)
+	}
+
+	return resBody, nil
+}
+
+func CallEnrollGateway(httpClient *resty.Client, request EnrollGatewayRequest) (EnrollGatewayResponse, error) {
+	var resBody EnrollGatewayResponse
+	response, err := httpClient.
+		R().
+		SetResult(&resBody).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Post(fmt.Sprintf("%v/v2/gateways/enroll", config.INFISICAL_URL))
+
+	if err != nil {
+		return EnrollGatewayResponse{}, NewGenericRequestError(operationCallEnrollGateway, err)
+	}
+
+	if response.IsError() {
+		return EnrollGatewayResponse{}, NewAPIErrorWithResponse(operationCallEnrollGateway, response, nil)
 	}
 
 	return resBody, nil

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -923,7 +923,7 @@ func CallEnrollGateway(httpClient *resty.Client, request EnrollGatewayRequest) (
 		SetResult(&resBody).
 		SetHeader("User-Agent", USER_AGENT).
 		SetBody(request).
-		Post(fmt.Sprintf("%v/v2/gateways/enroll", config.INFISICAL_URL))
+		Post(fmt.Sprintf("%v/v3/gateways/token-auth/enroll", config.INFISICAL_URL))
 
 	if err != nil {
 		return EnrollGatewayResponse{}, NewGenericRequestError(operationCallEnrollGateway, err)

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -896,6 +896,26 @@ func CallGetRelays(httpClient *resty.Client) (GetRelaysResponse, error) {
 	return resBody, nil
 }
 
+func CallConnectGateway(httpClient *resty.Client, request ConnectGatewayRequest) (RegisterGatewayResponse, error) {
+	var resBody RegisterGatewayResponse
+	response, err := httpClient.
+		R().
+		SetResult(&resBody).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Post(fmt.Sprintf("%v/v3/gateways/connect", config.INFISICAL_URL))
+
+	if err != nil {
+		return RegisterGatewayResponse{}, NewGenericRequestError(operationCallRegisterGateway, err)
+	}
+
+	if response.IsError() {
+		return RegisterGatewayResponse{}, NewAPIErrorWithResponse(operationCallRegisterGateway, response, nil)
+	}
+
+	return resBody, nil
+}
+
 func CallRegisterGateway(httpClient *resty.Client, request RegisterGatewayRequest) (RegisterGatewayResponse, error) {
 	var resBody RegisterGatewayResponse
 	response, err := httpClient.

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -48,6 +48,7 @@ const (
 	operationCallRegisterOrgRelay                  = "CallRegisterOrgRelay"
 	operationCallGetOrgRelays                      = "CallGetOrgRelays"
 	operationCallRegisterGateway                   = "CallRegisterGateway"
+	operationCallConnectGateway                    = "CallConnectGateway"
 	operationCallEnrollGateway                     = "CallEnrollGateway"
 	operationCallPAMAccess                         = "CallPAMAccess"
 	operationCallPAMAccessApprovalRequest          = "CallPAMAccessApprovalRequest"
@@ -906,11 +907,11 @@ func CallConnectGateway(httpClient *resty.Client, request ConnectGatewayRequest)
 		Post(fmt.Sprintf("%v/v3/gateways/connect", config.INFISICAL_URL))
 
 	if err != nil {
-		return RegisterGatewayResponse{}, NewGenericRequestError(operationCallRegisterGateway, err)
+		return RegisterGatewayResponse{}, NewGenericRequestError(operationCallConnectGateway, err)
 	}
 
 	if response.IsError() {
-		return RegisterGatewayResponse{}, NewAPIErrorWithResponse(operationCallRegisterGateway, response, nil)
+		return RegisterGatewayResponse{}, NewAPIErrorWithResponse(operationCallConnectGateway, response, nil)
 	}
 
 	return resBody, nil

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -790,6 +790,10 @@ type RegisterGatewayRequest struct {
 	Name      string `json:"name,omitempty"`
 }
 
+type ConnectGatewayRequest struct {
+	RelayName string `json:"relayName,omitempty"`
+}
+
 type EnrollGatewayRequest struct {
 	Token     string `json:"token"`
 	RelayName string `json:"relayName,omitempty"`

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -795,24 +795,12 @@ type ConnectGatewayRequest struct {
 }
 
 type EnrollGatewayRequest struct {
-	Token     string `json:"token"`
-	RelayName string `json:"relayName,omitempty"`
+	Token string `json:"token"`
 }
 
 type EnrollGatewayResponse struct {
 	AccessToken string `json:"accessToken"`
 	GatewayID   string `json:"gatewayId"`
-	RelayHost   string `json:"relayHost"`
-	PKI         struct {
-		ServerCertificate      string `json:"serverCertificate"`
-		ServerPrivateKey       string `json:"serverPrivateKey"`
-		ClientCertificateChain string `json:"clientCertificateChain"`
-	} `json:"pki"`
-	SSH struct {
-		ClientCertificate string `json:"clientCertificate"`
-		ClientPrivateKey  string `json:"clientPrivateKey"`
-		ServerCAPublicKey string `json:"serverCAPublicKey"`
-	} `json:"ssh"`
 }
 
 type RegisterGatewayResponse struct {

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -786,8 +786,29 @@ type Relay struct {
 type GetRelaysResponse []Relay
 
 type RegisterGatewayRequest struct {
-	RelayName string `json:"relayName"`
-	Name      string `json:"name"`
+	RelayName string `json:"relayName,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+type EnrollGatewayRequest struct {
+	Token     string `json:"token"`
+	RelayName string `json:"relayName,omitempty"`
+}
+
+type EnrollGatewayResponse struct {
+	AccessToken string `json:"accessToken"`
+	GatewayID   string `json:"gatewayId"`
+	RelayHost   string `json:"relayHost"`
+	PKI         struct {
+		ServerCertificate      string `json:"serverCertificate"`
+		ServerPrivateKey       string `json:"serverPrivateKey"`
+		ClientCertificateChain string `json:"clientCertificateChain"`
+	} `json:"pki"`
+	SSH struct {
+		ClientCertificate string `json:"clientCertificate"`
+		ClientPrivateKey  string `json:"clientPrivateKey"`
+		ServerCAPublicKey string `json:"serverCAPublicKey"`
+	} `json:"ssh"`
 }
 
 type RegisterGatewayResponse struct {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -373,6 +373,7 @@ var gatewayStartCmd = &cobra.Command{
 			Name:           gatewayName,
 			RelayName:      relayName,
 			ReconnectDelay: 10 * time.Second,
+			UseV3Connect:   runningWithStoredToken,
 		})
 
 		if err != nil {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -213,6 +213,18 @@ var gatewayStartCmd = &cobra.Command{
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 		var alreadyEnrolled bool
 
+		// Resolve gateway name early so config files can be scoped per gateway.
+		// Positional arg > --name flag (deprecated) > env var
+		var gatewayName string
+		if len(args) > 0 {
+			gatewayName = args[0]
+		} else {
+			gatewayName, _ = util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
+		}
+		if gatewayName == "" {
+			util.HandleError(errors.New("gateway name is required (provide as positional argument)"))
+		}
+
 		// --- Enrollment token path ---
 		if enrollMethod == gatewayv2.EnrollMethodStatic {
 			enrollToken, err := cmd.Flags().GetString("token")
@@ -222,7 +234,7 @@ var gatewayStartCmd = &cobra.Command{
 
 			// Check if this is the same token we already enrolled with.
 			// If so, skip enrollment and just start the gateway.
-			storedEnrollToken, _ := gatewayv2.LoadStoredEnrollmentToken()
+			storedEnrollToken, _ := gatewayv2.LoadStoredEnrollmentToken(gatewayName)
 			alreadyEnrolled = storedEnrollToken != "" && storedEnrollToken == enrollToken
 
 			if alreadyEnrolled {
@@ -249,11 +261,11 @@ var gatewayStartCmd = &cobra.Command{
 					util.HandleError(err, "enrollment failed")
 				}
 
-				if err := gatewayv2.SaveAccessToken(enrollResp.AccessToken); err != nil {
+				if err := gatewayv2.SaveAccessToken(gatewayName, enrollResp.AccessToken); err != nil {
 					util.HandleError(err, "failed to save gateway access token")
 				}
 
-				if err := gatewayv2.SaveEnrollmentToken(enrollToken); err != nil {
+				if err := gatewayv2.SaveEnrollmentToken(gatewayName, enrollToken); err != nil {
 					util.HandleError(err, "failed to save enrollment token to config")
 				}
 
@@ -263,12 +275,12 @@ var gatewayStartCmd = &cobra.Command{
 					effectiveDomain = config.INFISICAL_URL
 				}
 				if effectiveDomain != "" {
-					if err := gatewayv2.SaveDomain(effectiveDomain); err != nil {
+					if err := gatewayv2.SaveDomain(gatewayName, effectiveDomain); err != nil {
 						util.HandleError(err, "failed to save domain to config")
 					}
 				}
 
-				log.Info().Msgf("Gateway enrolled successfully. Access token saved to %s", gatewayv2.GetConfPathDisplay())
+				log.Info().Msgf("Gateway enrolled successfully. Access token saved to %s", gatewayv2.GetConfPathDisplay(gatewayName))
 			}
 
 			log.Info().Msg("Starting gateway...")
@@ -281,7 +293,7 @@ var gatewayStartCmd = &cobra.Command{
 		if enrollMethod != gatewayv2.EnrollMethodStatic || alreadyEnrolled {
 			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
 				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
-			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(); storedDomain != "" {
+			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" {
 				config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
 			}
 		}
@@ -298,7 +310,7 @@ var gatewayStartCmd = &cobra.Command{
 			hasExplicitCreds := explicitToken != nil || explicitAuthMethod != ""
 
 			if !hasExplicitCreds {
-				storedToken, loadErr := gatewayv2.LoadStoredAccessToken()
+				storedToken, loadErr := gatewayv2.LoadStoredAccessToken(gatewayName)
 				if loadErr != nil {
 					util.HandleError(loadErr, "failed to load stored gateway access token")
 				}
@@ -310,17 +322,7 @@ var gatewayStartCmd = &cobra.Command{
 			}
 		}
 
-		// Resolve gateway name: positional arg > --name flag (deprecated) > env var
-		var gatewayName string
 		var err error
-		if len(args) > 0 {
-			gatewayName = args[0]
-		} else {
-			gatewayName, _ = util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
-		}
-		if gatewayName == "" {
-			util.HandleError(errors.New("gateway name is required (provide as positional argument or --name flag)"))
-		}
 
 		pamSessionRecordingPath, err := util.GetCmdFlagOrEnv(cmd, "pam-session-recording-path", []string{gatewayv2.INFISICAL_PAM_SESSION_RECORDING_PATH_ENV_NAME})
 		if err == nil && pamSessionRecordingPath != "" {
@@ -331,7 +333,7 @@ var gatewayStartCmd = &cobra.Command{
 		cancelSdk := func() {}                              // noop by default
 		var sdkTokenGetter func() string                    // nil when using stored token
 		if runningWithStoredToken {
-			loadedToken, loadErr := gatewayv2.LoadStoredAccessToken()
+			loadedToken, loadErr := gatewayv2.LoadStoredAccessToken(gatewayName)
 			if loadErr != nil || loadedToken == "" {
 				util.HandleError(errors.New("no stored access token found"))
 			}

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -565,6 +565,8 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 				util.HandleError(errors.New("--token is required when --enroll-method=token"))
 			}
 
+			relayName, _ := util.GetRelayName(cmd, false, "")
+
 			httpClient, clientErr := util.GetRestyClientWithCustomHeaders()
 			if clientErr != nil {
 				util.HandleError(clientErr, "unable to create HTTP client")
@@ -579,7 +581,7 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 			}
 
 			// Install systemd service using the long-lived access token
-			if installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, "", serviceLogFile); installErr != nil {
+			if installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
 				util.HandleError(installErr, "Unable to install systemd service")
 			}
 		} else {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -280,14 +280,16 @@ var gatewayStartCmd = &cobra.Command{
 			explicitAuthMethod, _ := cmd.Flags().GetString("auth-method")
 			hasExplicitCreds := explicitToken != nil || explicitAuthMethod != ""
 
-			storedToken, loadErr := gatewayv2.LoadStoredAccessToken()
-			if loadErr != nil {
-				util.HandleError(loadErr, "failed to load stored gateway access token")
-			}
+			if !hasExplicitCreds {
+				storedToken, loadErr := gatewayv2.LoadStoredAccessToken()
+				if loadErr != nil {
+					util.HandleError(loadErr, "failed to load stored gateway access token")
+				}
 
-			if storedToken != "" && !hasExplicitCreds {
-				log.Info().Msg("Using stored gateway access token")
-				runningWithStoredToken = true
+				if storedToken != "" {
+					log.Info().Msg("Using stored gateway access token")
+					runningWithStoredToken = true
+				}
 			}
 		}
 

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -211,6 +211,7 @@ var gatewayStartCmd = &cobra.Command{
 	Args:                  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
+		var alreadyEnrolled bool
 
 		// --- Enrollment token path ---
 		if enrollMethod == "static" {
@@ -219,49 +220,65 @@ var gatewayStartCmd = &cobra.Command{
 				util.HandleError(errors.New("--token is required when --enroll-method=static"))
 			}
 
-			relayName, _ := util.GetRelayName(cmd, false, "")
+			// Check if this is the same token we already enrolled with.
+			// If so, skip enrollment and just start the gateway.
+			storedEnrollToken, _ := gatewayv2.LoadStoredEnrollmentToken()
+			alreadyEnrolled = storedEnrollToken != "" && storedEnrollToken == enrollToken
 
-			domain, _ := cmd.Flags().GetString("domain")
-			if domain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
-			}
+			if alreadyEnrolled {
+				log.Info().Msg("Enrollment token matches stored token. Skipping enrollment.")
+			} else {
+				relayName, _ := util.GetRelayName(cmd, false, "")
 
-			httpClient, err := util.GetRestyClientWithCustomHeaders()
-			if err != nil {
-				util.HandleError(err, "unable to create HTTP client")
-			}
-
-			log.Info().Msg("Enrolling gateway with enrollment token...")
-			enrollResp, err := api.CallEnrollGateway(httpClient, api.EnrollGatewayRequest{
-				Token:     enrollToken,
-				RelayName: relayName,
-			})
-			if err != nil {
-				util.HandleError(err, "enrollment failed")
-			}
-
-			if err := gatewayv2.SaveAccessToken(enrollResp.AccessToken); err != nil {
-				util.HandleError(err, "failed to save gateway access token")
-			}
-
-			// Always persist the effective domain so restarts use the same backend
-			effectiveDomain := domain
-			if effectiveDomain == "" {
-				effectiveDomain = config.INFISICAL_URL
-			}
-			if effectiveDomain != "" {
-				if err := gatewayv2.SaveDomain(effectiveDomain); err != nil {
-					util.HandleError(err, "failed to save domain to config")
+				domain, _ := cmd.Flags().GetString("domain")
+				if domain != "" {
+					config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
 				}
+
+				httpClient, err := util.GetRestyClientWithCustomHeaders()
+				if err != nil {
+					util.HandleError(err, "unable to create HTTP client")
+				}
+
+				log.Info().Msg("Enrolling gateway with enrollment token...")
+				enrollResp, err := api.CallEnrollGateway(httpClient, api.EnrollGatewayRequest{
+					Token:     enrollToken,
+					RelayName: relayName,
+				})
+				if err != nil {
+					util.HandleError(err, "enrollment failed")
+				}
+
+				if err := gatewayv2.SaveAccessToken(enrollResp.AccessToken); err != nil {
+					util.HandleError(err, "failed to save gateway access token")
+				}
+
+				if err := gatewayv2.SaveEnrollmentToken(enrollToken); err != nil {
+					util.HandleError(err, "failed to save enrollment token to config")
+				}
+
+				// Always persist the effective domain so restarts use the same backend
+				effectiveDomain := domain
+				if effectiveDomain == "" {
+					effectiveDomain = config.INFISICAL_URL
+				}
+				if effectiveDomain != "" {
+					if err := gatewayv2.SaveDomain(effectiveDomain); err != nil {
+						util.HandleError(err, "failed to save domain to config")
+					}
+				}
+
+				log.Info().Msgf("Gateway enrolled successfully. Access token saved to %s", gatewayv2.GetConfPathDisplay())
 			}
 
-			log.Info().Msgf("Gateway enrolled successfully. Access token saved to %s", gatewayv2.GetConfPathDisplay())
 			log.Info().Msg("Starting gateway...")
 		}
 
 		// --- Stored token / post-enrollment path ---
 		// --domain flag takes priority; fall back to domain saved at enrollment time.
-		if enrollMethod != "static" {
+		// For enrollment flow with alreadyEnrolled, domain was set during original enrollment
+		// and needs to be loaded from config.
+		if enrollMethod != "static" || alreadyEnrolled {
 			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
 				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
 			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(); storedDomain != "" {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -205,7 +205,7 @@ var gatewayCmd = &cobra.Command{
 var gatewayStartCmd = &cobra.Command{
 	Use:                   "start [name]",
 	Short:                 "Start the new Infisical gateway",
-	Long:                  "Start the new Infisical gateway component. The gateway name can be provided as a positional argument or via the --name flag.",
+	Long:                  "Start the new Infisical gateway component.",
 	Example:               "infisical gateway start my-gateway --token=<token>",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MaximumNArgs(1),
@@ -502,7 +502,7 @@ var gatewaySystemdCmd = &cobra.Command{
 	Use:   "systemd",
 	Short: "Manage systemd service for Infisical gateway",
 	Long:  "Manage systemd service for Infisical gateway. Use 'systemd install' to install and enable the service.",
-	Example: `sudo infisical gateway systemd install --token=<token> --domain=<domain> --name=<name>
+	Example: `sudo infisical gateway systemd install my-gateway --token=<token> --domain=<domain>
   sudo infisical gateway systemd uninstall`,
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.NoArgs,
@@ -511,7 +511,7 @@ var gatewaySystemdCmd = &cobra.Command{
 var gatewaySystemdInstallCmd = &cobra.Command{
 	Use:                   "install [name]",
 	Short:                 "Install and enable systemd service for the gateway (v2) (requires sudo)",
-	Long:                  "Install and enable systemd service for the new gateway (v2). Must be run with sudo on Linux. The gateway name can be provided as a positional argument or via the --name flag.",
+	Long:                  "Install and enable systemd service for the new gateway (v2). Must be run with sudo on Linux.",
 	Example:               "sudo infisical gateway systemd install my-gateway --token=<token> --domain=<domain>",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MaximumNArgs(1),

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -212,6 +212,7 @@ var gatewayStartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 		var alreadyEnrolled bool
+		var enrolledAccessToken string // set during fresh enrollment, used directly to avoid env var interference
 
 		// Resolve gateway name early so config files can be scoped per gateway.
 		// Positional arg > --name flag (deprecated) > env var
@@ -261,6 +262,7 @@ var gatewayStartCmd = &cobra.Command{
 					util.HandleError(err, "enrollment failed")
 				}
 
+				enrolledAccessToken = enrollResp.AccessToken
 				if err := gatewayv2.SaveAccessToken(gatewayName, enrollResp.AccessToken); err != nil {
 					util.HandleError(err, "failed to save gateway access token")
 				}
@@ -331,11 +333,16 @@ var gatewayStartCmd = &cobra.Command{
 		cancelSdk := func() {}                              // noop by default
 		var sdkTokenGetter func() string                    // nil when using stored token
 		if runningWithStoredToken {
-			loadedToken, loadErr := gatewayv2.LoadStoredAccessToken(gatewayName)
-			if loadErr != nil || loadedToken == "" {
-				util.HandleError(errors.New("no stored access token found"))
+			if enrolledAccessToken != "" {
+				// Fresh enrollment: use the token directly to avoid env var interference
+				accessToken.Store(enrolledAccessToken)
+			} else {
+				loadedToken, loadErr := gatewayv2.LoadStoredAccessToken(gatewayName)
+				if loadErr != nil || loadedToken == "" {
+					util.HandleError(errors.New("no stored access token found"))
+				}
+				accessToken.Store(loadedToken)
 			}
-			accessToken.Store(loadedToken)
 		} else {
 			infisicalClient, sdkCancel, sdkErr := getInfisicalSdkInstance(cmd)
 			if sdkErr != nil {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -214,7 +214,7 @@ var gatewayStartCmd = &cobra.Command{
 		var alreadyEnrolled bool
 
 		// --- Enrollment token path ---
-		if enrollMethod == "static" {
+		if enrollMethod == gatewayv2.EnrollMethodStatic {
 			enrollToken, err := cmd.Flags().GetString("token")
 			if err != nil || enrollToken == "" {
 				util.HandleError(errors.New("--token is required when --enroll-method=static"))
@@ -278,7 +278,7 @@ var gatewayStartCmd = &cobra.Command{
 		// --domain flag takes priority; fall back to domain saved at enrollment time.
 		// For enrollment flow with alreadyEnrolled, domain was set during original enrollment
 		// and needs to be loaded from config.
-		if enrollMethod != "static" || alreadyEnrolled {
+		if enrollMethod != gatewayv2.EnrollMethodStatic || alreadyEnrolled {
 			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
 				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
 			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(); storedDomain != "" {
@@ -289,7 +289,7 @@ var gatewayStartCmd = &cobra.Command{
 		// Only use the stored token when no explicit identity credentials are provided.
 		// If --token or --auth-method is set, the user wants the identity-based path.
 		var runningWithStoredToken bool
-		if enrollMethod == "static" {
+		if enrollMethod == gatewayv2.EnrollMethodStatic {
 			// Just enrolled above; use the freshly saved token.
 			runningWithStoredToken = true
 		} else {
@@ -551,7 +551,7 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 
-		if enrollMethod == "static" {
+		if enrollMethod == gatewayv2.EnrollMethodStatic {
 			// --- Enrollment token path ---
 			enrollToken, flagErr := cmd.Flags().GetString("token")
 			if flagErr != nil || enrollToken == "" {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -203,12 +203,12 @@ var gatewayCmd = &cobra.Command{
 }
 
 var gatewayStartCmd = &cobra.Command{
-	Use:                   "start",
+	Use:                   "start [name]",
 	Short:                 "Start the new Infisical gateway",
-	Long:                  "Start the new Infisical gateway component.",
-	Example:               "infisical gateway start --name=<name> --token=<token>",
+	Long:                  "Start the new Infisical gateway component. The gateway name can be provided as a positional argument or via the --name flag.",
+	Example:               "infisical gateway start my-gateway --token=<token>",
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.NoArgs,
+	Args:                  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 
@@ -286,16 +286,16 @@ var gatewayStartCmd = &cobra.Command{
 			}
 		}
 
+		// Resolve gateway name: positional arg > --name flag (deprecated) > env var
 		var gatewayName string
 		var err error
-		if !runningWithStoredToken {
-			gatewayName, err = util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
-			if err != nil {
-				util.HandleError(err, fmt.Sprintf("unable to get name flag or %s env", gatewayv2.GATEWAY_NAME_ENV_NAME))
-			}
+		if len(args) > 0 {
+			gatewayName = args[0]
 		} else {
-			// Name was set at enrollment time and is stored in the backend; not needed for cert refresh.
 			gatewayName, _ = util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
+		}
+		if gatewayName == "" {
+			util.HandleError(errors.New("gateway name is required (provide as positional argument or --name flag)"))
 		}
 
 		pamSessionRecordingPath, err := util.GetCmdFlagOrEnv(cmd, "pam-session-recording-path", []string{gatewayv2.INFISICAL_PAM_SESSION_RECORDING_PATH_ENV_NAME})
@@ -485,12 +485,12 @@ var gatewaySystemdCmd = &cobra.Command{
 }
 
 var gatewaySystemdInstallCmd = &cobra.Command{
-	Use:                   "install",
+	Use:                   "install [name]",
 	Short:                 "Install and enable systemd service for the gateway (v2) (requires sudo)",
-	Long:                  "Install and enable systemd service for the new gateway (v2). Must be run with sudo on Linux.",
-	Example:               "sudo infisical gateway systemd install --token=<token> --domain=<domain> --name=<name>",
+	Long:                  "Install and enable systemd service for the new gateway (v2). Must be run with sudo on Linux. The gateway name can be provided as a positional argument or via the --name flag.",
+	Example:               "sudo infisical gateway systemd install my-gateway --token=<token> --domain=<domain>",
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.NoArgs,
+	Args:                  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if runtime.GOOS != "linux" {
 			util.HandleError(fmt.Errorf("systemd service installation is only supported on Linux"))
@@ -509,12 +509,15 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 			config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
 		}
 
-		gatewayName, err := cmd.Flags().GetString("name")
-		if err != nil {
-			util.HandleError(err, "Unable to parse name flag")
+		// Resolve gateway name: positional arg > --name flag (deprecated) > env var
+		var gatewayName string
+		if len(args) > 0 {
+			gatewayName = args[0]
+		} else {
+			gatewayName, _ = cmd.Flags().GetString("name")
 		}
 		if gatewayName == "" {
-			util.HandleError(errors.New("Gateway name is required"))
+			util.HandleError(errors.New("gateway name is required (provide as positional argument or --name flag)"))
 		}
 
 		serviceLogFile, err := cmd.Flags().GetString("log-file")
@@ -645,7 +648,8 @@ func init() {
 	// Gateway start command flags (v2)
 	gatewayStartCmd.Flags().String("relay", "", "name of the relay to connect to (deprecated, use --target-relay-name)") // Deprecated, use --target-relay-name instead
 	gatewayStartCmd.Flags().String("target-relay-name", "", "name of the relay to connect to")
-	gatewayStartCmd.Flags().String("name", "", "name of the gateway")
+	gatewayStartCmd.Flags().String("name", "", "name of the gateway (deprecated, use positional argument instead)")
+	_ = gatewayStartCmd.Flags().MarkDeprecated("name", "use positional argument instead: infisical gateway start <name>")
 	gatewayStartCmd.Flags().String("token", "", "connect with Infisical using machine identity access token, or enrollment token when --enroll-method=static")
 	gatewayStartCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token to obtain a long-lived gateway access token")
 	gatewayStartCmd.Flags().String("domain", "", "domain of your self-hosted Infisical instance (used with --enroll-method=static)")
@@ -667,7 +671,8 @@ func init() {
 	gatewaySystemdInstallCmd.Flags().String("token", "", "Connect with Infisical using machine identity access token, or enrollment token when --enroll-method=static")
 	gatewaySystemdInstallCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token")
 	gatewaySystemdInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
-	gatewaySystemdInstallCmd.Flags().String("name", "", "The name of the gateway")
+	gatewaySystemdInstallCmd.Flags().String("name", "", "The name of the gateway (deprecated, use positional argument instead)")
+	_ = gatewaySystemdInstallCmd.Flags().MarkDeprecated("name", "use positional argument instead: infisical gateway systemd install <name>")
 	gatewaySystemdInstallCmd.Flags().String("relay", "", "The name of the relay (deprecated, use --target-relay-name)") // Deprecated, use --target-relay-name instead
 	gatewaySystemdInstallCmd.Flags().String("target-relay-name", "", "The name of the relay")
 	gatewaySystemdInstallCmd.Flags().String("log-file", "", "The file to write the service logs to. Example: /var/log/infisical/gateway.log. If not provided, logs will not be written to a file.")

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -241,8 +241,6 @@ var gatewayStartCmd = &cobra.Command{
 			if alreadyEnrolled {
 				log.Info().Msg("Enrollment token matches stored token. Skipping enrollment.")
 			} else {
-				relayName, _ := util.GetRelayName(cmd, false, "")
-
 				domain, _ := cmd.Flags().GetString("domain")
 				if domain != "" {
 					config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
@@ -255,8 +253,7 @@ var gatewayStartCmd = &cobra.Command{
 
 				log.Info().Msg("Enrolling gateway with enrollment token...")
 				enrollResp, err := api.CallEnrollGateway(httpClient, api.EnrollGatewayRequest{
-					Token:     enrollToken,
-					RelayName: relayName,
+					Token: enrollToken,
 				})
 				if err != nil {
 					util.HandleError(err, "enrollment failed")
@@ -566,8 +563,6 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 				util.HandleError(errors.New("--token is required when --enroll-method=token"))
 			}
 
-			relayName, _ := util.GetRelayName(cmd, false, "")
-
 			httpClient, clientErr := util.GetRestyClientWithCustomHeaders()
 			if clientErr != nil {
 				util.HandleError(clientErr, "unable to create HTTP client")
@@ -575,15 +570,14 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 
 			log.Info().Msg("Enrolling gateway with enrollment token...")
 			enrollResp, enrollErr := api.CallEnrollGateway(httpClient, api.EnrollGatewayRequest{
-				Token:     enrollToken,
-				RelayName: relayName,
+				Token: enrollToken,
 			})
 			if enrollErr != nil {
 				util.HandleError(enrollErr, "enrollment failed")
 			}
 
 			// Install systemd service using the long-lived access token
-			if installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
+			if installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, "", serviceLogFile); installErr != nil {
 				util.HandleError(installErr, "Unable to install systemd service")
 			}
 		} else {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -226,10 +226,10 @@ var gatewayStartCmd = &cobra.Command{
 		}
 
 		// --- Enrollment token path ---
-		if enrollMethod == gatewayv2.EnrollMethodStatic {
+		if enrollMethod == gatewayv2.EnrollMethodToken {
 			enrollToken, err := cmd.Flags().GetString("token")
 			if err != nil || enrollToken == "" {
-				util.HandleError(errors.New("--token is required when --enroll-method=static"))
+				util.HandleError(errors.New("--token is required when --enroll-method=token"))
 			}
 
 			// Check if this is the same token we already enrolled with.
@@ -290,7 +290,7 @@ var gatewayStartCmd = &cobra.Command{
 		// --domain flag takes priority; fall back to domain saved at enrollment time.
 		// For enrollment flow with alreadyEnrolled, domain was set during original enrollment
 		// and needs to be loaded from config.
-		if enrollMethod != gatewayv2.EnrollMethodStatic || alreadyEnrolled {
+		if enrollMethod != gatewayv2.EnrollMethodToken || alreadyEnrolled {
 			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
 				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
 			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" {
@@ -301,7 +301,7 @@ var gatewayStartCmd = &cobra.Command{
 		// Only use the stored token when no explicit identity credentials are provided.
 		// If --token or --auth-method is set, the user wants the identity-based path.
 		var runningWithStoredToken bool
-		if enrollMethod == gatewayv2.EnrollMethodStatic {
+		if enrollMethod == gatewayv2.EnrollMethodToken {
 			// Just enrolled above; use the freshly saved token.
 			runningWithStoredToken = true
 		} else {
@@ -553,11 +553,11 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 
-		if enrollMethod == gatewayv2.EnrollMethodStatic {
+		if enrollMethod == gatewayv2.EnrollMethodToken {
 			// --- Enrollment token path ---
 			enrollToken, flagErr := cmd.Flags().GetString("token")
 			if flagErr != nil || enrollToken == "" {
-				util.HandleError(errors.New("--token is required when --enroll-method=static"))
+				util.HandleError(errors.New("--token is required when --enroll-method=token"))
 			}
 
 			relayName, _ := util.GetRelayName(cmd, false, "")
@@ -677,8 +677,8 @@ func init() {
 	gatewayStartCmd.Flags().String("name", "", "name of the gateway (deprecated, use positional argument instead)")
 	_ = gatewayStartCmd.Flags().MarkDeprecated("name", "use positional argument instead: infisical gateway start <name>")
 	gatewayStartCmd.Flags().String("token", "", "enrollment token or access token for authenticating with Infisical")
-	gatewayStartCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token to obtain a long-lived gateway access token")
-	gatewayStartCmd.Flags().String("domain", "", "domain of your self-hosted Infisical instance (used with --enroll-method=static)")
+	gatewayStartCmd.Flags().String("enroll-method", "", "enrollment method [token]. when set to 'token', uses --token as a one-time enrollment token")
+	gatewayStartCmd.Flags().String("domain", "", "domain of your self-hosted Infisical instance (used with --enroll-method=token)")
 	gatewayStartCmd.Flags().String("auth-method", "", "login method [universal-auth, kubernetes, azure, gcp-id-token, gcp-iam, aws-iam, oidc-auth]. if not provided, you must set the token flag")
 	gatewayStartCmd.Flags().String("organization-slug", "", "When set, this will scope the login session to the specified sub-organization the machine identity has access to. If left empty, the session defaults to the organization where the machine identity was created in.")
 	gatewayStartCmd.Flags().String("client-id", "", "client id for universal auth")
@@ -695,7 +695,7 @@ func init() {
 
 	// Systemd install command flags (v2)
 	gatewaySystemdInstallCmd.Flags().String("token", "", "enrollment token or access token for authenticating with Infisical")
-	gatewaySystemdInstallCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token")
+	gatewaySystemdInstallCmd.Flags().String("enroll-method", "", "enrollment method [token]. when set to 'token', uses --token as a one-time enrollment token")
 	gatewaySystemdInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
 	gatewaySystemdInstallCmd.Flags().String("name", "", "The name of the gateway (deprecated, use positional argument instead)")
 	_ = gatewaySystemdInstallCmd.Flags().MarkDeprecated("name", "use positional argument instead: infisical gateway systemd install <name>")

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -674,7 +674,7 @@ func init() {
 	gatewayStartCmd.Flags().String("target-relay-name", "", "name of the relay to connect to")
 	gatewayStartCmd.Flags().String("name", "", "name of the gateway (deprecated, use positional argument instead)")
 	_ = gatewayStartCmd.Flags().MarkDeprecated("name", "use positional argument instead: infisical gateway start <name>")
-	gatewayStartCmd.Flags().String("token", "", "connect with Infisical using machine identity access token, or enrollment token when --enroll-method=static")
+	gatewayStartCmd.Flags().String("token", "", "enrollment token or access token for authenticating with Infisical")
 	gatewayStartCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token to obtain a long-lived gateway access token")
 	gatewayStartCmd.Flags().String("domain", "", "domain of your self-hosted Infisical instance (used with --enroll-method=static)")
 	gatewayStartCmd.Flags().String("auth-method", "", "login method [universal-auth, kubernetes, azure, gcp-id-token, gcp-iam, aws-iam, oidc-auth]. if not provided, you must set the token flag")
@@ -692,7 +692,7 @@ func init() {
 	gatewayInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
 
 	// Systemd install command flags (v2)
-	gatewaySystemdInstallCmd.Flags().String("token", "", "Connect with Infisical using machine identity access token, or enrollment token when --enroll-method=static")
+	gatewaySystemdInstallCmd.Flags().String("token", "", "enrollment token or access token for authenticating with Infisical")
 	gatewaySystemdInstallCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token")
 	gatewaySystemdInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
 	gatewaySystemdInstallCmd.Flags().String("name", "", "The name of the gateway (deprecated, use positional argument instead)")

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -305,9 +305,7 @@ var gatewayStartCmd = &cobra.Command{
 			// Just enrolled above; use the freshly saved token.
 			runningWithStoredToken = true
 		} else {
-			explicitToken, _ := util.GetInfisicalToken(cmd)
-			explicitAuthMethod, _ := cmd.Flags().GetString("auth-method")
-			hasExplicitCreds := explicitToken != nil || explicitAuthMethod != ""
+			hasExplicitCreds := cmd.Flags().Changed("token") || cmd.Flags().Changed("auth-method")
 
 			if !hasExplicitCreds {
 				storedToken, loadErr := gatewayv2.LoadStoredAccessToken(gatewayName)

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -244,8 +244,13 @@ var gatewayStartCmd = &cobra.Command{
 				util.HandleError(err, "failed to save gateway access token")
 			}
 
-			if domain != "" {
-				if err := gatewayv2.SaveDomain(domain); err != nil {
+			// Always persist the effective domain so restarts use the same backend
+			effectiveDomain := domain
+			if effectiveDomain == "" {
+				effectiveDomain = config.INFISICAL_URL
+			}
+			if effectiveDomain != "" {
+				if err := gatewayv2.SaveDomain(effectiveDomain); err != nil {
 					util.HandleError(err, "failed to save domain to config")
 				}
 			}

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -357,8 +357,10 @@ var gatewayStartCmd = &cobra.Command{
 
 		var relayName string
 		if runningWithStoredToken {
-			// For enrollment-flow gateways, relay is optional — the backend uses the relay stored at enrollment time.
-			relayName, _ = util.GetRelayName(cmd, false, "")
+			relayName, err = util.GetRelayName(cmd, false, accessToken.Load().(string))
+			if err != nil {
+				util.HandleError(err, "unable to get relay name")
+			}
 		} else {
 			relayName, err = util.GetRelayName(cmd, false, accessToken.Load().(string))
 			if err != nil {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -210,9 +210,92 @@ var gatewayStartCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		gatewayName, err := util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
-		if err != nil {
-			util.HandleError(err, fmt.Sprintf("unable to get name flag or %s env", gatewayv2.GATEWAY_NAME_ENV_NAME))
+		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
+
+		// --- Enrollment token path ---
+		if enrollMethod == "static" {
+			enrollToken, err := cmd.Flags().GetString("token")
+			if err != nil || enrollToken == "" {
+				util.HandleError(errors.New("--token is required when --enroll-method=static"))
+			}
+
+			relayName, _ := util.GetRelayName(cmd, false, "")
+
+			domain, _ := cmd.Flags().GetString("domain")
+			if domain != "" {
+				config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
+			}
+
+			httpClient, err := util.GetRestyClientWithCustomHeaders()
+			if err != nil {
+				util.HandleError(err, "unable to create HTTP client")
+			}
+
+			log.Info().Msg("Enrolling gateway with enrollment token...")
+			enrollResp, err := api.CallEnrollGateway(httpClient, api.EnrollGatewayRequest{
+				Token:     enrollToken,
+				RelayName: relayName,
+			})
+			if err != nil {
+				util.HandleError(err, "enrollment failed")
+			}
+
+			if err := gatewayv2.SaveAccessToken(enrollResp.AccessToken); err != nil {
+				util.HandleError(err, "failed to save gateway access token")
+			}
+
+			if domain != "" {
+				if err := gatewayv2.SaveDomain(domain); err != nil {
+					util.HandleError(err, "failed to save domain to config")
+				}
+			}
+
+			log.Info().Msgf("Gateway enrolled successfully. Access token saved to %s", gatewayv2.GetConfPathDisplay())
+			log.Info().Msg("Starting gateway...")
+		}
+
+		// --- Stored token / post-enrollment path ---
+		// --domain flag takes priority; fall back to domain saved at enrollment time.
+		if enrollMethod != "static" {
+			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
+				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
+			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(); storedDomain != "" {
+				config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
+			}
+		}
+
+		// Only use the stored token when no explicit identity credentials are provided.
+		// If --token or --auth-method is set, the user wants the identity-based path.
+		var runningWithStoredToken bool
+		if enrollMethod == "static" {
+			// Just enrolled above; use the freshly saved token.
+			runningWithStoredToken = true
+		} else {
+			explicitToken, _ := util.GetInfisicalToken(cmd)
+			explicitAuthMethod, _ := cmd.Flags().GetString("auth-method")
+			hasExplicitCreds := explicitToken != nil || explicitAuthMethod != ""
+
+			storedToken, loadErr := gatewayv2.LoadStoredAccessToken()
+			if loadErr != nil {
+				util.HandleError(loadErr, "failed to load stored gateway access token")
+			}
+
+			if storedToken != "" && !hasExplicitCreds {
+				log.Info().Msg("Using stored gateway access token")
+				runningWithStoredToken = true
+			}
+		}
+
+		var gatewayName string
+		var err error
+		if !runningWithStoredToken {
+			gatewayName, err = util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
+			if err != nil {
+				util.HandleError(err, fmt.Sprintf("unable to get name flag or %s env", gatewayv2.GATEWAY_NAME_ENV_NAME))
+			}
+		} else {
+			// Name was set at enrollment time and is stored in the backend; not needed for cert refresh.
+			gatewayName, _ = util.GetCmdFlagOrEnv(cmd, "name", []string{gatewayv2.GATEWAY_NAME_ENV_NAME})
 		}
 
 		pamSessionRecordingPath, err := util.GetCmdFlagOrEnv(cmd, "pam-session-recording-path", []string{gatewayv2.INFISICAL_PAM_SESSION_RECORDING_PATH_ENV_NAME})
@@ -220,22 +303,39 @@ var gatewayStartCmd = &cobra.Command{
 			session.SetSessionRecordingPath(pamSessionRecordingPath)
 		}
 
-		infisicalClient, cancelSdk, err := getInfisicalSdkInstance(cmd)
-		if err != nil {
-			util.HandleError(err, "unable to get infisical client")
-		}
-		defer cancelSdk()
-
 		var accessToken atomic.Value
-		accessToken.Store(infisicalClient.Auth().GetAccessToken())
+		cancelSdk := func() {}                              // noop by default
+		var sdkTokenGetter func() string                    // nil when using stored token
+		if runningWithStoredToken {
+			loadedToken, loadErr := gatewayv2.LoadStoredAccessToken()
+			if loadErr != nil || loadedToken == "" {
+				util.HandleError(errors.New("no stored access token found"))
+			}
+			accessToken.Store(loadedToken)
+		} else {
+			infisicalClient, sdkCancel, sdkErr := getInfisicalSdkInstance(cmd)
+			if sdkErr != nil {
+				util.HandleError(sdkErr, "unable to get infisical client")
+			}
+			cancelSdk = sdkCancel
+			defer cancelSdk()
+			accessToken.Store(infisicalClient.Auth().GetAccessToken())
+			sdkTokenGetter = infisicalClient.Auth().GetAccessToken
+		}
 
 		if accessToken.Load().(string) == "" {
 			util.HandleError(errors.New("no access token found"))
 		}
 
-		relayName, err := util.GetRelayName(cmd, false, accessToken.Load().(string))
-		if err != nil {
-			util.HandleError(err, "unable to get relay name")
+		var relayName string
+		if runningWithStoredToken {
+			// For enrollment-flow gateways, relay is optional — the backend uses the relay stored at enrollment time.
+			relayName, _ = util.GetRelayName(cmd, false, "")
+		} else {
+			relayName, err = util.GetRelayName(cmd, false, accessToken.Load().(string))
+			if err != nil {
+				util.HandleError(err, "unable to get relay name")
+			}
 		}
 
 		gatewayInstance, err := gatewayv2.NewGateway(&gatewayv2.GatewayConfig{
@@ -275,29 +375,31 @@ var gatewayStartCmd = &cobra.Command{
 			}
 		}()
 
-		// Token refresh goroutine - runs every 10 seconds
-		go func() {
-			tokenRefreshTicker := time.NewTicker(10 * time.Second)
-			defer tokenRefreshTicker.Stop()
+		// Token refresh goroutine - runs every 10 seconds (SDK-managed tokens only)
+		if sdkTokenGetter != nil {
+			go func() {
+				tokenRefreshTicker := time.NewTicker(10 * time.Second)
+				defer tokenRefreshTicker.Stop()
 
-			for {
-				select {
-				case <-tokenRefreshTicker.C:
-					if ctx.Err() != nil {
+				for {
+					select {
+					case <-tokenRefreshTicker.C:
+						if ctx.Err() != nil {
+							return
+						}
+
+						newToken := sdkTokenGetter()
+						if newToken != "" && newToken != accessToken.Load().(string) {
+							accessToken.Store(newToken)
+							gatewayInstance.SetToken(newToken)
+						}
+
+					case <-ctx.Done():
 						return
 					}
-
-					newToken := infisicalClient.Auth().GetAccessToken()
-					if newToken != "" && newToken != accessToken.Load().(string) {
-						accessToken.Store(newToken)
-						gatewayInstance.SetToken(newToken)
-					}
-
-				case <-ctx.Done():
-					return
 				}
-			}
-		}()
+			}()
+		}
 
 		err = gatewayInstance.Start(ctx)
 		if err != nil {
@@ -398,15 +500,6 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 			util.HandleError(fmt.Errorf("systemd service installation requires root/sudo privileges"))
 		}
 
-		token, err := util.GetInfisicalToken(cmd)
-		if err != nil {
-			util.HandleError(err, "Unable to parse flag")
-		}
-
-		if token == nil {
-			util.HandleError(errors.New("Token not found"))
-		}
-
 		domain, err := cmd.Flags().GetString("domain")
 		if err != nil {
 			util.HandleError(err, "Unable to parse domain flag")
@@ -429,14 +522,54 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse log-file flag")
 		}
 
-		relayName, err := util.GetRelayName(cmd, false, token.Token)
-		if err != nil {
-			util.HandleError(err, "unable to get relay name")
-		}
+		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 
-		err = gatewayv2.InstallGatewaySystemdService(token.Token, domain, gatewayName, relayName, serviceLogFile)
-		if err != nil {
-			util.HandleError(err, "Unable to install systemd service")
+		if enrollMethod == "static" {
+			// --- Enrollment token path ---
+			enrollToken, flagErr := cmd.Flags().GetString("token")
+			if flagErr != nil || enrollToken == "" {
+				util.HandleError(errors.New("--token is required when --enroll-method=static"))
+			}
+
+			relayName, _ := util.GetRelayName(cmd, false, "")
+
+			httpClient, clientErr := util.GetRestyClientWithCustomHeaders()
+			if clientErr != nil {
+				util.HandleError(clientErr, "unable to create HTTP client")
+			}
+
+			log.Info().Msg("Enrolling gateway with enrollment token...")
+			enrollResp, enrollErr := api.CallEnrollGateway(httpClient, api.EnrollGatewayRequest{
+				Token:     enrollToken,
+				RelayName: relayName,
+			})
+			if enrollErr != nil {
+				util.HandleError(enrollErr, "enrollment failed")
+			}
+
+			// Install systemd service using the long-lived access token
+			if installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
+				util.HandleError(installErr, "Unable to install systemd service")
+			}
+		} else {
+			// --- Machine identity token path ---
+			token, tokenErr := util.GetInfisicalToken(cmd)
+			if tokenErr != nil {
+				util.HandleError(tokenErr, "Unable to parse flag")
+			}
+
+			if token == nil {
+				util.HandleError(errors.New("Token not found"))
+			}
+
+			relayName, relayErr := util.GetRelayName(cmd, false, token.Token)
+			if relayErr != nil {
+				util.HandleError(relayErr, "unable to get relay name")
+			}
+
+			if installErr := gatewayv2.InstallGatewaySystemdService(token.Token, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
+				util.HandleError(installErr, "Unable to install systemd service")
+			}
 		}
 
 		enableCmd := exec.Command("systemctl", "enable", "infisical-gateway")
@@ -513,7 +646,9 @@ func init() {
 	gatewayStartCmd.Flags().String("relay", "", "name of the relay to connect to (deprecated, use --target-relay-name)") // Deprecated, use --target-relay-name instead
 	gatewayStartCmd.Flags().String("target-relay-name", "", "name of the relay to connect to")
 	gatewayStartCmd.Flags().String("name", "", "name of the gateway")
-	gatewayStartCmd.Flags().String("token", "", "connect with Infisical using machine identity access token. if not provided, you must set the auth-method flag")
+	gatewayStartCmd.Flags().String("token", "", "connect with Infisical using machine identity access token, or enrollment token when --enroll-method=static")
+	gatewayStartCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token to obtain a long-lived gateway access token")
+	gatewayStartCmd.Flags().String("domain", "", "domain of your self-hosted Infisical instance (used with --enroll-method=static)")
 	gatewayStartCmd.Flags().String("auth-method", "", "login method [universal-auth, kubernetes, azure, gcp-id-token, gcp-iam, aws-iam, oidc-auth]. if not provided, you must set the token flag")
 	gatewayStartCmd.Flags().String("organization-slug", "", "When set, this will scope the login session to the specified sub-organization the machine identity has access to. If left empty, the session defaults to the organization where the machine identity was created in.")
 	gatewayStartCmd.Flags().String("client-id", "", "client id for universal auth")
@@ -529,7 +664,8 @@ func init() {
 	gatewayInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
 
 	// Systemd install command flags (v2)
-	gatewaySystemdInstallCmd.Flags().String("token", "", "Connect with Infisical using machine identity access token")
+	gatewaySystemdInstallCmd.Flags().String("token", "", "Connect with Infisical using machine identity access token, or enrollment token when --enroll-method=static")
+	gatewaySystemdInstallCmd.Flags().String("enroll-method", "", "enrollment method [static]. when set to 'static', uses --token as a one-time enrollment token")
 	gatewaySystemdInstallCmd.Flags().String("domain", "", "Domain of your self-hosted Infisical instance")
 	gatewaySystemdInstallCmd.Flags().String("name", "", "The name of the gateway")
 	gatewaySystemdInstallCmd.Flags().String("relay", "", "The name of the relay (deprecated, use --target-relay-name)") // Deprecated, use --target-relay-name instead

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -1,0 +1,132 @@
+package gatewayv2
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	INFISICAL_GATEWAY_ACCESS_TOKEN_KEY = "INFISICAL_GATEWAY_ACCESS_TOKEN"
+	INFISICAL_GATEWAY_DOMAIN_KEY       = "INFISICAL_GATEWAY_DOMAIN"
+)
+
+// gatewayConfPath returns the path to the gateway config file.
+// Uses /etc/infisical/gateway.conf when running as root, otherwise ~/.infisical/gateway.conf.
+func gatewayConfPath() (string, error) {
+	if os.Getuid() == 0 {
+		return "/etc/infisical/gateway.conf", nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".infisical", "gateway.conf"), nil
+}
+
+// loadConfKey reads a key from the config file. Returns empty string if not found.
+func loadConfKey(key string) (string, error) {
+	confPath, err := gatewayConfPath()
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(confPath)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to read gateway config: %w", err)
+	}
+
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix), nil
+		}
+	}
+
+	return "", nil
+}
+
+// saveConfKey writes a key=value pair to the config file, preserving other keys.
+// The file is created with 0600 permissions (owner read/write only).
+func saveConfKey(key, value string) error {
+	confPath, err := gatewayConfPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	var existingLines []string
+	data, err := os.ReadFile(confPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read existing config: %w", err)
+	}
+	if err == nil {
+		prefix := key + "="
+		for _, line := range strings.Split(string(data), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, prefix) {
+				continue
+			}
+			existingLines = append(existingLines, line)
+		}
+	}
+
+	existingLines = append(existingLines, fmt.Sprintf("%s=%s", key, value))
+	content := strings.Join(existingLines, "\n") + "\n"
+
+	if err := os.WriteFile(confPath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write gateway config: %w", err)
+	}
+
+	return nil
+}
+
+// LoadStoredAccessToken reads the gateway access token from the environment or config file.
+// Env var takes precedence over the config file.
+// Returns an empty string if neither source has the token set.
+func LoadStoredAccessToken() (string, error) {
+	if envToken := os.Getenv(INFISICAL_GATEWAY_ACCESS_TOKEN_KEY); envToken != "" {
+		return envToken, nil
+	}
+	return loadConfKey(INFISICAL_GATEWAY_ACCESS_TOKEN_KEY)
+}
+
+// SaveAccessToken writes the gateway access token to the config file.
+func SaveAccessToken(token string) error {
+	return saveConfKey(INFISICAL_GATEWAY_ACCESS_TOKEN_KEY, token)
+}
+
+// LoadStoredDomain reads the Infisical domain from the gateway config file.
+// Returns empty string if not set (caller should use the default).
+func LoadStoredDomain() (string, error) {
+	return loadConfKey(INFISICAL_GATEWAY_DOMAIN_KEY)
+}
+
+// SaveDomain writes the Infisical domain to the config file.
+func SaveDomain(domain string) error {
+	return saveConfKey(INFISICAL_GATEWAY_DOMAIN_KEY, domain)
+}
+
+// GetConfPathDisplay returns the config path for display in log messages,
+// without returning an error (falls back to a sensible default).
+func GetConfPathDisplay() string {
+	path, err := gatewayConfPath()
+	if err != nil {
+		if runtime.GOOS == "linux" {
+			return "/etc/infisical/gateway.conf"
+		}
+		return "~/.infisical/gateway.conf"
+	}
+	return path
+}

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -12,7 +12,7 @@ const (
 	INFISICAL_GATEWAY_ACCESS_TOKEN_KEY    = "INFISICAL_GATEWAY_ACCESS_TOKEN"
 	INFISICAL_GATEWAY_DOMAIN_KEY          = "INFISICAL_GATEWAY_DOMAIN"
 	INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY = "INFISICAL_GATEWAY_ENROLLMENT_TOKEN"
-	EnrollMethodStatic                     = "static"
+	EnrollMethodToken                      = "token"
 )
 
 // gatewayConfPath returns the path to the gateway config file scoped by name.

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -62,7 +62,7 @@ func saveConfKey(key, value string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(confPath), 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -12,6 +12,7 @@ const (
 	INFISICAL_GATEWAY_ACCESS_TOKEN_KEY    = "INFISICAL_GATEWAY_ACCESS_TOKEN"
 	INFISICAL_GATEWAY_DOMAIN_KEY          = "INFISICAL_GATEWAY_DOMAIN"
 	INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY = "INFISICAL_GATEWAY_ENROLLMENT_TOKEN"
+	EnrollMethodStatic                     = "static"
 )
 
 // gatewayConfPath returns the path to the gateway config file.

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	INFISICAL_GATEWAY_ACCESS_TOKEN_KEY = "INFISICAL_GATEWAY_ACCESS_TOKEN"
-	INFISICAL_GATEWAY_DOMAIN_KEY       = "INFISICAL_GATEWAY_DOMAIN"
+	INFISICAL_GATEWAY_ACCESS_TOKEN_KEY    = "INFISICAL_GATEWAY_ACCESS_TOKEN"
+	INFISICAL_GATEWAY_DOMAIN_KEY          = "INFISICAL_GATEWAY_DOMAIN"
+	INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY = "INFISICAL_GATEWAY_ENROLLMENT_TOKEN"
 )
 
 // gatewayConfPath returns the path to the gateway config file.
@@ -116,6 +117,16 @@ func LoadStoredDomain() (string, error) {
 // SaveDomain writes the Infisical domain to the config file.
 func SaveDomain(domain string) error {
 	return saveConfKey(INFISICAL_GATEWAY_DOMAIN_KEY, domain)
+}
+
+// LoadStoredEnrollmentToken reads the enrollment token from the config file.
+func LoadStoredEnrollmentToken() (string, error) {
+	return loadConfKey(INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY)
+}
+
+// SaveEnrollmentToken writes the enrollment token to the config file.
+func SaveEnrollmentToken(token string) error {
+	return saveConfKey(INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY, token)
 }
 
 // GetConfPathDisplay returns the config path for display in log messages,

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -16,7 +16,7 @@ const (
 // gatewayConfPath returns the path to the gateway config file.
 // Uses /etc/infisical/gateway.conf when running as root, otherwise ~/.infisical/gateway.conf.
 func gatewayConfPath() (string, error) {
-	if os.Getuid() == 0 {
+	if os.Geteuid() == 0 {
 		return "/etc/infisical/gateway.conf", nil
 	}
 

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -15,11 +15,12 @@ const (
 	EnrollMethodStatic                     = "static"
 )
 
-// gatewayConfPath returns the path to the gateway config file.
-// Uses /etc/infisical/gateway.conf when running as root, otherwise ~/.infisical/gateway.conf.
-func gatewayConfPath() (string, error) {
+// gatewayConfPath returns the path to the gateway config file scoped by name.
+// Uses /etc/infisical/gateways/<name>.conf when running as root,
+// otherwise ~/.infisical/gateways/<name>.conf.
+func gatewayConfPath(name string) (string, error) {
 	if os.Geteuid() == 0 {
-		return "/etc/infisical/gateway.conf", nil
+		return filepath.Join("/etc/infisical/gateways", name+".conf"), nil
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -27,12 +28,12 @@ func gatewayConfPath() (string, error) {
 		return "", fmt.Errorf("unable to determine home directory: %w", err)
 	}
 
-	return filepath.Join(homeDir, ".infisical", "gateway.conf"), nil
+	return filepath.Join(homeDir, ".infisical", "gateways", name+".conf"), nil
 }
 
-// loadConfKey reads a key from the config file. Returns empty string if not found.
-func loadConfKey(key string) (string, error) {
-	confPath, err := gatewayConfPath()
+// loadConfKey reads a key from the named gateway's config file. Returns empty string if not found.
+func loadConfKey(name, key string) (string, error) {
+	confPath, err := gatewayConfPath(name)
 	if err != nil {
 		return "", err
 	}
@@ -56,10 +57,10 @@ func loadConfKey(key string) (string, error) {
 	return "", nil
 }
 
-// saveConfKey writes a key=value pair to the config file, preserving other keys.
+// saveConfKey writes a key=value pair to the named gateway's config file, preserving other keys.
 // The file is created with 0600 permissions (owner read/write only).
-func saveConfKey(key, value string) error {
-	confPath, err := gatewayConfPath()
+func saveConfKey(name, key, value string) error {
+	confPath, err := gatewayConfPath(name)
 	if err != nil {
 		return err
 	}
@@ -96,49 +97,46 @@ func saveConfKey(key, value string) error {
 
 // LoadStoredAccessToken reads the gateway access token from the environment or config file.
 // Env var takes precedence over the config file.
-// Returns an empty string if neither source has the token set.
-func LoadStoredAccessToken() (string, error) {
+func LoadStoredAccessToken(name string) (string, error) {
 	if envToken := os.Getenv(INFISICAL_GATEWAY_ACCESS_TOKEN_KEY); envToken != "" {
 		return envToken, nil
 	}
-	return loadConfKey(INFISICAL_GATEWAY_ACCESS_TOKEN_KEY)
+	return loadConfKey(name, INFISICAL_GATEWAY_ACCESS_TOKEN_KEY)
 }
 
 // SaveAccessToken writes the gateway access token to the config file.
-func SaveAccessToken(token string) error {
-	return saveConfKey(INFISICAL_GATEWAY_ACCESS_TOKEN_KEY, token)
+func SaveAccessToken(name, token string) error {
+	return saveConfKey(name, INFISICAL_GATEWAY_ACCESS_TOKEN_KEY, token)
 }
 
 // LoadStoredDomain reads the Infisical domain from the gateway config file.
-// Returns empty string if not set (caller should use the default).
-func LoadStoredDomain() (string, error) {
-	return loadConfKey(INFISICAL_GATEWAY_DOMAIN_KEY)
+func LoadStoredDomain(name string) (string, error) {
+	return loadConfKey(name, INFISICAL_GATEWAY_DOMAIN_KEY)
 }
 
 // SaveDomain writes the Infisical domain to the config file.
-func SaveDomain(domain string) error {
-	return saveConfKey(INFISICAL_GATEWAY_DOMAIN_KEY, domain)
+func SaveDomain(name, domain string) error {
+	return saveConfKey(name, INFISICAL_GATEWAY_DOMAIN_KEY, domain)
 }
 
 // LoadStoredEnrollmentToken reads the enrollment token from the config file.
-func LoadStoredEnrollmentToken() (string, error) {
-	return loadConfKey(INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY)
+func LoadStoredEnrollmentToken(name string) (string, error) {
+	return loadConfKey(name, INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY)
 }
 
 // SaveEnrollmentToken writes the enrollment token to the config file.
-func SaveEnrollmentToken(token string) error {
-	return saveConfKey(INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY, token)
+func SaveEnrollmentToken(name, token string) error {
+	return saveConfKey(name, INFISICAL_GATEWAY_ENROLLMENT_TOKEN_KEY, token)
 }
 
-// GetConfPathDisplay returns the config path for display in log messages,
-// without returning an error (falls back to a sensible default).
-func GetConfPathDisplay() string {
-	path, err := gatewayConfPath()
+// GetConfPathDisplay returns the config path for display in log messages.
+func GetConfPathDisplay(name string) string {
+	path, err := gatewayConfPath(name)
 	if err != nil {
 		if runtime.GOOS == "linux" {
-			return "/etc/infisical/gateway.conf"
+			return "/etc/infisical/gateways/" + name + ".conf"
 		}
-		return "~/.infisical/gateway.conf"
+		return "~/.infisical/gateways/" + name + ".conf"
 	}
 	return path
 }

--- a/packages/gateway-v2/gateway.go
+++ b/packages/gateway-v2/gateway.go
@@ -82,6 +82,7 @@ type GatewayConfig struct {
 	IdentityToken  string
 	SSHPort        int
 	ReconnectDelay time.Duration
+	UseV3Connect   bool // Use V3 /connect endpoint instead of V2 /gateways for cert refresh
 }
 
 type pamSessionEntry struct {
@@ -505,10 +506,19 @@ func (g *Gateway) handleConnection(client *ssh.Client) error {
 }
 
 func (g *Gateway) registerGateway() error {
-	certResp, err := api.CallRegisterGateway(g.httpClient, api.RegisterGatewayRequest{
-		RelayName: g.config.RelayName,
-		Name:      g.config.Name,
-	})
+	var certResp api.RegisterGatewayResponse
+	var err error
+
+	if g.config.UseV3Connect {
+		certResp, err = api.CallConnectGateway(g.httpClient, api.ConnectGatewayRequest{
+			RelayName: g.config.RelayName,
+		})
+	} else {
+		certResp, err = api.CallRegisterGateway(g.httpClient, api.RegisterGatewayRequest{
+			RelayName: g.config.RelayName,
+			Name:      g.config.Name,
+		})
+	}
 	if err != nil {
 		return fmt.Errorf("failed to register gateway: %v", err)
 	}

--- a/packages/gateway-v2/gateway.go
+++ b/packages/gateway-v2/gateway.go
@@ -505,12 +505,10 @@ func (g *Gateway) handleConnection(client *ssh.Client) error {
 }
 
 func (g *Gateway) registerGateway() error {
-	body := api.RegisterGatewayRequest{
+	certResp, err := api.CallRegisterGateway(g.httpClient, api.RegisterGatewayRequest{
 		RelayName: g.config.RelayName,
 		Name:      g.config.Name,
-	}
-
-	certResp, err := api.CallRegisterGateway(g.httpClient, body)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to register gateway: %v", err)
 	}

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -64,6 +64,61 @@ func InstallGatewaySystemdService(token string, domain string, name string, rela
 	return nil
 }
 
+// InstallEnrolledGatewaySystemdService installs the systemd service for a gateway that was
+// enrolled via the enrollment token flow. It writes the long-lived gateway access token
+// (not a machine identity token) into the environment file.
+func InstallEnrolledGatewaySystemdService(accessToken string, domain string, name string, relayName string, serviceLogFile string) error {
+	if runtime.GOOS != "linux" {
+		log.Info().Msg("Skipping systemd service installation - not on Linux")
+		return nil
+	}
+
+	if os.Geteuid() != 0 {
+		log.Info().Msg("Skipping systemd service installation - not running as root/sudo")
+		return nil
+	}
+
+	configDir := "/etc/infisical"
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %v", err)
+	}
+
+	configContent := fmt.Sprintf("%s=%s\n", INFISICAL_GATEWAY_ACCESS_TOKEN_KEY, accessToken)
+	if domain != "" {
+		configContent += fmt.Sprintf("INFISICAL_API_URL=%s\n", domain)
+	}
+	if name != "" {
+		configContent += fmt.Sprintf("%s=%s\n", GATEWAY_NAME_ENV_NAME, name)
+	}
+	if relayName != "" {
+		configContent += fmt.Sprintf("%s=%s\n", RELAY_NAME_ENV_NAME, relayName)
+	}
+
+	environmentFilePath := filepath.Join(configDir, "gateway.conf")
+	if err := os.WriteFile(environmentFilePath, []byte(configContent), 0600); err != nil {
+		return fmt.Errorf("failed to write environment file: %v", err)
+	}
+
+	if err := util.WriteSystemdServiceFile(serviceLogFile, environmentFilePath, "infisical-gateway", "gateway", "Infisical Gateway Service"); err != nil {
+		return fmt.Errorf("failed to write systemd service file: %v", err)
+	}
+
+	if err := util.WriteLogrotateFile(serviceLogFile, "infisical-gateway"); err != nil {
+		return fmt.Errorf("failed to write logrotate file: %v", err)
+	}
+
+	reloadCmd := exec.Command("systemctl", "daemon-reload")
+	if err := reloadCmd.Run(); err != nil {
+		return fmt.Errorf("failed to reload systemd: %v", err)
+	}
+
+	log.Info().Msg("Successfully installed systemd service")
+	log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
+	log.Info().Msg("To enable the service on boot, run: sudo systemctl enable infisical-gateway")
+
+	return nil
+}
+
 func UninstallGatewaySystemdService() error {
 	if runtime.GOOS != "linux" {
 		log.Info().Msg("Skipping systemd service uninstallation - not on Linux")

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -148,10 +148,16 @@ func UninstallGatewaySystemdService() error {
 		return fmt.Errorf("failed to remove systemd service file: %v", err)
 	}
 
-	// Remove the configuration file
+	// Remove the legacy configuration file
 	configPath := "/etc/infisical/gateway.conf"
 	if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove config file: %v", err)
+	}
+
+	// Remove per-gateway config files from enrollment flow
+	gatewaysDir := "/etc/infisical/gateways"
+	if err := os.RemoveAll(gatewaysDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove gateways config directory: %v", err)
 	}
 
 	// Reload systemd to apply changes


### PR DESCRIPTION
# Description 📣

CLI support for enrollment token-based gateway registration. Gateways can now enroll and start in a single command using a one-time token from the UI, without requiring a machine identity.

- `gateway start --enroll-method=static --token=<token>` enrolls and starts in one step
- Gateway name as positional arg: `gateway start my-gateway --token=<token>`
- `--name` flag kept as deprecated alias for backwards compatibility
- Stored access token and domain persistence in `gateway.conf`
- `gateway systemd install` supports enrollment token flow
- Explicit `--token`/`--auth-method` flags override stored token

## Type ✨

- [x] New feature

# Tests 🛠️

```sh
# Enrollment flow
./infisical gateway start my-gateway --enroll-method=static --token=<token> --domain=http://localhost:8080

# Stored token flow (after enrollment)
./infisical gateway start my-gateway

# Legacy identity flow (unchanged)
./infisical gateway start my-gateway --token=<identity-token>

# Systemd install
sudo infisical gateway systemd install my-gateway --enroll-method=static --token=<token> --domain=<url>
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝