### PR TITLE
fix: upgrade go dependencies

### DIFF
--- a/detect/config/rule.go
+++ b/detect/config/rule.go
@@ -86,7 +86,7 @@ func (r *Rule) Validate() error {
 		} else if r.Description != "" {
 			context = ", description: " + r.Description
 		}
-		return fmt.Errorf("rule |id| is missing or empty" + context)
+		return fmt.Errorf("rule |id| is missing or empty%s", context)
 	}
 
 	// Ensure the rule actually matches something.

--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -229,7 +229,7 @@ func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string)
 	command := args[0]
 	argsForCommand := args[1:]
 
-	log.Info().Msgf(color.GreenString("Injecting %v Infisical secrets into your application process", secretsCount))
+	log.Info().Msg(color.GreenString("Injecting %v Infisical secrets into your application process", secretsCount))
 
 	cmd := exec.Command(command, argsForCommand...)
 	cmd.Stdin = os.Stdin
@@ -257,7 +257,7 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 	cmd.Stderr = os.Stderr
 	cmd.Env = env
 
-	log.Info().Msgf(color.GreenString("Injecting %v Infisical secrets into your application process", secretsCount))
+	log.Info().Msg(color.GreenString("Injecting %v Infisical secrets into your application process", secretsCount))
 	log.Debug().Msgf("executing command: %s %s %s \n", shell[0], shell[1], fullCommand)
 
 	return execBasicCmd(cmd)
@@ -335,7 +335,7 @@ func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInt
 			log.Info().Msg(color.HiMagentaString("[HOT RELOAD] Environment changes detected. Reloading process..."))
 			beingTerminated = true
 
-			log.Debug().Msgf(color.HiMagentaString("[HOT RELOAD] Sending SIGTERM to PID %d", cmd.Process.Pid))
+			log.Debug().Msg(color.HiMagentaString("[HOT RELOAD] Sending SIGTERM to PID %d", cmd.Process.Pid))
 			if e := cmd.Process.Signal(syscall.SIGTERM); e != nil {
 				log.Error().Err(e).Msg(color.HiMagentaString("[HOT RELOAD] Failed to send SIGTERM"))
 			}
@@ -376,7 +376,7 @@ func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInt
 		watcherWaitGroup.Add(1)
 
 		// start the process
-		log.Info().Msgf(color.GreenString("Injecting %v Infisical secrets into your application process", environmentVariables.SecretsCount))
+		log.Info().Msg(color.GreenString("Injecting %v Infisical secrets into your application process", environmentVariables.SecretsCount))
 
 		cmd, err = util.RunCommand(commandFlag, args, environmentVariables.Variables, false)
 		if err != nil {

--- a/packages/pam/handlers/redis/relay_handler.go
+++ b/packages/pam/handlers/redis/relay_handler.go
@@ -136,7 +136,7 @@ func (h *RelayHandler) Handle(ctx context.Context) error {
 		case resp3.TypeArray:
 			cmd := value.Elems[0]
 			if cmd.Type != resp3.TypeBlobString {
-				return fmt.Errorf("expected SimpleString, got %s", cmd.Type)
+				return fmt.Errorf("expected BlobString, got %d", cmd.Type)
 			}
 			cmdStr := strings.ToLower(value.Elems[0].Str)
 			switch cmdStr {


### PR DESCRIPTION
# Description 📣

Upgrades vulnerable Go dependencies for the CLI work related to ENG-4951 / Infisical issue #6244.

This updates `github.com/jackc/pgx/v5` to `v5.9.0` and `google.golang.org/grpc` to `v1.79.3`, along with required transitive dependency updates from `go mod tidy`. The CLI Go version and CI/release workflow Go versions were also aligned to Go `1.25.x`.

A few small compatibility fixes were included for the upgraded toolchain/dependencies:
- Updated pgx cancel request logging for the new `SecretKey []byte` type.
- Fixed Go vet failures from dynamic `fmt.Errorf` / `Msgf` format strings.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
GOCACHE=/private/tmp/go-build-cache GOMODCACHE=/private/tmp/go-mod-cache go test $(go list ./... | rg -v "/test$")
GOCACHE=/private/tmp/go-build-cache GOMODCACHE=/private/tmp/go-mod-cache go build -o /private/tmp/infisical-eng-4951 .
git diff --check
