### PR TITLE
feat: support fetching imported certificates in cert-agent

### DIFF
--- a/certificate-agent-config.yaml
+++ b/certificate-agent-config.yaml
@@ -11,6 +11,7 @@ auth:
     remove_client_secret_on_read: false
 
 certificates:
+  # Issue a new certificate from a profile
   - profile-name: "my-profile-name"
     project-slug: "my-project-slug"
 
@@ -29,8 +30,8 @@ certificates:
         - "server_auth"
       ttl: "30d"
     lifecycle:
-      renew-before-expiry: "1d"            # When to start checking for renewal before expiration
-      status-check-interval: "6h"          # How often to check certificate status and renewal needs
+      renew-before-expiry: "1d" # When to start checking for renewal before expiration
+      status-check-interval: "6h" # How often to check certificate status and renewal needs
 
     # Post-hooks for automation
     post-hooks:
@@ -55,3 +56,20 @@ certificates:
         path: "./certs/web-server/chain.crt"
         permission: "0644"
         omit-root: true
+
+  # Fetch an existing certificate by ID. Skips issuance entirely.
+  # If private-key.path is configured but the imported certificate has no
+  # private key (e.g. ACME-issued), a warning is logged and the file is skipped.
+  # - imported-certificate-id: "00000000-0000-0000-0000-000000000000"
+  #   lifecycle:
+  #     status-check-interval: "6h"
+  #   file-output:
+  #     certificate:
+  #       path: "./certs/imported/certificate.crt"
+  #       permission: "0644"
+  #     chain:
+  #       path: "./certs/imported/chain.crt"
+  #       permission: "0644"
+  #     private-key:
+  #       path: "./certs/imported/private.key"
+  #       permission: "0600"

--- a/certificate-agent-config.yaml
+++ b/certificate-agent-config.yaml
@@ -58,18 +58,18 @@ certificates:
         omit-root: true
 
   # Fetch an existing certificate by ID. Skips issuance entirely.
-  # If private-key.path is configured but the imported certificate has no
-  # private key (e.g. ACME-issued), a warning is logged and the file is skipped.
-  # - imported-certificate-id: "00000000-0000-0000-0000-000000000000"
+  # If private-key.path is configured but the certificate has no private key
+  # (e.g. ACME-issued), a warning is logged and the file is skipped.
+  # - certificate-id: "00000000-0000-0000-0000-000000000000"
   #   lifecycle:
   #     status-check-interval: "6h"
   #   file-output:
   #     certificate:
-  #       path: "./certs/imported/certificate.crt"
+  #       path: "./certs/existing/certificate.crt"
   #       permission: "0644"
   #     chain:
-  #       path: "./certs/imported/chain.crt"
+  #       path: "./certs/existing/chain.crt"
   #       permission: "0644"
   #     private-key:
-  #       path: "./certs/imported/private.key"
+  #       path: "./certs/existing/private.key"
   #       permission: "0600"

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -62,6 +62,7 @@ const (
 	operationCallInstanceRelayHeartBeat            = "CallInstanceRelayHeartBeat"
 	operationCallIssueCertificate                  = "CallIssueCertificate"
 	operationCallRetrieveCertificate               = "CallRetrieveCertificate"
+	operationCallGetCertificateBundle              = "CallGetCertificateBundle"
 	operationCallRenewCertificate                  = "CallRenewCertificate"
 	operationCallGetCertificateRequest             = "CallGetCertificateRequest"
 )
@@ -1138,6 +1139,25 @@ func CallRetrieveCertificate(httpClient *resty.Client, certificateId string) (*R
 
 	if response.IsError() {
 		return nil, NewAPIErrorWithResponse(operationCallRetrieveCertificate, response, nil)
+	}
+
+	return &resBody, nil
+}
+
+func CallGetCertificateBundle(httpClient *resty.Client, certificateId string) (*CertificateBundleResponse, error) {
+	var resBody CertificateBundleResponse
+	response, err := httpClient.
+		R().
+		SetResult(&resBody).
+		SetHeader("User-Agent", USER_AGENT).
+		Get(fmt.Sprintf("%v/v1/cert-manager/certificates/%s/bundle", config.INFISICAL_URL, certificateId))
+
+	if err != nil {
+		return nil, NewGenericRequestError(operationCallGetCertificateBundle, err)
+	}
+
+	if response.IsError() {
+		return nil, NewAPIErrorWithResponse(operationCallGetCertificateBundle, response, nil)
 	}
 
 	return &resBody, nil

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -996,6 +996,13 @@ type RetrieveCertificateResponse struct {
 	} `json:"certificate"`
 }
 
+type CertificateBundleResponse struct {
+	Certificate      string `json:"certificate"`
+	CertificateChain string `json:"certificateChain"`
+	PrivateKey       string `json:"privateKey,omitempty"`
+	SerialNumber     string `json:"serialNumber"`
+}
+
 type RenewCertificateRequest struct {
 	RemoveRootsFromChain bool `json:"removeRootsFromChain,omitempty"`
 }

--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -2167,6 +2167,20 @@ func (tm *AgentManager) createAuthenticatedClient() (*resty.Client, error) {
 	return httpClient, nil
 }
 
