### PR TITLE
Saif/pam 16feat(pam): gateway auth for kubernetes8 kubernetes gateway mediated authentication

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -187,19 +187,21 @@ cd e2e
 go test -v -timeout 30m -count=1 github.com/infisical/cli/e2e-tests/pam
 ```
 
-To run a specific test (e.g., only SSH or only Postgres):
+To run a specific test (e.g., only SSH, Postgres, or Redis):
 
 ```bash
 cd e2e
 go test -v -timeout 30m -count=1 -run TestPAM_SSH github.com/infisical/cli/e2e-tests/pam
 go test -v -timeout 30m -count=1 -run TestPAM_Postgres github.com/infisical/cli/e2e-tests/pam
+go test -v -timeout 5m -count=1 -run TestPAM_Redis github.com/infisical/cli/e2e-tests/pam
 ```
 
-To run a specific sub-test (e.g., only certificate auth within SSH):
+To run a specific sub-test (e.g., only certificate auth within SSH, or ACL over SSL within Redis):
 
 ```bash
 cd e2e
 go test -v -timeout 30m -count=1 -run TestPAM_SSH/certificate github.com/infisical/cli/e2e-tests/pam
+go test -v -timeout 5m -count=1 -run TestPAM_Redis/acl-over-ssl github.com/infisical/cli/e2e-tests/pam
 ```
 
 **Prerequisites:**

--- a/e2e/agent/agent_helpers.go
+++ b/e2e/agent/agent_helpers.go
@@ -302,12 +302,13 @@ func (h *CertAgentTestHelper) CreateAcmeCA(dnsConnectionID, directoryUrl string)
 			AccountEmail       string             `json:"accountEmail"`
 			DirectoryUrl       string             `json:"directoryUrl"`
 			DnsAppConnectionId openapi_types.UUID `json:"dnsAppConnectionId"`
-			DnsProviderConfig  struct {
+			DnsProviderConfig struct {
 				HostedZoneId string                                                                                `json:"hostedZoneId"`
 				Provider     client.CreateAcmeCertificateAuthorityV1JSONBodyConfigurationDnsProviderConfigProvider `json:"provider"`
 			} `json:"dnsProviderConfig"`
-			EabHmacKey *string `json:"eabHmacKey,omitempty"`
-			EabKid     *string `json:"eabKid,omitempty"`
+			DnsResolver *string `json:"dnsResolver,omitempty"`
+			EabHmacKey  *string `json:"eabHmacKey,omitempty"`
+			EabKid      *string `json:"eabKid,omitempty"`
 		}{
 			DnsAppConnectionId: uuid.MustParse(dnsConnectionID),
 			DnsProviderConfig: struct {
@@ -380,12 +381,13 @@ func (h *CertAgentTestHelper) CreateAcmeCARaw(name, dnsConnectionID, directoryUr
 			AccountEmail       string             `json:"accountEmail"`
 			DirectoryUrl       string             `json:"directoryUrl"`
 			DnsAppConnectionId openapi_types.UUID `json:"dnsAppConnectionId"`
-			DnsProviderConfig  struct {
+			DnsProviderConfig struct {
 				HostedZoneId string                                                                                `json:"hostedZoneId"`
 				Provider     client.CreateAcmeCertificateAuthorityV1JSONBodyConfigurationDnsProviderConfigProvider `json:"provider"`
 			} `json:"dnsProviderConfig"`
-			EabHmacKey *string `json:"eabHmacKey,omitempty"`
-			EabKid     *string `json:"eabKid,omitempty"`
+			DnsResolver *string `json:"dnsResolver,omitempty"`
+			EabHmacKey  *string `json:"eabHmacKey,omitempty"`
+			EabKid      *string `json:"eabKid,omitempty"`
 		}{
 			DnsAppConnectionId: uuid.MustParse(dnsConnectionID),
 			DnsProviderConfig: struct {

--- a/e2e/openapi-cfg.yaml
+++ b/e2e/openapi-cfg.yaml
@@ -36,3 +36,4 @@ output-options:
     - createPostgresPamAccount
     - createSshPamResource
     - createSshPamAccount
+    - createRedisPamAccount

--- a/e2e/packages/client/client.gen.go
+++ b/e2e/packages/client/client.gen.go
@@ -22,6 +22,11 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for CreateCloudflareAppConnectionJSONBodyIsAutoRotationEnabled.
+const (
+	CreateCloudflareAppConnectionJSONBodyIsAutoRotationEnabledFalse CreateCloudflareAppConnectionJSONBodyIsAutoRotationEnabled = false
+)
+
 // Defines values for CreateCloudflareAppConnectionJSONBodyIsPlatformManagedCredentials.
 const (
 	CreateCloudflareAppConnectionJSONBodyIsPlatformManagedCredentialsFalse CreateCloudflareAppConnectionJSONBodyIsPlatformManagedCredentials = false
@@ -221,6 +226,7 @@ const (
 	Acme CreateCertificateProfileJSONBodyEnrollmentType = "acme"
 	Api  CreateCertificateProfileJSONBodyEnrollmentType = "api"
 	Est  CreateCertificateProfileJSONBodyEnrollmentType = "est"
+	Scep CreateCertificateProfileJSONBodyEnrollmentType = "scep"
 )
 
 // Defines values for CreateCertificateProfileJSONBodyIssuerType.
@@ -336,8 +342,8 @@ const (
 
 // Defines values for GetSecretByNameV4ParamsIncludeImports.
 const (
-	False GetSecretByNameV4ParamsIncludeImports = "false"
-	True  GetSecretByNameV4ParamsIncludeImports = "true"
+	GetSecretByNameV4ParamsIncludeImportsFalse GetSecretByNameV4ParamsIncludeImports = "false"
+	GetSecretByNameV4ParamsIncludeImportsTrue  GetSecretByNameV4ParamsIncludeImports = "true"
 )
 
 // Defines values for UpdateSecretV4JSONBodyType.
@@ -368,6 +374,9 @@ type CreateCloudflareAppConnectionJSONBody struct {
 	// GatewayId Not supported for Cloudflare Connections.
 	GatewayId *CreateCloudflareAppConnectionJSONBody_GatewayId `json:"gatewayId,omitempty"`
 
+	// IsAutoRotationEnabled Not supported for Cloudflare Connections.
+	IsAutoRotationEnabled *CreateCloudflareAppConnectionJSONBodyIsAutoRotationEnabled `json:"isAutoRotationEnabled,omitempty"`
+
 	// IsPlatformManagedCredentials Not supported for Cloudflare Connections.
 	IsPlatformManagedCredentials *CreateCloudflareAppConnectionJSONBodyIsPlatformManagedCredentials `json:"isPlatformManagedCredentials,omitempty"`
 
@@ -376,6 +385,9 @@ type CreateCloudflareAppConnectionJSONBody struct {
 
 	// ProjectId The ID of the project to create the Cloudflare Connection in.
 	ProjectId *string `json:"projectId,omitempty"`
+
+	// Rotation Not supported for Cloudflare Connections.
+	Rotation *CreateCloudflareAppConnectionJSONBody_Rotation `json:"rotation,omitempty"`
 }
 
 // CreateCloudflareAppConnectionJSONBodyGatewayId0 defines parameters for CreateCloudflareAppConnection.
@@ -389,8 +401,22 @@ type CreateCloudflareAppConnectionJSONBody_GatewayId struct {
 	union json.RawMessage
 }
 
+// CreateCloudflareAppConnectionJSONBodyIsAutoRotationEnabled defines parameters for CreateCloudflareAppConnection.
+type CreateCloudflareAppConnectionJSONBodyIsAutoRotationEnabled bool
+
 // CreateCloudflareAppConnectionJSONBodyIsPlatformManagedCredentials defines parameters for CreateCloudflareAppConnection.
 type CreateCloudflareAppConnectionJSONBodyIsPlatformManagedCredentials bool
+
+// CreateCloudflareAppConnectionJSONBodyRotation0 defines parameters for CreateCloudflareAppConnection.
+type CreateCloudflareAppConnectionJSONBodyRotation0 = interface{}
+
+// CreateCloudflareAppConnectionJSONBodyRotation1 defines parameters for CreateCloudflareAppConnection.
+type CreateCloudflareAppConnectionJSONBodyRotation1 = interface{}
+
+// CreateCloudflareAppConnectionJSONBody_Rotation defines parameters for CreateCloudflareAppConnection.
+type CreateCloudflareAppConnectionJSONBody_Rotation struct {
+	union json.RawMessage
+}
 
 // AttachTokenAuthJSONBody defines parameters for AttachTokenAuth.
 type AttachTokenAuthJSONBody struct {
@@ -486,6 +512,9 @@ type CreateAcmeCertificateAuthorityV1JSONBody struct {
 			Provider CreateAcmeCertificateAuthorityV1JSONBodyConfigurationDnsProviderConfigProvider `json:"provider"`
 		} `json:"dnsProviderConfig"`
 
+		// DnsResolver An optional custom DNS resolver IP address to use for verifying DNS propagation during ACME challenges. Must be a valid IP address (e.g. 8.8.8.8). When not set, the system default DNS resolver is used.
+		DnsResolver *string `json:"dnsResolver,omitempty"`
+
 		// EabHmacKey The External Account Binding (EAB) HMAC key for the ACME Certificate Authority. Required if the ACME provider uses EAB.
 		EabHmacKey *string `json:"eabHmacKey,omitempty"`
 
@@ -527,6 +556,9 @@ type UpdateAcmeCertificateAuthorityV1JSONBody struct {
 			// Provider The DNS provider for the ACME Certificate Authority.
 			Provider UpdateAcmeCertificateAuthorityV1JSONBodyConfigurationDnsProviderConfigProvider `json:"provider"`
 		} `json:"dnsProviderConfig"`
+
+		// DnsResolver An optional custom DNS resolver IP address to use for verifying DNS propagation during ACME challenges. Must be a valid IP address (e.g. 8.8.8.8). When not set, the system default DNS resolver is used.
+		DnsResolver *string `json:"dnsResolver,omitempty"`
 
 		// EabHmacKey The External Account Binding (EAB) HMAC key for the ACME Certificate Authority. Required if the ACME provider uses EAB.
 		EabHmacKey *string `json:"eabHmacKey,omitempty"`
@@ -715,7 +747,12 @@ type CreateCertificateProfileJSONBody struct {
 	ExternalConfigs *CreateCertificateProfileJSONBody_ExternalConfigs `json:"externalConfigs"`
 	IssuerType      *CreateCertificateProfileJSONBodyIssuerType       `json:"issuerType,omitempty"`
 	ProjectId       string                                            `json:"projectId"`
-	Slug            string                                            `json:"slug"`
+	ScepConfig      *struct {
+		AllowCertBasedRenewal   *bool  `json:"allowCertBasedRenewal,omitempty"`
+		ChallengePassword       string `json:"challengePassword"`
+		IncludeCaCertInResponse *bool  `json:"includeCaCertInResponse,omitempty"`
+	} `json:"scepConfig,omitempty"`
+	Slug string `json:"slug"`
 }
 
 // CreateCertificateProfileJSONBodyDefaultsExtendedKeyUsages defines parameters for CreateCertificateProfile.
@@ -787,11 +824,26 @@ type CreatePostgresPamAccountJSONBody struct {
 		Key   string  `json:"key"`
 		Value *string `json:"value,omitempty"`
 	} `json:"metadata,omitempty"`
-	Name                    string             `json:"name"`
-	RequireMfa              *bool              `json:"requireMfa,omitempty"`
-	ResourceId              openapi_types.UUID `json:"resourceId"`
-	RotationEnabled         bool               `json:"rotationEnabled"`
-	RotationIntervalSeconds *float32           `json:"rotationIntervalSeconds"`
+	Name       string             `json:"name"`
+	RequireMfa *bool              `json:"requireMfa,omitempty"`
+	ResourceId openapi_types.UUID `json:"resourceId"`
+}
+
+// CreateRedisPamAccountJSONBody defines parameters for CreateRedisPamAccount.
+type CreateRedisPamAccountJSONBody struct {
+	Credentials struct {
+		Password *string `json:"password,omitempty"`
+		Username *string `json:"username,omitempty"`
+	} `json:"credentials"`
+	Description *string             `json:"description"`
+	FolderId    *openapi_types.UUID `json:"folderId,omitempty"`
+	Metadata    *[]struct {
+		Key   string  `json:"key"`
+		Value *string `json:"value,omitempty"`
+	} `json:"metadata,omitempty"`
+	Name       string             `json:"name"`
+	RequireMfa *bool              `json:"requireMfa,omitempty"`
+	ResourceId openapi_types.UUID `json:"resourceId"`
 }
 
 // CreateSshPamAccountJSONBody defines parameters for CreateSshPamAccount.
@@ -803,11 +855,9 @@ type CreateSshPamAccountJSONBody struct {
 		Key   string  `json:"key"`
 		Value *string `json:"value,omitempty"`
 	} `json:"metadata,omitempty"`
-	Name                    string             `json:"name"`
-	RequireMfa              *bool              `json:"requireMfa,omitempty"`
-	ResourceId              openapi_types.UUID `json:"resourceId"`
-	RotationEnabled         bool               `json:"rotationEnabled"`
-	RotationIntervalSeconds *float32           `json:"rotationIntervalSeconds"`
+	Name       string             `json:"name"`
+	RequireMfa *bool              `json:"requireMfa,omitempty"`
+	ResourceId openapi_types.UUID `json:"resourceId"`
 }
 
 // CreateSshPamAccountJSONBodyCredentials0 defines parameters for CreateSshPamAccount.
@@ -1235,6 +1285,9 @@ type CreateMachineIdentityJSONRequestBody CreateMachineIdentityJSONBody
 // CreatePostgresPamAccountJSONRequestBody defines body for CreatePostgresPamAccount for application/json ContentType.
 type CreatePostgresPamAccountJSONRequestBody CreatePostgresPamAccountJSONBody
 
+// CreateRedisPamAccountJSONRequestBody defines body for CreateRedisPamAccount for application/json ContentType.
+type CreateRedisPamAccountJSONRequestBody CreateRedisPamAccountJSONBody
+
 // CreateSshPamAccountJSONRequestBody defines body for CreateSshPamAccount for application/json ContentType.
 type CreateSshPamAccountJSONRequestBody CreateSshPamAccountJSONBody
 
@@ -1405,6 +1458,11 @@ type ClientInterface interface {
 	CreatePostgresPamAccountWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CreatePostgresPamAccount(ctx context.Context, body CreatePostgresPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateRedisPamAccountWithBody request with any body
+	CreateRedisPamAccountWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateRedisPamAccount(ctx context.Context, body CreateRedisPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateSshPamAccountWithBody request with any body
 	CreateSshPamAccountWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1783,6 +1841,30 @@ func (c *Client) CreatePostgresPamAccountWithBody(ctx context.Context, contentTy
 
 func (c *Client) CreatePostgresPamAccount(ctx context.Context, body CreatePostgresPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreatePostgresPamAccountRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateRedisPamAccountWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateRedisPamAccountRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateRedisPamAccount(ctx context.Context, body CreateRedisPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateRedisPamAccountRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2644,6 +2726,46 @@ func NewCreatePostgresPamAccountRequestWithBody(server string, contentType strin
 	}
 
 	operationPath := fmt.Sprintf("/api/v1/pam/accounts/postgres")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCreateRedisPamAccountRequest calls the generic CreateRedisPamAccount builder with application/json body
+func NewCreateRedisPamAccountRequest(server string, body CreateRedisPamAccountJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateRedisPamAccountRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateRedisPamAccountRequestWithBody generates requests for CreateRedisPamAccount with any type of body
+func NewCreateRedisPamAccountRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/pam/accounts/redis")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3606,6 +3728,11 @@ type ClientWithResponsesInterface interface {
 
 	CreatePostgresPamAccountWithResponse(ctx context.Context, body CreatePostgresPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*CreatePostgresPamAccountResponse, error)
 
+	// CreateRedisPamAccountWithBodyWithResponse request with any body
+	CreateRedisPamAccountWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRedisPamAccountResponse, error)
+
+	CreateRedisPamAccountWithResponse(ctx context.Context, body CreateRedisPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateRedisPamAccountResponse, error)
+
 	// CreateSshPamAccountWithBodyWithResponse request with any body
 	CreateSshPamAccountWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSshPamAccountResponse, error)
 
@@ -3851,6 +3978,7 @@ type CreateCloudflareAppConnection200AppConnection0 struct {
 	Description                  *string                                              `json:"description"`
 	GatewayId                    *openapi_types.UUID                                  `json:"gatewayId"`
 	Id                           openapi_types.UUID                                   `json:"id"`
+	IsAutoRotationEnabled        *bool                                                `json:"isAutoRotationEnabled,omitempty"`
 	IsPlatformManagedCredentials *bool                                                `json:"isPlatformManagedCredentials"`
 	Method                       CreateCloudflareAppConnection200AppConnection0Method `json:"method"`
 	Name                         string                                               `json:"name"`
@@ -3861,12 +3989,37 @@ type CreateCloudflareAppConnection200AppConnection0 struct {
 		Slug string `json:"slug"`
 		Type string `json:"type"`
 	} `json:"project"`
-	ProjectId *string   `json:"projectId"`
+	ProjectId *string `json:"projectId"`
+
+	// Rotation The credential rotation configuration, if configured.
+	Rotation *struct {
+		// LastRotationMessage The message from the last rotation attempt.
+		LastRotationMessage *string `json:"lastRotationMessage"`
+
+		// NextRotationAt The next scheduled rotation time.
+		NextRotationAt *time.Time `json:"nextRotationAt"`
+
+		// RotateAtUtc The UTC time of day at which rotation should occur.
+		RotateAtUtc struct {
+			// Hours The hour (0-23) at which to rotate.
+			Hours float32 `json:"hours"`
+
+			// Minutes The minute (0-59) at which to rotate.
+			Minutes float32 `json:"minutes"`
+		} `json:"rotateAtUtc"`
+
+		// RotationInterval The interval in days between credential rotations.
+		RotationInterval float32 `json:"rotationInterval"`
+
+		// RotationStatus The status of the last rotation attempt.
+		RotationStatus CreateCloudflareAppConnection200AppConnection0RotationRotationStatus `json:"rotationStatus"`
+	} `json:"rotation,omitempty"`
 	UpdatedAt time.Time `json:"updatedAt"`
 	Version   *float32  `json:"version,omitempty"`
 }
 type CreateCloudflareAppConnection200AppConnection0App string
 type CreateCloudflareAppConnection200AppConnection0Method string
+type CreateCloudflareAppConnection200AppConnection0RotationRotationStatus string
 type CreateCloudflareAppConnection_200_AppConnection struct {
 	union json.RawMessage
 }
@@ -4316,6 +4469,9 @@ type CreateAcmeCertificateAuthorityV1Response struct {
 				Provider CreateAcmeCertificateAuthorityV1200ConfigurationDnsProviderConfigProvider `json:"provider"`
 			} `json:"dnsProviderConfig"`
 
+			// DnsResolver An optional custom DNS resolver IP address to use for verifying DNS propagation during ACME challenges. Must be a valid IP address (e.g. 8.8.8.8). When not set, the system default DNS resolver is used.
+			DnsResolver *string `json:"dnsResolver,omitempty"`
+
 			// EabHmacKey The External Account Binding (EAB) HMAC key for the ACME Certificate Authority. Required if the ACME provider uses EAB.
 			EabHmacKey *string `json:"eabHmacKey,omitempty"`
 
@@ -4414,6 +4570,9 @@ type UpdateAcmeCertificateAuthorityV1Response struct {
 				// Provider The DNS provider for the ACME Certificate Authority.
 				Provider UpdateAcmeCertificateAuthorityV1200ConfigurationDnsProviderConfigProvider `json:"provider"`
 			} `json:"dnsProviderConfig"`
+
+			// DnsResolver An optional custom DNS resolver IP address to use for verifying DNS propagation during ACME challenges. Must be a valid IP address (e.g. 8.8.8.8). When not set, the system default DNS resolver is used.
+			DnsResolver *string `json:"dnsResolver,omitempty"`
 
 			// EabHmacKey The External Account Binding (EAB) HMAC key for the ACME Certificate Authority. Required if the ACME provider uses EAB.
 			EabHmacKey *string `json:"eabHmacKey,omitempty"`
@@ -4763,6 +4922,7 @@ type CreateCertificateProfileResponse struct {
 			Id              openapi_types.UUID                                               `json:"id"`
 			IssuerType      *string                                                          `json:"issuerType,omitempty"`
 			ProjectId       string                                                           `json:"projectId"`
+			ScepConfigId    *openapi_types.UUID                                              `json:"scepConfigId"`
 			Slug            string                                                           `json:"slug"`
 			UpdatedAt       time.Time                                                        `json:"updatedAt"`
 		} `json:"certificateProfile"`
@@ -4957,12 +5117,10 @@ type CreatePostgresPamAccountResponse struct {
 				ResourceType                  string             `json:"resourceType"`
 				RotationCredentialsConfigured bool               `json:"rotationCredentialsConfigured"`
 			} `json:"resource"`
-			ResourceId              openapi_types.UUID                             `json:"resourceId"`
-			ResourceType            CreatePostgresPamAccount200AccountResourceType `json:"resourceType"`
-			RotationEnabled         *bool                                          `json:"rotationEnabled,omitempty"`
-			RotationIntervalSeconds *float32                                       `json:"rotationIntervalSeconds"`
-			RotationStatus          *string                                        `json:"rotationStatus"`
-			UpdatedAt               time.Time                                      `json:"updatedAt"`
+			ResourceId     openapi_types.UUID                             `json:"resourceId"`
+			ResourceType   CreatePostgresPamAccount200AccountResourceType `json:"resourceType"`
+			RotationStatus *string                                        `json:"rotationStatus"`
+			UpdatedAt      time.Time                                      `json:"updatedAt"`
 		} `json:"account"`
 	}
 	JSON400 *struct {
@@ -5028,6 +5186,106 @@ func (r CreatePostgresPamAccountResponse) StatusCode() int {
 	return 0
 }
 
+type CreateRedisPamAccountResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Account struct {
+			CreatedAt   time.Time `json:"createdAt"`
+			Credentials struct {
+				Username *string `json:"username,omitempty"`
+			} `json:"credentials"`
+			Description                  *string             `json:"description"`
+			DiscoveryFingerprint         *string             `json:"discoveryFingerprint"`
+			EncryptedLastRotationMessage interface{}         `json:"encryptedLastRotationMessage"`
+			FolderId                     *openapi_types.UUID `json:"folderId"`
+			Id                           openapi_types.UUID  `json:"id"`
+			InternalMetadata             interface{}         `json:"internalMetadata"`
+			LastRotatedAt                *time.Time          `json:"lastRotatedAt"`
+			LastRotationMessage          *string             `json:"lastRotationMessage"`
+			Metadata                     *[]struct {
+				Id    openapi_types.UUID `json:"id"`
+				Key   string             `json:"key"`
+				Value *string            `json:"value"`
+			} `json:"metadata,omitempty"`
+			Name       string `json:"name"`
+			ProjectId  string `json:"projectId"`
+			RequireMfa *bool  `json:"requireMfa"`
+			Resource   struct {
+				Id                            openapi_types.UUID `json:"id"`
+				Name                          string             `json:"name"`
+				ResourceType                  string             `json:"resourceType"`
+				RotationCredentialsConfigured bool               `json:"rotationCredentialsConfigured"`
+			} `json:"resource"`
+			ResourceId     openapi_types.UUID                          `json:"resourceId"`
+			ResourceType   CreateRedisPamAccount200AccountResourceType `json:"resourceType"`
+			RotationStatus *string                                     `json:"rotationStatus"`
+			UpdatedAt      time.Time                                   `json:"updatedAt"`
+		} `json:"account"`
+	}
+	JSON400 *struct {
+		Details    interface{}                        `json:"details,omitempty"`
+		Error      string                             `json:"error"`
+		Message    string                             `json:"message"`
+		ReqId      string                             `json:"reqId"`
+		StatusCode CreateRedisPamAccount400StatusCode `json:"statusCode"`
+	}
+	JSON401 *struct {
+		Error      string                             `json:"error"`
+		Message    string                             `json:"message"`
+		ReqId      string                             `json:"reqId"`
+		StatusCode CreateRedisPamAccount401StatusCode `json:"statusCode"`
+	}
+	JSON403 *struct {
+		Details    interface{}                        `json:"details,omitempty"`
+		Error      string                             `json:"error"`
+		Message    string                             `json:"message"`
+		ReqId      string                             `json:"reqId"`
+		StatusCode CreateRedisPamAccount403StatusCode `json:"statusCode"`
+	}
+	JSON404 *struct {
+		Error      string                             `json:"error"`
+		Message    string                             `json:"message"`
+		ReqId      string                             `json:"reqId"`
+		StatusCode CreateRedisPamAccount404StatusCode `json:"statusCode"`
+	}
+	JSON422 *struct {
+		Error      string                             `json:"error"`
+		Message    interface{}                        `json:"message,omitempty"`
+		ReqId      string                             `json:"reqId"`
+		StatusCode CreateRedisPamAccount422StatusCode `json:"statusCode"`
+	}
+	JSON500 *struct {
+		Error      string                             `json:"error"`
+		Message    string                             `json:"message"`
+		ReqId      string                             `json:"reqId"`
+		StatusCode CreateRedisPamAccount500StatusCode `json:"statusCode"`
+	}
+}
+type CreateRedisPamAccount200AccountResourceType string
+type CreateRedisPamAccount400StatusCode float32
+type CreateRedisPamAccount401StatusCode float32
+type CreateRedisPamAccount403StatusCode float32
+type CreateRedisPamAccount404StatusCode float32
+type CreateRedisPamAccount422StatusCode float32
+type CreateRedisPamAccount500StatusCode float32
+
+// Status returns HTTPResponse.Status
+func (r CreateRedisPamAccountResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateRedisPamAccountResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type CreateSshPamAccountResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -5057,12 +5315,10 @@ type CreateSshPamAccountResponse struct {
 				ResourceType                  string             `json:"resourceType"`
 				RotationCredentialsConfigured bool               `json:"rotationCredentialsConfigured"`
 			} `json:"resource"`
-			ResourceId              openapi_types.UUID                        `json:"resourceId"`
-			ResourceType            CreateSshPamAccount200AccountResourceType `json:"resourceType"`
-			RotationEnabled         *bool                                     `json:"rotationEnabled,omitempty"`
-			RotationIntervalSeconds *float32                                  `json:"rotationIntervalSeconds"`
-			RotationStatus          *string                                   `json:"rotationStatus"`
-			UpdatedAt               time.Time                                 `json:"updatedAt"`
+			ResourceId     openapi_types.UUID                        `json:"resourceId"`
+			ResourceType   CreateSshPamAccount200AccountResourceType `json:"resourceType"`
+			RotationStatus *string                                   `json:"rotationStatus"`
+			UpdatedAt      time.Time                                 `json:"updatedAt"`
 		} `json:"account"`
 	}
 	JSON400 *struct {
@@ -5718,16 +5974,18 @@ type ListGatewaysResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		CreatedAt time.Time          `json:"createdAt"`
-		Heartbeat *time.Time         `json:"heartbeat"`
-		Id        openapi_types.UUID `json:"id"`
-		Identity  struct {
+		ConnectedResourcesCount float32            `json:"connectedResourcesCount"`
+		CreatedAt               time.Time          `json:"createdAt"`
+		Heartbeat               *time.Time         `json:"heartbeat"`
+		Id                      openapi_types.UUID `json:"id"`
+		Identity                struct {
 			Id   string `json:"id"`
 			Name string `json:"name"`
 		} `json:"identity"`
-		IdentityId openapi_types.UUID `json:"identityId"`
-		Name       string             `json:"name"`
-		UpdatedAt  time.Time          `json:"updatedAt"`
+		IdentityId            openapi_types.UUID `json:"identityId"`
+		LastHealthCheckStatus *string            `json:"lastHealthCheckStatus"`
+		Name                  string             `json:"name"`
+		UpdatedAt             time.Time          `json:"updatedAt"`
 	}
 	JSON400 *struct {
 		Details    interface{}               `json:"details,omitempty"`
@@ -6671,6 +6929,23 @@ func (c *ClientWithResponses) CreatePostgresPamAccountWithResponse(ctx context.C
 		return nil, err
 	}
 	return ParseCreatePostgresPamAccountResponse(rsp)
+}
+
+// CreateRedisPamAccountWithBodyWithResponse request with arbitrary body returning *CreateRedisPamAccountResponse
+func (c *ClientWithResponses) CreateRedisPamAccountWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateRedisPamAccountResponse, error) {
+	rsp, err := c.CreateRedisPamAccountWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateRedisPamAccountResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateRedisPamAccountWithResponse(ctx context.Context, body CreateRedisPamAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateRedisPamAccountResponse, error) {
+	rsp, err := c.CreateRedisPamAccount(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateRedisPamAccountResponse(rsp)
 }
 
 // CreateSshPamAccountWithBodyWithResponse request with arbitrary body returning *CreateSshPamAccountResponse
@@ -7746,6 +8021,9 @@ func ParseCreateAcmeCertificateAuthorityV1Response(rsp *http.Response) (*CreateA
 					Provider CreateAcmeCertificateAuthorityV1200ConfigurationDnsProviderConfigProvider `json:"provider"`
 				} `json:"dnsProviderConfig"`
 
+				// DnsResolver An optional custom DNS resolver IP address to use for verifying DNS propagation during ACME challenges. Must be a valid IP address (e.g. 8.8.8.8). When not set, the system default DNS resolver is used.
+				DnsResolver *string `json:"dnsResolver,omitempty"`
+
 				// EabHmacKey The External Account Binding (EAB) HMAC key for the ACME Certificate Authority. Required if the ACME provider uses EAB.
 				EabHmacKey *string `json:"eabHmacKey,omitempty"`
 
@@ -7875,6 +8153,9 @@ func ParseUpdateAcmeCertificateAuthorityV1Response(rsp *http.Response) (*UpdateA
 					// Provider The DNS provider for the ACME Certificate Authority.
 					Provider UpdateAcmeCertificateAuthorityV1200ConfigurationDnsProviderConfigProvider `json:"provider"`
 				} `json:"dnsProviderConfig"`
+
+				// DnsResolver An optional custom DNS resolver IP address to use for verifying DNS propagation during ACME challenges. Must be a valid IP address (e.g. 8.8.8.8). When not set, the system default DNS resolver is used.
+				DnsResolver *string `json:"dnsResolver,omitempty"`
 
 				// EabHmacKey The External Account Binding (EAB) HMAC key for the ACME Certificate Authority. Required if the ACME provider uses EAB.
 				EabHmacKey *string `json:"eabHmacKey,omitempty"`
@@ -8310,6 +8591,7 @@ func ParseCreateCertificateProfileResponse(rsp *http.Response) (*CreateCertifica
 				Id              openapi_types.UUID                                               `json:"id"`
 				IssuerType      *string                                                          `json:"issuerType,omitempty"`
 				ProjectId       string                                                           `json:"projectId"`
+				ScepConfigId    *openapi_types.UUID                                              `json:"scepConfigId"`
 				Slug            string                                                           `json:"slug"`
 				UpdatedAt       time.Time                                                        `json:"updatedAt"`
 			} `json:"certificateProfile"`
@@ -8558,12 +8840,10 @@ func ParseCreatePostgresPamAccountResponse(rsp *http.Response) (*CreatePostgresP
 					ResourceType                  string             `json:"resourceType"`
 					RotationCredentialsConfigured bool               `json:"rotationCredentialsConfigured"`
 				} `json:"resource"`
-				ResourceId              openapi_types.UUID                             `json:"resourceId"`
-				ResourceType            CreatePostgresPamAccount200AccountResourceType `json:"resourceType"`
-				RotationEnabled         *bool                                          `json:"rotationEnabled,omitempty"`
-				RotationIntervalSeconds *float32                                       `json:"rotationIntervalSeconds"`
-				RotationStatus          *string                                        `json:"rotationStatus"`
-				UpdatedAt               time.Time                                      `json:"updatedAt"`
+				ResourceId     openapi_types.UUID                             `json:"resourceId"`
+				ResourceType   CreatePostgresPamAccount200AccountResourceType `json:"resourceType"`
+				RotationStatus *string                                        `json:"rotationStatus"`
+				UpdatedAt      time.Time                                      `json:"updatedAt"`
 			} `json:"account"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -8650,6 +8930,139 @@ func ParseCreatePostgresPamAccountResponse(rsp *http.Response) (*CreatePostgresP
 	return response, nil
 }
 
