### PR TITLE
fix: cli release failing

### DIFF
--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/pre-tag-validation.yml
   cli-tests:
     uses: ./.github/workflows/run-cli-e2e-tests.yml
+    secrets: inherit
 
   # cli-integration-tests:
   #   name: Run tests before deployment

--- a/e2e/packages/infisical/compose.go
+++ b/e2e/packages/infisical/compose.go
@@ -303,7 +303,7 @@ func WithPebbleService() StackOption {
 func WithBackendService(options BackendOptions) StackOption {
 
 	licenseKey, found := os.LookupEnv("INFISICAL_LICENSE_KEY")
-	if !found {
+	if !found || licenseKey == "" {
 		log.Println("INFISICAL_LICENSE_KEY not set, continuing without licensing.")
 	} else {
 		log.Println("INFISICAL_LICENSE_KEY set, continuing with licensing.")


### PR DESCRIPTION
# Description 📣

Fixed github action secrets not being passed down to reusable workflows. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->