+func importedStatusCheckInterval(certificate *AgentCertificateConfig) time.Duration {
+	if interval, err := parseDurationWithDays(certificate.Lifecycle.StatusCheckInterval); err == nil && interval > 0 {
+		return interval
+	}
+	return DEFAULT_MONITORING_INTERVAL
+}
+
+func importedFailureRetryInterval(certificate *AgentCertificateConfig) time.Duration {
+	if interval, err := parseDurationWithDays(certificate.Lifecycle.FailureRetryInterval); err == nil && interval > 0 {
+		return interval
+	}
+	return importedStatusCheckInterval(certificate)
+}
+
 func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate *AgentCertificateConfig) error {
 	displayName := tm.getCertificateDisplayName(certificateId, certificate)
 	log.Info().Str("Certificate", displayName).Msg("fetching imported certificate")
@@ -2231,7 +2245,7 @@ func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate 
 	state.Status = "active"
 	state.LastError = ""
 	state.RetryCount = 0
-	state.NextRenewalCheck = state.ExpiresAt
+	state.NextRenewalCheck = time.Now().Add(importedStatusCheckInterval(certificate))
 
 	certResponse := &api.CertificateResponse{
 		Certificate: &api.CertificateData{
@@ -2677,15 +2691,39 @@ func (tm *AgentManager) CheckCertificateRenewals() {
 		state := tm.certificateStates[cert.ID]
 
 		if cert.Certificate.IsImported() {
+			importedCert := &cert.Certificate
+			displayName := tm.getCertificateDisplayName(cert.ID, importedCert)
+
+			if state.Status == "failed" {
+				if cert.Certificate.Lifecycle.MaxFailureRetries > 0 && state.RetryCount >= cert.Certificate.Lifecycle.MaxFailureRetries {
+					continue
+				}
+				if !state.LastRetry.IsZero() && now.Sub(state.LastRetry) < importedFailureRetryInterval(importedCert) {
+					continue
+				}
+				log.Info().Str("Certificate", displayName).Msg("retrying imported certificate fetch")
+				tm.mutex.Unlock()
+				if err := tm.FetchImportedCertificate(cert.ID, importedCert); err != nil {
+					log.Error().Str("Certificate", displayName).Msgf("imported certificate retry failed: %v", err)
+				}
+				tm.mutex.Lock()
+				continue
+			}
+
 			if state.Status != "active" || state.CertificateID == "" {
 				continue
 			}
-			displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
+			if !state.NextRenewalCheck.IsZero() && now.Before(state.NextRenewalCheck) {
+				continue
+			}
+
 			tm.mutex.Unlock()
 			if err := tm.CheckCertificateStatus(cert.ID, state.CertificateID); err != nil {
 				log.Error().Str("Certificate", displayName).Msgf("failed to check imported certificate status: %v", err)
 			}
 			tm.mutex.Lock()
+
+			state.NextRenewalCheck = time.Now().Add(importedStatusCheckInterval(importedCert))
 			continue
 		}
 

--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -217,13 +217,14 @@ type CertificateAttributes struct {
 }
 
 type AgentCertificateConfig struct {
-	ProjectName     string                 `yaml:"project-slug"`
-	ProfileName     string                 `yaml:"profile-name"`
-	ProfileID       string                 `yaml:"-"`
-	DestinationPath string                 `yaml:"destination-path"`
-	CSR             string                 `yaml:"csr,omitempty"`
-	CSRPath         string                 `yaml:"csr-path,omitempty"`
-	Attributes      *CertificateAttributes `yaml:"attributes,omitempty"`
+	ProjectName           string                 `yaml:"project-slug,omitempty"`
+	ProfileName           string                 `yaml:"profile-name,omitempty"`
+	ProfileID             string                 `yaml:"-"`
+	ImportedCertificateID string                 `yaml:"imported-certificate-id,omitempty"`
+	DestinationPath       string                 `yaml:"destination-path,omitempty"`
+	CSR                   string                 `yaml:"csr,omitempty"`
+	CSRPath               string                 `yaml:"csr-path,omitempty"`
+	Attributes            *CertificateAttributes `yaml:"attributes,omitempty"`
 	// Certificate lifecycle and monitoring configuration
 	Lifecycle CertificateLifecycleConfig `yaml:"lifecycle"`
 	PostHooks struct {
@@ -255,6 +256,10 @@ type AgentCertificateConfig struct {
 			OmitRoot   *bool  `yaml:"omit-root,omitempty"`
 		} `yaml:"chain,omitempty"`
 	} `yaml:"file-output,omitempty"`
+}
+
+func (c *AgentCertificateConfig) IsImported() bool {
+	return c.ImportedCertificateID != ""
 }
 
 type DynamicSecretLeaseWithTTL struct {
@@ -1944,6 +1949,10 @@ func processCertificateCSRPaths(certificates *[]AgentCertificateConfig) error {
 	for i := range *certificates {
 		cert := &(*certificates)[i]
 
+		if cert.IsImported() {
+			continue
+		}
+
 		if cert.CSRPath != "" {
 			if cert.CSR != "" {
 				return fmt.Errorf("certificate configuration cannot specify both 'csr' and 'csr-path' fields")
@@ -2015,8 +2024,12 @@ func resolveCertificateNameReferences(certificates *[]AgentCertificateConfig, ht
 	for i := range *certificates {
 		cert := &(*certificates)[i]
 
+		if cert.IsImported() {
+			continue
+		}
+
 		if cert.ProjectName == "" || cert.ProfileName == "" {
-			return fmt.Errorf("certificate configuration must specify both 'project-slug' and 'profile-name'")
+			return fmt.Errorf("certificate configuration must specify both 'project-slug' and 'profile-name' (or 'imported-certificate-id' for imported certificates)")
 		}
 
 		project, err := api.CallGetProjectBySlug(httpClient, cert.ProjectName)
@@ -2038,6 +2051,29 @@ func resolveCertificateNameReferences(certificates *[]AgentCertificateConfig, ht
 	return nil
 }
 
+func validateCertificateSourceConfig(certificates *[]AgentCertificateConfig) error {
+	for i, cert := range *certificates {
+		certIndex := i + 1
+		if cert.IsImported() {
+			if cert.ProjectName != "" || cert.ProfileName != "" {
+				return fmt.Errorf("certificate %d: 'imported-certificate-id' cannot be used together with 'project-slug' or 'profile-name'", certIndex)
+			}
+			if cert.CSR != "" || cert.CSRPath != "" {
+				return fmt.Errorf("certificate %d: 'imported-certificate-id' cannot be used together with 'csr' or 'csr-path'", certIndex)
+			}
+			if cert.Attributes != nil {
+				return fmt.Errorf("certificate %d: 'attributes' is not supported for imported certificates", certIndex)
+			}
+			continue
+		}
+
+		if cert.ProjectName == "" || cert.ProfileName == "" {
+			return fmt.Errorf("certificate %d: must specify either 'imported-certificate-id' or both 'project-slug' and 'profile-name'", certIndex)
+		}
+	}
+	return nil
+}
+
 func (tm *AgentManager) getCertificateTTL(certificate *AgentCertificateConfig) string {
 	if certificate.Attributes != nil {
 		return certificate.Attributes.TTL
@@ -2053,6 +2089,9 @@ func (tm *AgentManager) getCertificateDisplayName(certificateId int, certificate
 		if len(certificate.Attributes.AltNames) > 0 {
 			return certificate.Attributes.AltNames[0]
 		}
+	}
+	if certificate.IsImported() {
+		return fmt.Sprintf("imported certificate %s", certificate.ImportedCertificateID)
 	}
 	if certificate.CSRPath != "" {
 		return fmt.Sprintf("CSR-based certificate (%s)", certificate.CSRPath)
@@ -2126,6 +2165,98 @@ func (tm *AgentManager) createAuthenticatedClient() (*resty.Client, error) {
 	}
 	httpClient.SetAuthToken(token)
 	return httpClient, nil
+}
+
+func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate *AgentCertificateConfig) error {
+	displayName := tm.getCertificateDisplayName(certificateId, certificate)
+	log.Info().Str("Certificate", displayName).Msg("fetching imported certificate")
+
+	httpClient, err := tm.createAuthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	recordFailure := func(reason string) {
+		tm.mutex.Lock()
+		defer tm.mutex.Unlock()
+		state := tm.certificateStates[certificateId]
+		state.Status = "failed"
+		state.LastError = reason
+		state.RetryCount++
+		state.LastRetry = time.Now()
+	}
+
+	metadata, err := api.CallRetrieveCertificate(httpClient, certificate.ImportedCertificateID)
+	if err != nil {
+		recordFailure(err.Error())
+		log.Error().Str("Certificate", displayName).Msgf("failed to fetch imported certificate metadata: %v", err)
+		return fmt.Errorf("failed to fetch imported certificate: %v", err)
+	}
+
+	if metadata.Certificate.Status != "active" {
+		reason := fmt.Sprintf("imported certificate is in '%s' state", metadata.Certificate.Status)
+		recordFailure(reason)
+		log.Error().Str("Certificate", displayName).Str("status", metadata.Certificate.Status).Msg("imported certificate is not active; skipping fetch")
+		return fmt.Errorf("imported certificate %s %s", certificate.ImportedCertificateID, reason)
+	}
+
+	bundle, err := api.CallGetCertificateBundle(httpClient, certificate.ImportedCertificateID)
+	if err != nil {
+		recordFailure(err.Error())
+		log.Error().Str("Certificate", displayName).Msgf("failed to fetch imported certificate bundle: %v", err)
+		return fmt.Errorf("failed to fetch imported certificate bundle: %v", err)
+	}
+
+	if bundle.Certificate == "" {
+		reason := "imported certificate bundle did not include certificate content"
+		recordFailure(reason)
+		log.Error().Str("Certificate", displayName).Msg(reason)
+		return fmt.Errorf("imported certificate %s: %s", certificate.ImportedCertificateID, reason)
+	}
+
+	serialNumber := bundle.SerialNumber
+	if serialNumber == "" {
+		serialNumber = metadata.Certificate.SerialNumber
+	}
+
+	tm.mutex.Lock()
+	defer tm.mutex.Unlock()
+
+	state := tm.certificateStates[certificateId]
+	state.CertificateID = metadata.Certificate.ID
+	state.SerialNumber = serialNumber
+	state.CommonName = metadata.Certificate.CommonName
+	state.IssuedAt = time.Now()
+	state.ExpiresAt = metadata.Certificate.NotAfter
+	state.Status = "active"
+	state.LastError = ""
+	state.RetryCount = 0
+	state.NextRenewalCheck = state.ExpiresAt
+
+	certResponse := &api.CertificateResponse{
+		Certificate: &api.CertificateData{
+			Certificate:      bundle.Certificate,
+			CertificateChain: bundle.CertificateChain,
+			PrivateKey:       bundle.PrivateKey,
+			SerialNumber:     serialNumber,
+			CertificateID:    metadata.Certificate.ID,
+		},
+	}
+
+	if err := tm.WriteCertificateFiles(certificate, certResponse); err != nil {
+		log.Error().Str("Certificate", displayName).Msgf("failed to write imported certificate files: %v", err)
+		state.Status = "failed"
+		state.LastError = fmt.Sprintf("failed to write files: %v", err)
+		return err
+	}
+
+	log.Info().Str("Certificate", displayName).Str("serial", serialNumber).Msg("imported certificate fetched successfully")
+
+	if certificate.PostHooks.OnIssuance.Command != "" {
+		tm.ExecutePostHook(certificate.PostHooks.OnIssuance.Command, certificate.PostHooks.OnIssuance.Timeout, "issuance", certificateId, certificate)
+	}
+
+	return nil
 }
 
 func (tm *AgentManager) IssueCertificate(certificateId int, certificate *AgentCertificateConfig) error {
@@ -2429,6 +2560,8 @@ func (tm *AgentManager) WriteCertificateFiles(certificate *AgentCertificateConfi
 		if err := ioutil.WriteFile(privateKeyPath, []byte(response.Certificate.PrivateKey), privateKeyPerms); err != nil {
 			return fmt.Errorf("failed to write private key to %s: %v", privateKeyPath, err)
 		}
+	} else if privateKeyPath != "" {
+		log.Warn().Str("path", privateKeyPath).Msg("private-key.path is configured but the certificate response does not include a private key (this is expected for certificates issued via ACME or imported without a private key); skipping private key file write")
 	}
 
 	if err := os.MkdirAll(path.Dir(certificatePath), 0755); err != nil {
@@ -2509,6 +2642,13 @@ func (tm *AgentManager) MonitorCertificates(ctx context.Context) {
 
 	for _, cert := range tm.certificates {
 		tm.certificateFirstIssueOnce[cert.ID].Do(func() {
+			if cert.Certificate.IsImported() {
+				if err := tm.FetchImportedCertificate(cert.ID, &cert.Certificate); err != nil {
+					displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
+					log.Error().Str("Certificate", displayName).Msgf("initial imported certificate fetch failed: %v", err)
+				}
+				return
+			}
 			if err := tm.IssueCertificate(cert.ID, &cert.Certificate); err != nil {
 				displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
 				log.Error().Str("Certificate", displayName).Msgf("initial certificate issuance failed: %v", err)
@@ -2535,6 +2675,19 @@ func (tm *AgentManager) CheckCertificateRenewals() {
 
 	for _, cert := range tm.certificates {
 		state := tm.certificateStates[cert.ID]
+
+		if cert.Certificate.IsImported() {
+			if state.Status != "active" || state.CertificateID == "" {
+				continue
+			}
+			displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
+			tm.mutex.Unlock()
+			if err := tm.CheckCertificateStatus(cert.ID, state.CertificateID); err != nil {
+				log.Error().Str("Certificate", displayName).Msgf("failed to check imported certificate status: %v", err)
+			}
+			tm.mutex.Lock()
+			continue
+		}
 
 		if cert.Certificate.CSR != "" || cert.Certificate.CSRPath != "" {
 			continue
@@ -3034,6 +3187,12 @@ var agentCmd = &cobra.Command{
 			return
 		}
 
+		err = validateCertificateSourceConfig(&agentConfig.Certificates)
+		if err != nil {
+			log.Error().Msgf("Certificate configuration validation failed: %v", err)
+			return
+		}
+
 		err = processCertificateCSRPaths(&agentConfig.Certificates)
 		if err != nil {
 			log.Error().Msgf("Failed to load CSR files: %v", err)
@@ -3308,6 +3467,12 @@ var certManagerAgentCmd = &cobra.Command{
 
 		if err := validateCertificateOnlyMode(agentConfig); err != nil {
 			log.Error().Msgf("Certificate-only mode validation failed: %v", err)
+			return
+		}
+
+		err = validateCertificateSourceConfig(&agentConfig.Certificates)
+		if err != nil {
+			log.Error().Msgf("Certificate configuration validation failed: %v", err)
 			return
 		}
 

--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -61,6 +61,7 @@ var CACHE_LEASE_EXPIRE_BUFFER = 30 * time.Second
 const EXTERNAL_CA_INITIAL_POLLING_INTERVAL = 10 * time.Second
 const EXTERNAL_CA_MAX_POLLING_INTERVAL = 1 * time.Hour
 const DEFAULT_MONITORING_INTERVAL = 10 * time.Second
+const DEFAULT_MAX_FAILURE_RETRIES = 10
 
 type PersistentCacheConfig struct {
 	Type                    string `yaml:"type"`                       // file or kubernetes
@@ -2192,6 +2193,13 @@ func failureRetryIntervalFor(certificate *AgentCertificateConfig) time.Duration 
 	return statusCheckIntervalFor(certificate)
 }
 
+func effectiveMaxFailureRetries(certificate *AgentCertificateConfig) int {
+	if certificate.Lifecycle.MaxFailureRetries > 0 {
+		return certificate.Lifecycle.MaxFailureRetries
+	}
+	return DEFAULT_MAX_FAILURE_RETRIES
+}
+
 func (tm *AgentManager) FetchCertificate(certificateId int, certificate *AgentCertificateConfig) error {
 	displayName := tm.getCertificateDisplayName(certificateId, certificate)
 	log.Info().Str("Certificate", displayName).Msg("fetching certificate")
@@ -2219,10 +2227,16 @@ func (tm *AgentManager) FetchCertificate(certificateId int, certificate *AgentCe
 	}
 
 	if metadata.Certificate.Status != "active" {
-		reason := fmt.Sprintf("certificate is in '%s' state", metadata.Certificate.Status)
-		recordFailure(reason)
+		func() {
+			tm.mutex.Lock()
+			defer tm.mutex.Unlock()
+			state := tm.certificateStates[certificateId]
+			state.Status = metadata.Certificate.Status
+			state.LastError = fmt.Sprintf("certificate is in '%s' state", metadata.Certificate.Status)
+			state.LastRetry = time.Now()
+		}()
 		log.Error().Str("Certificate", displayName).Str("status", metadata.Certificate.Status).Msg("certificate is not active; skipping fetch")
-		return fmt.Errorf("certificate %s %s", certificate.CertificateID, reason)
+		return fmt.Errorf("certificate %s is in '%s' state", certificate.CertificateID, metadata.Certificate.Status)
 	}
 
 	bundle, err := api.CallGetCertificateBundle(httpClient, certificate.CertificateID)
@@ -2248,15 +2262,6 @@ func (tm *AgentManager) FetchCertificate(certificateId int, certificate *AgentCe
 	defer tm.mutex.Unlock()
 
 	state := tm.certificateStates[certificateId]
-	state.CertificateID = metadata.Certificate.ID
-	state.SerialNumber = serialNumber
-	state.CommonName = metadata.Certificate.CommonName
-	state.IssuedAt = time.Now()
-	state.ExpiresAt = metadata.Certificate.NotAfter
-	state.Status = "active"
-	state.LastError = ""
-	state.RetryCount = 0
-	state.NextRenewalCheck = time.Now().Add(statusCheckIntervalFor(certificate))
 
 	certResponse := &api.CertificateResponse{
 		Certificate: &api.CertificateData{
@@ -2272,8 +2277,20 @@ func (tm *AgentManager) FetchCertificate(certificateId int, certificate *AgentCe
 		log.Error().Str("Certificate", displayName).Msgf("failed to write certificate files: %v", err)
 		state.Status = "failed"
 		state.LastError = fmt.Sprintf("failed to write files: %v", err)
+		state.RetryCount++
+		state.LastRetry = time.Now()
 		return err
 	}
+
+	state.CertificateID = metadata.Certificate.ID
+	state.SerialNumber = serialNumber
+	state.CommonName = metadata.Certificate.CommonName
+	state.IssuedAt = time.Now()
+	state.ExpiresAt = metadata.Certificate.NotAfter
+	state.Status = "active"
+	state.LastError = ""
+	state.RetryCount = 0
+	state.NextRenewalCheck = time.Now().Add(statusCheckIntervalFor(certificate))
 
 	log.Info().Str("Certificate", displayName).Str("serial", serialNumber).Msg("certificate fetched successfully")
 
@@ -2693,7 +2710,7 @@ func (tm *AgentManager) CheckCertificateRenewals() {
 			displayName := tm.getCertificateDisplayName(cert.ID, referencedCert)
 
 			if state.Status == "failed" {
-				if referencedCert.Lifecycle.MaxFailureRetries > 0 && state.RetryCount >= referencedCert.Lifecycle.MaxFailureRetries {
+				if state.RetryCount >= effectiveMaxFailureRetries(referencedCert) {
 					continue
 				}
 				if !state.LastRetry.IsZero() && now.Sub(state.LastRetry) < failureRetryIntervalFor(referencedCert) {

--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -217,14 +217,14 @@ type CertificateAttributes struct {
 }
 
 type AgentCertificateConfig struct {
-	ProjectName           string                 `yaml:"project-slug,omitempty"`
-	ProfileName           string                 `yaml:"profile-name,omitempty"`
-	ProfileID             string                 `yaml:"-"`
-	ImportedCertificateID string                 `yaml:"imported-certificate-id,omitempty"`
-	DestinationPath       string                 `yaml:"destination-path,omitempty"`
-	CSR                   string                 `yaml:"csr,omitempty"`
-	CSRPath               string                 `yaml:"csr-path,omitempty"`
-	Attributes            *CertificateAttributes `yaml:"attributes,omitempty"`
+	ProjectName     string                 `yaml:"project-slug,omitempty"`
+	ProfileName     string                 `yaml:"profile-name,omitempty"`
+	ProfileID       string                 `yaml:"-"`
+	CertificateID   string                 `yaml:"certificate-id,omitempty"`
+	DestinationPath string                 `yaml:"destination-path,omitempty"`
+	CSR             string                 `yaml:"csr,omitempty"`
+	CSRPath         string                 `yaml:"csr-path,omitempty"`
+	Attributes      *CertificateAttributes `yaml:"attributes,omitempty"`
 	// Certificate lifecycle and monitoring configuration
 	Lifecycle CertificateLifecycleConfig `yaml:"lifecycle"`
 	PostHooks struct {
@@ -258,8 +258,8 @@ type AgentCertificateConfig struct {
 	} `yaml:"file-output,omitempty"`
 }
 
-func (c *AgentCertificateConfig) IsImported() bool {
-	return c.ImportedCertificateID != ""
+func (c *AgentCertificateConfig) HasCertificateID() bool {
+	return c.CertificateID != ""
 }
 
 type DynamicSecretLeaseWithTTL struct {
@@ -1949,7 +1949,7 @@ func processCertificateCSRPaths(certificates *[]AgentCertificateConfig) error {
 	for i := range *certificates {
 		cert := &(*certificates)[i]
 
-		if cert.IsImported() {
+		if cert.HasCertificateID() {
 			continue
 		}
 
@@ -2024,12 +2024,12 @@ func resolveCertificateNameReferences(certificates *[]AgentCertificateConfig, ht
 	for i := range *certificates {
 		cert := &(*certificates)[i]
 
-		if cert.IsImported() {
+		if cert.HasCertificateID() {
 			continue
 		}
 
 		if cert.ProjectName == "" || cert.ProfileName == "" {
-			return fmt.Errorf("certificate configuration must specify both 'project-slug' and 'profile-name' (or 'imported-certificate-id' for imported certificates)")
+			return fmt.Errorf("certificate configuration must specify both 'project-slug' and 'profile-name' (or 'certificate-id' to reference an existing certificate)")
 		}
 
 		project, err := api.CallGetProjectBySlug(httpClient, cert.ProjectName)
@@ -2054,21 +2054,21 @@ func resolveCertificateNameReferences(certificates *[]AgentCertificateConfig, ht
 func validateCertificateSourceConfig(certificates *[]AgentCertificateConfig) error {
 	for i, cert := range *certificates {
 		certIndex := i + 1
-		if cert.IsImported() {
+		if cert.HasCertificateID() {
 			if cert.ProjectName != "" || cert.ProfileName != "" {
-				return fmt.Errorf("certificate %d: 'imported-certificate-id' cannot be used together with 'project-slug' or 'profile-name'", certIndex)
+				return fmt.Errorf("certificate %d: 'certificate-id' cannot be used together with 'project-slug' or 'profile-name'", certIndex)
 			}
 			if cert.CSR != "" || cert.CSRPath != "" {
-				return fmt.Errorf("certificate %d: 'imported-certificate-id' cannot be used together with 'csr' or 'csr-path'", certIndex)
+				return fmt.Errorf("certificate %d: 'certificate-id' cannot be used together with 'csr' or 'csr-path'", certIndex)
 			}
 			if cert.Attributes != nil {
-				return fmt.Errorf("certificate %d: 'attributes' is not supported for imported certificates", certIndex)
+				return fmt.Errorf("certificate %d: 'attributes' is not supported when using 'certificate-id'", certIndex)
 			}
 			continue
 		}
 
 		if cert.ProjectName == "" || cert.ProfileName == "" {
-			return fmt.Errorf("certificate %d: must specify either 'imported-certificate-id' or both 'project-slug' and 'profile-name'", certIndex)
+			return fmt.Errorf("certificate %d: must specify either 'certificate-id' or both 'project-slug' and 'profile-name'", certIndex)
 		}
 	}
 	return nil
@@ -2090,8 +2090,8 @@ func (tm *AgentManager) getCertificateDisplayName(certificateId int, certificate
 			return certificate.Attributes.AltNames[0]
 		}
 	}
-	if certificate.IsImported() {
-		return fmt.Sprintf("imported certificate %s", certificate.ImportedCertificateID)
+	if certificate.HasCertificateID() {
+		return fmt.Sprintf("certificate %s", certificate.CertificateID)
 	}
 	if certificate.CSRPath != "" {
 		return fmt.Sprintf("CSR-based certificate (%s)", certificate.CSRPath)
@@ -2167,23 +2167,23 @@ func (tm *AgentManager) createAuthenticatedClient() (*resty.Client, error) {
 	return httpClient, nil
 }
 
-func importedStatusCheckInterval(certificate *AgentCertificateConfig) time.Duration {
+func statusCheckIntervalFor(certificate *AgentCertificateConfig) time.Duration {
 	if interval, err := parseDurationWithDays(certificate.Lifecycle.StatusCheckInterval); err == nil && interval > 0 {
 		return interval
 	}
 	return DEFAULT_MONITORING_INTERVAL
 }
 
-func importedFailureRetryInterval(certificate *AgentCertificateConfig) time.Duration {
+func failureRetryIntervalFor(certificate *AgentCertificateConfig) time.Duration {
 	if interval, err := parseDurationWithDays(certificate.Lifecycle.FailureRetryInterval); err == nil && interval > 0 {
 		return interval
 	}
-	return importedStatusCheckInterval(certificate)
+	return statusCheckIntervalFor(certificate)
 }
 
-func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate *AgentCertificateConfig) error {
+func (tm *AgentManager) FetchCertificate(certificateId int, certificate *AgentCertificateConfig) error {
 	displayName := tm.getCertificateDisplayName(certificateId, certificate)
-	log.Info().Str("Certificate", displayName).Msg("fetching imported certificate")
+	log.Info().Str("Certificate", displayName).Msg("fetching certificate")
 
 	httpClient, err := tm.createAuthenticatedClient()
 	if err != nil {
@@ -2200,32 +2200,32 @@ func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate 
 		state.LastRetry = time.Now()
 	}
 
-	metadata, err := api.CallRetrieveCertificate(httpClient, certificate.ImportedCertificateID)
+	metadata, err := api.CallRetrieveCertificate(httpClient, certificate.CertificateID)
 	if err != nil {
 		recordFailure(err.Error())
-		log.Error().Str("Certificate", displayName).Msgf("failed to fetch imported certificate metadata: %v", err)
-		return fmt.Errorf("failed to fetch imported certificate: %v", err)
+		log.Error().Str("Certificate", displayName).Msgf("failed to fetch certificate metadata: %v", err)
+		return fmt.Errorf("failed to fetch certificate: %v", err)
 	}
 
 	if metadata.Certificate.Status != "active" {
-		reason := fmt.Sprintf("imported certificate is in '%s' state", metadata.Certificate.Status)
+		reason := fmt.Sprintf("certificate is in '%s' state", metadata.Certificate.Status)
 		recordFailure(reason)
-		log.Error().Str("Certificate", displayName).Str("status", metadata.Certificate.Status).Msg("imported certificate is not active; skipping fetch")
-		return fmt.Errorf("imported certificate %s %s", certificate.ImportedCertificateID, reason)
+		log.Error().Str("Certificate", displayName).Str("status", metadata.Certificate.Status).Msg("certificate is not active; skipping fetch")
+		return fmt.Errorf("certificate %s %s", certificate.CertificateID, reason)
 	}
 
-	bundle, err := api.CallGetCertificateBundle(httpClient, certificate.ImportedCertificateID)
+	bundle, err := api.CallGetCertificateBundle(httpClient, certificate.CertificateID)
 	if err != nil {
 		recordFailure(err.Error())
-		log.Error().Str("Certificate", displayName).Msgf("failed to fetch imported certificate bundle: %v", err)
-		return fmt.Errorf("failed to fetch imported certificate bundle: %v", err)
+		log.Error().Str("Certificate", displayName).Msgf("failed to fetch certificate bundle: %v", err)
+		return fmt.Errorf("failed to fetch certificate bundle: %v", err)
 	}
 
 	if bundle.Certificate == "" {
-		reason := "imported certificate bundle did not include certificate content"
+		reason := "certificate bundle did not include certificate content"
 		recordFailure(reason)
 		log.Error().Str("Certificate", displayName).Msg(reason)
-		return fmt.Errorf("imported certificate %s: %s", certificate.ImportedCertificateID, reason)
+		return fmt.Errorf("certificate %s: %s", certificate.CertificateID, reason)
 	}
 
 	serialNumber := bundle.SerialNumber
@@ -2245,7 +2245,7 @@ func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate 
 	state.Status = "active"
 	state.LastError = ""
 	state.RetryCount = 0
-	state.NextRenewalCheck = time.Now().Add(importedStatusCheckInterval(certificate))
+	state.NextRenewalCheck = time.Now().Add(statusCheckIntervalFor(certificate))
 
 	certResponse := &api.CertificateResponse{
 		Certificate: &api.CertificateData{
@@ -2258,13 +2258,13 @@ func (tm *AgentManager) FetchImportedCertificate(certificateId int, certificate 
 	}
 
 	if err := tm.WriteCertificateFiles(certificate, certResponse); err != nil {
-		log.Error().Str("Certificate", displayName).Msgf("failed to write imported certificate files: %v", err)
+		log.Error().Str("Certificate", displayName).Msgf("failed to write certificate files: %v", err)
 		state.Status = "failed"
 		state.LastError = fmt.Sprintf("failed to write files: %v", err)
 		return err
 	}
 
-	log.Info().Str("Certificate", displayName).Str("serial", serialNumber).Msg("imported certificate fetched successfully")
+	log.Info().Str("Certificate", displayName).Str("serial", serialNumber).Msg("certificate fetched successfully")
 
 	if certificate.PostHooks.OnIssuance.Command != "" {
 		tm.ExecutePostHook(certificate.PostHooks.OnIssuance.Command, certificate.PostHooks.OnIssuance.Timeout, "issuance", certificateId, certificate)
@@ -2575,7 +2575,7 @@ func (tm *AgentManager) WriteCertificateFiles(certificate *AgentCertificateConfi
 			return fmt.Errorf("failed to write private key to %s: %v", privateKeyPath, err)
 		}
 	} else if privateKeyPath != "" {
-		log.Warn().Str("path", privateKeyPath).Msg("private-key.path is configured but the certificate response does not include a private key (this is expected for certificates issued via ACME or imported without a private key); skipping private key file write")
+		log.Warn().Str("path", privateKeyPath).Msg("private-key.path is configured but the certificate response does not include a private key (this is expected for certificates issued via ACME or stored without a private key); skipping private key file write")
 	}
 
 	if err := os.MkdirAll(path.Dir(certificatePath), 0755); err != nil {
@@ -2656,10 +2656,10 @@ func (tm *AgentManager) MonitorCertificates(ctx context.Context) {
 
 	for _, cert := range tm.certificates {
 		tm.certificateFirstIssueOnce[cert.ID].Do(func() {
-			if cert.Certificate.IsImported() {
-				if err := tm.FetchImportedCertificate(cert.ID, &cert.Certificate); err != nil {
+			if cert.Certificate.HasCertificateID() {
+				if err := tm.FetchCertificate(cert.ID, &cert.Certificate); err != nil {
 					displayName := tm.getCertificateDisplayName(cert.ID, &cert.Certificate)
-					log.Error().Str("Certificate", displayName).Msgf("initial imported certificate fetch failed: %v", err)
+					log.Error().Str("Certificate", displayName).Msgf("initial certificate fetch failed: %v", err)
 				}
 				return
 			}
@@ -2690,21 +2690,21 @@ func (tm *AgentManager) CheckCertificateRenewals() {
 	for _, cert := range tm.certificates {
 		state := tm.certificateStates[cert.ID]
 
-		if cert.Certificate.IsImported() {
-			importedCert := &cert.Certificate
-			displayName := tm.getCertificateDisplayName(cert.ID, importedCert)
+		if cert.Certificate.HasCertificateID() {
+			referencedCert := &cert.Certificate
+			displayName := tm.getCertificateDisplayName(cert.ID, referencedCert)
 
 			if state.Status == "failed" {
-				if cert.Certificate.Lifecycle.MaxFailureRetries > 0 && state.RetryCount >= cert.Certificate.Lifecycle.MaxFailureRetries {
+				if referencedCert.Lifecycle.MaxFailureRetries > 0 && state.RetryCount >= referencedCert.Lifecycle.MaxFailureRetries {
 					continue
 				}
-				if !state.LastRetry.IsZero() && now.Sub(state.LastRetry) < importedFailureRetryInterval(importedCert) {
+				if !state.LastRetry.IsZero() && now.Sub(state.LastRetry) < failureRetryIntervalFor(referencedCert) {
 					continue
 				}
-				log.Info().Str("Certificate", displayName).Msg("retrying imported certificate fetch")
+				log.Info().Str("Certificate", displayName).Msg("retrying certificate fetch")
 				tm.mutex.Unlock()
-				if err := tm.FetchImportedCertificate(cert.ID, importedCert); err != nil {
-					log.Error().Str("Certificate", displayName).Msgf("imported certificate retry failed: %v", err)
+				if err := tm.FetchCertificate(cert.ID, referencedCert); err != nil {
+					log.Error().Str("Certificate", displayName).Msgf("certificate fetch retry failed: %v", err)
 				}
 				tm.mutex.Lock()
 				continue
@@ -2719,11 +2719,11 @@ func (tm *AgentManager) CheckCertificateRenewals() {
 
 			tm.mutex.Unlock()
 			if err := tm.CheckCertificateStatus(cert.ID, state.CertificateID); err != nil {
-				log.Error().Str("Certificate", displayName).Msgf("failed to check imported certificate status: %v", err)
+				log.Error().Str("Certificate", displayName).Msgf("failed to check certificate status: %v", err)
 			}
 			tm.mutex.Lock()
 
-			state.NextRenewalCheck = time.Now().Add(importedStatusCheckInterval(importedCert))
+			state.NextRenewalCheck = time.Now().Add(statusCheckIntervalFor(referencedCert))
 			continue
 		}
 


### PR DESCRIPTION
# Description 📣

Adds support in the certificate agent for fetching an existing certificate by ID and writing the cert, chain, and private key in the desired destinations instead of always issuing a new certificate from a profile.
A new `imported-certificate-id` config field selects this mode and skips the issuance flow entirely, periodic status checks still run so revocation and expiry are detected, but renewal is left to whatever issued the cert externally. When the imported certificate has no private key (e.g. ACME-issued), the agent logs a warning if a `private-key` path is configured and otherwise stays quiet.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->