+// ParseCreateRedisPamAccountResponse parses an HTTP response from a CreateRedisPamAccountWithResponse call
+func ParseCreateRedisPamAccountResponse(rsp *http.Response) (*CreateRedisPamAccountResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateRedisPamAccountResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Account struct {
+				CreatedAt   time.Time `json:"createdAt"`
+				Credentials struct {
+					Username *string `json:"username,omitempty"`
+				} `json:"credentials"`
+				Description                  *string             `json:"description"`
+				DiscoveryFingerprint         *string             `json:"discoveryFingerprint"`
+				EncryptedLastRotationMessage interface{}         `json:"encryptedLastRotationMessage"`
+				FolderId                     *openapi_types.UUID `json:"folderId"`
+				Id                           openapi_types.UUID  `json:"id"`
+				InternalMetadata             interface{}         `json:"internalMetadata"`
+				LastRotatedAt                *time.Time          `json:"lastRotatedAt"`
+				LastRotationMessage          *string             `json:"lastRotationMessage"`
+				Metadata                     *[]struct {
+					Id    openapi_types.UUID `json:"id"`
+					Key   string             `json:"key"`
+					Value *string            `json:"value"`
+				} `json:"metadata,omitempty"`
+				Name       string `json:"name"`
+				ProjectId  string `json:"projectId"`
+				RequireMfa *bool  `json:"requireMfa"`
+				Resource   struct {
+					Id                            openapi_types.UUID `json:"id"`
+					Name                          string             `json:"name"`
+					ResourceType                  string             `json:"resourceType"`
+					RotationCredentialsConfigured bool               `json:"rotationCredentialsConfigured"`
+				} `json:"resource"`
+				ResourceId     openapi_types.UUID                          `json:"resourceId"`
+				ResourceType   CreateRedisPamAccount200AccountResourceType `json:"resourceType"`
+				RotationStatus *string                                     `json:"rotationStatus"`
+				UpdatedAt      time.Time                                   `json:"updatedAt"`
+			} `json:"account"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Details    interface{}                        `json:"details,omitempty"`
+			Error      string                             `json:"error"`
+			Message    string                             `json:"message"`
+			ReqId      string                             `json:"reqId"`
+			StatusCode CreateRedisPamAccount400StatusCode `json:"statusCode"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Error      string                             `json:"error"`
+			Message    string                             `json:"message"`
+			ReqId      string                             `json:"reqId"`
+			StatusCode CreateRedisPamAccount401StatusCode `json:"statusCode"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Details    interface{}                        `json:"details,omitempty"`
+			Error      string                             `json:"error"`
+			Message    string                             `json:"message"`
+			ReqId      string                             `json:"reqId"`
+			StatusCode CreateRedisPamAccount403StatusCode `json:"statusCode"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Error      string                             `json:"error"`
+			Message    string                             `json:"message"`
+			ReqId      string                             `json:"reqId"`
+			StatusCode CreateRedisPamAccount404StatusCode `json:"statusCode"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest struct {
+			Error      string                             `json:"error"`
+			Message    interface{}                        `json:"message,omitempty"`
+			ReqId      string                             `json:"reqId"`
+			StatusCode CreateRedisPamAccount422StatusCode `json:"statusCode"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Error      string                             `json:"error"`
+			Message    string                             `json:"message"`
+			ReqId      string                             `json:"reqId"`
+			StatusCode CreateRedisPamAccount500StatusCode `json:"statusCode"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseCreateSshPamAccountResponse parses an HTTP response from a CreateSshPamAccountWithResponse call
 func ParseCreateSshPamAccountResponse(rsp *http.Response) (*CreateSshPamAccountResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -8691,12 +9104,10 @@ func ParseCreateSshPamAccountResponse(rsp *http.Response) (*CreateSshPamAccountR
 					ResourceType                  string             `json:"resourceType"`
 					RotationCredentialsConfigured bool               `json:"rotationCredentialsConfigured"`
 				} `json:"resource"`
-				ResourceId              openapi_types.UUID                        `json:"resourceId"`
-				ResourceType            CreateSshPamAccount200AccountResourceType `json:"resourceType"`
-				RotationEnabled         *bool                                     `json:"rotationEnabled,omitempty"`
-				RotationIntervalSeconds *float32                                  `json:"rotationIntervalSeconds"`
-				RotationStatus          *string                                   `json:"rotationStatus"`
-				UpdatedAt               time.Time                                 `json:"updatedAt"`
+				ResourceId     openapi_types.UUID                        `json:"resourceId"`
+				ResourceType   CreateSshPamAccount200AccountResourceType `json:"resourceType"`
+				RotationStatus *string                                   `json:"rotationStatus"`
+				UpdatedAt      time.Time                                 `json:"updatedAt"`
 			} `json:"account"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -9542,16 +9953,18 @@ func ParseListGatewaysResponse(rsp *http.Response) (*ListGatewaysResponse, error
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			CreatedAt time.Time          `json:"createdAt"`
-			Heartbeat *time.Time         `json:"heartbeat"`
-			Id        openapi_types.UUID `json:"id"`
-			Identity  struct {
+			ConnectedResourcesCount float32            `json:"connectedResourcesCount"`
+			CreatedAt               time.Time          `json:"createdAt"`
+			Heartbeat               *time.Time         `json:"heartbeat"`
+			Id                      openapi_types.UUID `json:"id"`
+			Identity                struct {
 				Id   string `json:"id"`
 				Name string `json:"name"`
 			} `json:"identity"`
-			IdentityId openapi_types.UUID `json:"identityId"`
-			Name       string             `json:"name"`
-			UpdatedAt  time.Time          `json:"updatedAt"`
+			IdentityId            openapi_types.UUID `json:"identityId"`
+			LastHealthCheckStatus *string            `json:"lastHealthCheckStatus"`
+			Name                  string             `json:"name"`
+			UpdatedAt             time.Time          `json:"updatedAt"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/e2e/packages/infisical/compose.go
+++ b/e2e/packages/infisical/compose.go
@@ -319,7 +319,7 @@ func WithBackendService(options BackendOptions) StackOption {
 				{Target: 9229},
 			},
 			Environment: types.NewMappingWithEquals([]string{
-				"NODE_ENV=development",
+				"NODE_ENV=production",
 				"ENCRYPTION_KEY=6c1fe4e407b8911c104518103505b218",
 				"AUTH_SECRET=5lrMXKKWCVocS/uerPsl7V+TX/aaUaI7iDkgl3tSmLE=",
 				"DB_CONNECTION_URI=postgres://infisical:infisical@db:5432/infisical",

--- a/e2e/packages/infisical/compose.go
+++ b/e2e/packages/infisical/compose.go
@@ -319,7 +319,7 @@ func WithBackendService(options BackendOptions) StackOption {
 				{Target: 9229},
 			},
 			Environment: types.NewMappingWithEquals([]string{
-				"NODE_ENV=production",
+				"NODE_ENV=test",
 				"ENCRYPTION_KEY=6c1fe4e407b8911c104518103505b218",
 				"AUTH_SECRET=5lrMXKKWCVocS/uerPsl7V+TX/aaUaI7iDkgl3tSmLE=",
 				"DB_CONNECTION_URI=postgres://infisical:infisical@db:5432/infisical",

--- a/e2e/pam/postgres_test.go
+++ b/e2e/pam/postgres_test.go
@@ -95,9 +95,8 @@ func TestPAM_Postgres_ConnectToDatabase(t *testing.T) {
 	pgAcctResp, err := infra.ApiClient.CreatePostgresPamAccountWithResponse(
 		ctx,
 		client.CreatePostgresPamAccountJSONRequestBody{
-			ResourceId:      resourceId,
-			Name:            accountName,
-			RotationEnabled: false,
+			ResourceId: resourceId,
+			Name:       accountName,
 			Credentials: struct {
 				Password string `json:"password"`
 				Username string `json:"username"`

--- a/e2e/pam/redis_test.go
+++ b/e2e/pam/redis_test.go
@@ -1,0 +1,444 @@
+package pam
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/infisical/cli/e2e-tests/packages/client"
+	helpers "github.com/infisical/cli/e2e-tests/util"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+func startRedisContainer(t *testing.T, ctx context.Context, opts ...testcontainers.ContainerCustomizer) *tcredis.RedisContainer {
+	container, err := tcredis.Run(ctx, "redis:8.4.0", opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Logf("Failed to terminate Redis container: %v", err)
+		}
+	})
+	return container
+}
+
+func createRedisPamResource(t *testing.T, ctx context.Context, infra *PAMTestInfra, name, host string, port int, sslEnabled bool, sslCertificate *string) uuid.UUID {
+	resp, err := infra.ApiClient.CreateRedisPamResourceWithResponse(
+		ctx,
+		client.CreateRedisPamResourceJSONRequestBody{
+			ProjectId: uuid.MustParse(infra.ProjectId),
+			GatewayId: infra.GatewayId,
+			Name:      name,
+			ConnectionDetails: struct {
+				Host                  string  `json:"host"`
+				Port                  float32 `json:"port"`
+				SslCertificate        *string `json:"sslCertificate,omitempty"`
+				SslEnabled            bool    `json:"sslEnabled"`
+				SslRejectUnauthorized bool    `json:"sslRejectUnauthorized"`
+			}{
+				Host:                  host,
+				Port:                  float32(port),
+				SslEnabled:            sslEnabled,
+				SslCertificate:        sslCertificate,
+				SslRejectUnauthorized: false,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode())
+	slog.Info("Created Redis PAM resource", "resourceId", resp.JSON200.Resource.Id, "name", name)
+	return resp.JSON200.Resource.Id
+}
+
+func createRedisPamAccount(t *testing.T, ctx context.Context, infra *PAMTestInfra, resourceId uuid.UUID, name string, username, password *string) {
+	resp, err := infra.ApiClient.CreateRedisPamAccountWithResponse(
+		ctx,
+		client.CreateRedisPamAccountJSONRequestBody{
+			ResourceId: resourceId,
+			Name:       name,
+			Credentials: struct {
+				Password *string `json:"password,omitempty"`
+				Username *string `json:"username,omitempty"`
+			}{
+				Username: username,
+				Password: password,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode())
+	slog.Info("Created Redis PAM account", "name", name)
+}
+
+func startRedisProxy(t *testing.T, ctx context.Context, infra *PAMTestInfra, resourceName, accountName string) (int, *helpers.Command) {
+	freePort := helpers.GetFreePort()
+	pamCmd := helpers.Command{
+		Test:               t,
+		RunMethod:          helpers.RunMethodSubprocess,
+		DisableTempHomeDir: true,
+		Args: []string{
+			"pam", "redis", "access",
+			"--resource", resourceName,
+			"--account", accountName,
+			"--project-id", infra.ProjectId,
+			"--duration", "5m",
+			"--port", fmt.Sprintf("%d", freePort),
+		},
+		Env: map[string]string{
+			"HOME":              infra.SharedHomeDir,
+			"INFISICAL_API_URL": infra.Infisical.ApiUrl(t),
+		},
+	}
+	pamCmd.Start(ctx)
+	t.Cleanup(pamCmd.Stop)
+
+	// Redis proxy prints the banner to stderr (unlike the Postgres proxy which uses stdout).
+	result := helpers.WaitFor(t, helpers.WaitForOptions{
+		EnsureCmdRunning: &pamCmd,
+		Condition: func() helpers.ConditionResult {
+			if strings.Contains(pamCmd.Stderr(), "Redis Proxy Session Started") {
+				return helpers.ConditionSuccess
+			}
+			return helpers.ConditionWait
+		},
+	})
+	if result != helpers.WaitSuccess {
+		pamCmd.DumpOutput()
+	}
+	require.Equal(t, helpers.WaitSuccess, result, "Redis proxy should start successfully")
+
+	return freePort, &pamCmd
+}
+
+func verifyRedisThroughProxy(t *testing.T, ctx context.Context, pamCmd *helpers.Command, proxyAddr, testKey, testValue string) {
+	var rdb *redis.Client
+	connectResult := helpers.WaitFor(t, helpers.WaitForOptions{
+		EnsureCmdRunning: pamCmd,
+		Interval:         2 * time.Second,
+		Timeout:          30 * time.Second,
+		Condition: func() helpers.ConditionResult {
+			rdb = redis.NewClient(&redis.Options{Addr: proxyAddr})
+			_, err := rdb.Ping(ctx).Result()
+			if err != nil {
+				rdb.Close()
+				slog.Warn("Redis proxy connection attempt failed, retrying...", "error", err)
+				return helpers.ConditionWait
+			}
+			return helpers.ConditionSuccess
+		},
+	})
+	require.Equal(t, helpers.WaitSuccess, connectResult, "Should connect to Redis through proxy")
+	t.Cleanup(func() { rdb.Close() })
+
+	err := rdb.Set(ctx, testKey, testValue, 0).Err()
+	require.NoError(t, err)
+	slog.Info("SET through proxy succeeded", "key", testKey)
+
+	got, err := rdb.Get(ctx, testKey).Result()
+	require.NoError(t, err)
+	require.Equal(t, testValue, got)
+	slog.Info("GET through proxy succeeded", "key", testKey, "value", got)
+}
+
+// generateSelfSignedCert creates a self-signed CA and server certificate for TLS tests.
+// Returns the CA PEM, and writes the server cert + key to the given directory.
+func generateSelfSignedCert(t *testing.T, host, certDir string) (caPEM string) {
+	// Generate CA key and certificate.
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "e2e-test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	// Generate server key and certificate signed by the CA.
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: host},
+		DNSNames:     []string{host, "localhost"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+
+	// Write files to cert directory.
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "ca.crt"), caCertPEM, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "server.crt"), serverCertPEM, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "server.key"), serverKeyPEM, 0600))
+
+	return string(caCertPEM)
+}
+
+func TestPAM_Redis(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	infra := SetupPAMInfra(t, ctx)
+	LoginUser(t, ctx, infra)
+
+	t.Run("no-auth", func(t *testing.T) {
+		container := startRedisContainer(t, ctx)
+
+		redisHost, err := container.Host(ctx)
+		require.NoError(t, err)
+		redisPort, err := container.MappedPort(ctx, "6379")
+		require.NoError(t, err)
+		directAddr := fmt.Sprintf("%s:%d", redisHost, redisPort.Int())
+
+		// Verify Redis is accessible directly.
+		rdb := redis.NewClient(&redis.Options{Addr: directAddr})
+		pong, err := rdb.Ping(ctx).Result()
+		require.NoError(t, err)
+		require.Equal(t, "PONG", pong)
+		rdb.Close()
+		slog.Info("Verified Redis is accessible directly")
+
+		resourceName := "redis-noauth-resource"
+		resourceId := createRedisPamResource(t, ctx, infra, resourceName, redisHost, redisPort.Int(), false, nil)
+		createRedisPamAccount(t, ctx, infra, resourceId, "redis-noauth-account", nil, nil)
+
+		proxyPort, pamCmd := startRedisProxy(t, ctx, infra, resourceName, "redis-noauth-account")
+		proxyAddr := fmt.Sprintf("localhost:%d", proxyPort)
+
+		testKey := "e2e-noauth-key"
+		testValue := "e2e-noauth-value"
+
+		verifyRedisThroughProxy(t, ctx, pamCmd, proxyAddr, testKey, testValue)
+	})
+
+	t.Run("acl-user-password", func(t *testing.T) {
+		const (
+			aclUser = "pamuser"
+			aclPass = "pampassword"
+		)
+
+		confDir := t.TempDir()
+		redisConf := fmt.Sprintf(`user default off
+user %s on >%s ~* +@all -@dangerous
+`, aclUser, aclPass)
+		confPath := filepath.Join(confDir, "redis.conf")
+		require.NoError(t, os.WriteFile(confPath, []byte(redisConf), 0644))
+
+		container := startRedisContainer(t, ctx, tcredis.WithConfigFile(confPath))
+
+		redisHost, err := container.Host(ctx)
+		require.NoError(t, err)
+		redisPort, err := container.MappedPort(ctx, "6379")
+		require.NoError(t, err)
+		directAddr := fmt.Sprintf("%s:%d", redisHost, redisPort.Int())
+
+		// Verify Redis is accessible with ACL credentials directly.
+		rdb := redis.NewClient(&redis.Options{
+			Addr:     directAddr,
+			Username: aclUser,
+			Password: aclPass,
+		})
+		pong, err := rdb.Ping(ctx).Result()
+		require.NoError(t, err)
+		require.Equal(t, "PONG", pong)
+		rdb.Close()
+		slog.Info("Verified Redis is accessible directly with ACL credentials")
+
+		resourceName := "redis-acl-resource"
+		resourceId := createRedisPamResource(t, ctx, infra, resourceName, redisHost, redisPort.Int(), false, nil)
+		username := aclUser
+		password := aclPass
+		createRedisPamAccount(t, ctx, infra, resourceId, "redis-acl-account", &username, &password)
+
+		proxyPort, pamCmd := startRedisProxy(t, ctx, infra, resourceName, "redis-acl-account")
+		proxyAddr := fmt.Sprintf("localhost:%d", proxyPort)
+
+		testKey := "e2e-acl-key"
+		testValue := "e2e-acl-value"
+
+		verifyRedisThroughProxy(t, ctx, pamCmd, proxyAddr, testKey, testValue)
+
+		// Verify ACL permissions are enforced: FLUSHALL should be denied
+		// because the ACL user does not have @dangerous commands.
+		proxyClient := redis.NewClient(&redis.Options{Addr: proxyAddr})
+		t.Cleanup(func() { proxyClient.Close() })
+		err = proxyClient.FlushAll(ctx).Err()
+		require.Error(t, err, "FLUSHALL should be denied for the ACL user")
+		slog.Info("FLUSHALL correctly denied through proxy", "error", err)
+	})
+
+	t.Run("acl-over-ssl", func(t *testing.T) {
+		const (
+			aclUser = "pamuser"
+			aclPass = "pampassword"
+		)
+
+		// Generate self-signed certs at test time.
+		certDir := t.TempDir()
+		caPEM := generateSelfSignedCert(t, "localhost", certDir)
+
+		// Write a Redis config that enables TLS and sets up the ACL user.
+		redisConf := fmt.Sprintf(`tls-port 6379
+port 0
+tls-cert-file /tls/server.crt
+tls-key-file /tls/server.key
+tls-ca-cert-file /tls/ca.crt
+tls-auth-clients no
+
+user default off
+user %s on >%s ~* +@all -@dangerous
+`, aclUser, aclPass)
+		confPath := filepath.Join(certDir, "redis-ssl.conf")
+		require.NoError(t, os.WriteFile(confPath, []byte(redisConf), 0644))
+
+		// Start Redis with TLS config and mounted certs.
+		container := startRedisContainer(t, ctx,
+			tcredis.WithConfigFile(confPath),
+			testcontainers.WithFiles(testcontainers.ContainerFile{
+				HostFilePath:      filepath.Join(certDir, "ca.crt"),
+				ContainerFilePath: "/tls/ca.crt",
+				FileMode:          0644,
+			}),
+			testcontainers.WithFiles(testcontainers.ContainerFile{
+				HostFilePath:      filepath.Join(certDir, "server.crt"),
+				ContainerFilePath: "/tls/server.crt",
+				FileMode:          0644,
+			}),
+			testcontainers.WithFiles(testcontainers.ContainerFile{
+				HostFilePath:      filepath.Join(certDir, "server.key"),
+				ContainerFilePath: "/tls/server.key",
+				FileMode:          0644,
+			}),
+		)
+
+		redisHost, err := container.Host(ctx)
+		require.NoError(t, err)
+		redisPort, err := container.MappedPort(ctx, "6379")
+		require.NoError(t, err)
+		directAddr := fmt.Sprintf("%s:%d", redisHost, redisPort.Int())
+
+		// Verify Redis is accessible directly with TLS + ACL.
+		rdb := redis.NewClient(&redis.Options{
+			Addr:     directAddr,
+			Username: aclUser,
+			Password: aclPass,
+			TLSConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		})
+		pong, err := rdb.Ping(ctx).Result()
+		require.NoError(t, err)
+		require.Equal(t, "PONG", pong)
+		rdb.Close()
+		slog.Info("Verified Redis is accessible directly with TLS + ACL")
+
+		resourceName := "redis-ssl-resource"
+		resourceId := createRedisPamResource(t, ctx, infra, resourceName, redisHost, redisPort.Int(), true, &caPEM)
+		username := aclUser
+		password := aclPass
+		createRedisPamAccount(t, ctx, infra, resourceId, "redis-ssl-account", &username, &password)
+
+		proxyPort, pamCmd := startRedisProxy(t, ctx, infra, resourceName, "redis-ssl-account")
+		proxyAddr := fmt.Sprintf("localhost:%d", proxyPort)
+
+		testKey := "e2e-ssl-key"
+		testValue := "e2e-ssl-value"
+
+		verifyRedisThroughProxy(t, ctx, pamCmd, proxyAddr, testKey, testValue)
+	})
+
+	t.Run("multiple-concurrent-connections", func(t *testing.T) {
+		container := startRedisContainer(t, ctx)
+
+		redisHost, err := container.Host(ctx)
+		require.NoError(t, err)
+		redisPort, err := container.MappedPort(ctx, "6379")
+		require.NoError(t, err)
+		directAddr := fmt.Sprintf("%s:%d", redisHost, redisPort.Int())
+
+		// Verify Redis is accessible directly.
+		rdb := redis.NewClient(&redis.Options{Addr: directAddr})
+		pong, err := rdb.Ping(ctx).Result()
+		require.NoError(t, err)
+		require.Equal(t, "PONG", pong)
+		rdb.Close()
+		slog.Info("Verified Redis is accessible directly")
+
+		resourceName := "redis-concurrent-resource"
+		resourceId := createRedisPamResource(t, ctx, infra, resourceName, redisHost, redisPort.Int(), false, nil)
+		createRedisPamAccount(t, ctx, infra, resourceId, "redis-concurrent-account", nil, nil)
+
+		proxyPort, _ := startRedisProxy(t, ctx, infra, resourceName, "redis-concurrent-account")
+		proxyAddr := fmt.Sprintf("localhost:%d", proxyPort)
+
+		const numClients = 5
+		var wg sync.WaitGroup
+		errs := make([]error, numClients)
+
+		for i := 0; i < numClients; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				rdb := redis.NewClient(&redis.Options{Addr: proxyAddr})
+				defer rdb.Close()
+
+				key := fmt.Sprintf("e2e-concurrent-key-%d", idx)
+				value := fmt.Sprintf("e2e-concurrent-value-%d", idx)
+
+				if err := rdb.Set(ctx, key, value, 0).Err(); err != nil {
+					errs[idx] = fmt.Errorf("SET failed for client %d: %w", idx, err)
+					return
+				}
+				got, err := rdb.Get(ctx, key).Result()
+				if err != nil {
+					errs[idx] = fmt.Errorf("GET failed for client %d: %w", idx, err)
+					return
+				}
+				if got != value {
+					errs[idx] = fmt.Errorf("client %d: expected %q, got %q", idx, value, got)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+		for i, err := range errs {
+			require.NoError(t, err, "concurrent client %d should succeed", i)
+		}
+		slog.Info("All concurrent connections succeeded", "numClients", numClients)
+	})
+}

--- a/e2e/pam/ssh_test.go
+++ b/e2e/pam/ssh_test.go
@@ -78,7 +78,9 @@ func createSSHPamResource(t *testing.T, ctx context.Context, infra *PAMTestInfra
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode())
+	if resp.StatusCode() != http.StatusOK {
+		t.Fatalf("CreateSshPamResource returned %d: %s", resp.StatusCode(), string(resp.Body))
+	}
 	slog.Info("Created SSH PAM resource", "resourceId", resp.JSON200.Resource.Id, "name", name)
 	return resp.JSON200.Resource.Id
 }

--- a/e2e/util/helpers.go
+++ b/e2e/util/helpers.go
@@ -70,6 +70,7 @@ func NewInfisicalService(opts ...InfisicalServiceOption) *InfisicalService {
 		),
 	}
 	svc.WithBackendEnvironment(types.NewMappingWithEquals([]string{
+		"NODE_ENV=development",
 		"ACME_DEVELOPMENT_MODE=true",
 		"ACME_SKIP_UPSTREAM_VALIDATION=true",
 		"BDD_NOCK_API_ENABLED=true",

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -864,6 +864,8 @@ type PAMSessionCredentials struct {
 	Certificate           string `json:"certificate,omitempty"`
 	Url                   string `json:"url,omitempty"`
 	ServiceAccountToken   string `json:"serviceAccountToken,omitempty"`
+	ServiceAccountName    string `json:"serviceAccountName,omitempty"`
+	Namespace             string `json:"namespace,omitempty"`
 }
 
 type MFASessionStatus string

--- a/packages/pam/handlers/kubernetes/proxy.go
+++ b/packages/pam/handlers/kubernetes/proxy.go
@@ -11,11 +11,13 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/Infisical/infisical-merge/packages/pam/session"
+	"github.com/Infisical/infisical-merge/packages/util"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
@@ -24,6 +26,8 @@ type KubernetesProxyConfig struct {
 	TargetApiServer           string
 	AuthMethod                string
 	InjectServiceAccountToken string
+	ImpersonateNamespace      string
+	ImpersonateServiceAccount string
 	TLSConfig                 *tls.Config
 	SessionID                 string
 	SessionLogger             session.SessionLogger
@@ -38,6 +42,33 @@ type KubernetesProxy struct {
 
 func NewKubernetesProxy(config KubernetesProxyConfig) *KubernetesProxy {
 	return &KubernetesProxy{config: config}
+}
+
+// injectAuthHeaders sets the appropriate auth headers based on the configured auth method.
+// For service-account-token: injects the stored Bearer token.
+// For gateway-kubernetes-auth: reads the gateway pod's own token (fresh each call) and sets
+// Impersonate-User/Group headers to act as the target service account.
+func (p *KubernetesProxy) injectAuthHeaders(headers http.Header) error {
+	switch p.config.AuthMethod {
+	case "service-account-token":
+		headers.Set("Authorization", fmt.Sprintf("Bearer %s", p.config.InjectServiceAccountToken))
+	case "gateway-kubernetes-auth":
+		// Read fresh on each request — K8s auto-rotates projected volume tokens
+		token, err := os.ReadFile(util.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)
+		if err != nil {
+			return fmt.Errorf("gateway not running in K8s cluster, unable to read pod service account token: %w", err)
+		}
+		headers.Set("Authorization", fmt.Sprintf("Bearer %s", strings.TrimSpace(string(token))))
+
+		saUser := fmt.Sprintf("system:serviceaccount:%s:%s",
+			p.config.ImpersonateNamespace, p.config.ImpersonateServiceAccount)
+		headers.Set("Impersonate-User", saUser)
+		headers.Set("Impersonate-Group", "system:serviceaccounts")
+		headers.Add("Impersonate-Group", fmt.Sprintf("system:serviceaccounts:%s", p.config.ImpersonateNamespace))
+	default:
+		return fmt.Errorf("unsupported Kubernetes auth method: %s", p.config.AuthMethod)
+	}
+	return nil
 }
 
 func buildHttpInternalServerError(message string) string {
@@ -165,7 +196,14 @@ func (p *KubernetesProxy) HandleConnection(ctx context.Context, clientConn net.C
 			continue // Continue to next request
 		}
 		proxyReq.Header = req.Header.Clone()
-		proxyReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", p.config.InjectServiceAccountToken))
+		if err := p.injectAuthHeaders(proxyReq.Header); err != nil {
+			l.Error().Err(err).Msg("Failed to inject auth headers")
+			_, err = clientConn.Write([]byte(buildHttpInternalServerError(err.Error())))
+			if err != nil {
+				return err
+			}
+			continue
+		}
 
 		resp, err := selfServerClient.Do(proxyReq)
 		if err != nil {
@@ -255,8 +293,10 @@ func (p *KubernetesProxy) forwardWebsocketConnection(
 	sb.WriteString(fmt.Sprintf("%s %s HTTP/1.1\r\n", req.Method, newUrl.RequestURI()))
 	headers := req.Header.Clone()
 	headers.Set("Host", newUrl.Host)
-	// Inject the auth header
-	headers.Set("Authorization", fmt.Sprintf("Bearer %s", p.config.InjectServiceAccountToken))
+	if err := p.injectAuthHeaders(headers); err != nil {
+		l.Error().Err(err).Msg("Failed to inject auth headers for websocket")
+		return err
+	}
 	for key, values := range headers {
 		for _, value := range values {
 			sb.WriteString(fmt.Sprintf("%s: %s\r\n", key, value))

--- a/packages/pam/pam-proxy.go
+++ b/packages/pam/pam-proxy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/Infisical/infisical-merge/packages/pam/handlers"
@@ -17,6 +18,7 @@ import (
 	"github.com/Infisical/infisical-merge/packages/pam/handlers/redis"
 	"github.com/Infisical/infisical-merge/packages/pam/handlers/ssh"
 	"github.com/Infisical/infisical-merge/packages/pam/session"
+	"github.com/Infisical/infisical-merge/packages/util"
 	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
@@ -297,10 +299,37 @@ func HandlePAMProxy(ctx context.Context, conn *tls.Conn, pamConfig *GatewayPAMCo
 			SessionID:                 pamConfig.SessionId,
 			SessionLogger:             sessionLogger,
 		}
+
+		// For gateway-kubernetes-auth, override target URL and TLS with pod's in-cluster credentials
+		if credentials.AuthMethod == "gateway-kubernetes-auth" {
+			kubernetesConfig.ImpersonateNamespace = credentials.Namespace
+			kubernetesConfig.ImpersonateServiceAccount = credentials.ServiceAccountName
+
+			// Auto-discover K8s API URL from env vars
+			k8sHost := util.KUBERNETES_SERVICE_HOST_ENV_NAME
+			k8sPort := util.KUBERNETES_SERVICE_PORT_HTTPS_ENV_NAME
+			if host, port := os.Getenv(k8sHost), os.Getenv(k8sPort); host != "" && port != "" {
+				kubernetesConfig.TargetApiServer = fmt.Sprintf("https://%s:%s", host, port)
+			}
+
+			// Use pod's in-cluster CA cert with strict TLS (ignore resource SSL settings)
+			caCert, err := os.ReadFile(util.KUBERNETES_SERVICE_ACCOUNT_CA_CERT_PATH)
+			if err != nil {
+				log.Warn().Err(err).Msg("Failed to read pod CA cert, falling back to resource TLS config")
+			} else {
+				caCertPool := x509.NewCertPool()
+				caCertPool.AppendCertsFromPEM(caCert)
+				kubernetesConfig.TLSConfig = &tls.Config{
+					RootCAs: caCertPool,
+				}
+			}
+		}
+
 		proxy := kubernetes.NewKubernetesProxy(kubernetesConfig)
 		log.Info().
 			Str("sessionId", pamConfig.SessionId).
 			Str("target", kubernetesConfig.TargetApiServer).
+			Str("authMethod", credentials.AuthMethod).
 			Msg("Starting Kubernetes PAM proxy")
 		return proxy.HandleConnection(ctx, conn)
 	case session.ResourceTypeMongodb:

--- a/packages/pam/session/credentials.go
+++ b/packages/pam/session/credentials.go
@@ -25,6 +25,8 @@ type PAMCredentials struct {
 	SSLCertificate        string
 	Url                   string
 	ServiceAccountToken   string
+	ServiceAccountName    string
+	Namespace             string
 }
 
 type cachedCredentials struct {
@@ -100,6 +102,8 @@ func (cm *CredentialsManager) GetPAMSessionCredentials(sessionId string, expiryT
 		SSLCertificate:        response.Credentials.SSLCertificate,
 		Url:                   response.Credentials.Url,
 		ServiceAccountToken:   response.Credentials.ServiceAccountToken,
+		ServiceAccountName:    response.Credentials.ServiceAccountName,
+		Namespace:             response.Credentials.Namespace,
 	}
 
 	cm.cacheMutex.Lock()


### PR DESCRIPTION
# Description 📣

Gateway-side changes for K8s PAM impersonation. When auth method is `gateway-kubernetes-auth`, the proxy reads its own pod token, sets `Impersonate-User`/`Group` headers, and auto-discovers the K8s API from env vars.

Existing token auth unchanged.


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Needs a K8s cluster with the gateway deployed as a pod. Create a PAM account with "Gateway" auth method, start a session, run kubectl commands.

```sh
# gateway pod SA needs a ClusterRole with impersonate verb on target SAs
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
