### PR TITLE
feat: support multiple paths in `infisical run`

### DIFF
--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -121,7 +121,7 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		secretsPath, err := cmd.Flags().GetString("path")
+		secretsPaths, err := cmd.Flags().GetStringArray("path")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -136,11 +136,11 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		request := models.GetAllSecretsParameters{
+		request := models.GetMultiPathSecretsParameters{
 			Environment:            environmentName,
 			WorkspaceId:            projectId,
 			TagSlugs:               tagSlugs,
-			SecretsPath:            secretsPath,
+			SecretsPaths:           secretsPaths,
 			IncludeImport:          includeImports,
 			Recursive:              recursive,
 			ExpandSecretReferences: shouldExpandSecrets,
@@ -220,7 +220,7 @@ func init() {
 	runCmd.Flags().Int("watch-interval", 10, "interval in seconds to check for secret changes")
 	runCmd.Flags().StringP("command", "c", "", "chained commands to execute (e.g. \"npm install && npm run dev; echo ...\")")
 	runCmd.Flags().StringP("tags", "t", "", "filter secrets by tag slugs ")
-	runCmd.Flags().String("path", "/", "get secrets within a folder path")
+	runCmd.Flags().StringArray("path", []string{"/"}, "get secrets within a folder path (can be specified multiple times, last path wins on conflicts)")
 	runCmd.Flags().String("project-config-dir", "", "explicitly set the directory where the .infisical.json resides")
 }
 
@@ -307,7 +307,7 @@ func waitForExitCommand(cmd *exec.Cmd) (int, error) {
 	return waitStatus.ExitStatus(), nil
 }
 
-func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInterval int, request models.GetAllSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) {
+func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInterval int, request models.GetMultiPathSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) {
 
 	var cmd *exec.Cmd
 	var err error
@@ -439,26 +439,44 @@ func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInt
 	}
 }
 
-func fetchAndFormatSecretsForShell(request models.GetAllSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) (models.InjectableEnvironmentResult, error) {
+func fetchSecrets(request models.GetMultiPathSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) ([]models.SingleEnvironmentVariable, error) {
+	var allSecrets []models.SingleEnvironmentVariable
 
-	if token != nil && token.Type == util.SERVICE_TOKEN_IDENTIFIER {
-		request.InfisicalToken = token.Token
-	} else if token != nil && token.Type == util.UNIVERSAL_AUTH_TOKEN_IDENTIFIER {
-		request.UniversalAuthAccessToken = token.Token
+	for _, path := range request.SecretsPaths {
+		params := models.GetAllSecretsParameters{
+			Environment:            request.Environment,
+			WorkspaceId:            request.WorkspaceId,
+			TagSlugs:               request.TagSlugs,
+			SecretsPath:            path,
+			IncludeImport:          request.IncludeImport,
+			Recursive:              request.Recursive,
+			ExpandSecretReferences: request.ExpandSecretReferences,
+		}
+
+		if token != nil && token.Type == util.SERVICE_TOKEN_IDENTIFIER {
+			params.InfisicalToken = token.Token
+		} else if token != nil && token.Type == util.UNIVERSAL_AUTH_TOKEN_IDENTIFIER {
+			params.UniversalAuthAccessToken = token.Token
+		}
+
+		secrets, err := util.GetAllEnvironmentVariables(params, projectConfigDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch secrets for path %q: %w", path, err)
+		}
+
+		if secretOverriding {
+			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_PERSONAL)
+		} else {
+			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_SHARED)
+		}
+
+		allSecrets = append(allSecrets, secrets...)
 	}
 
-	secrets, err := util.GetAllEnvironmentVariables(request, projectConfigDir)
+	return allSecrets, nil
+}
 
-	if err != nil {
-		return models.InjectableEnvironmentResult{}, err
-	}
-
-	if secretOverriding {
-		secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_PERSONAL)
-	} else {
-		secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_SHARED)
-	}
-
+func formatSecretsForShell(secrets []models.SingleEnvironmentVariable) models.InjectableEnvironmentResult {
 	secretsByKey := getSecretsByKeys(secrets)
 	environmentVariables := make(map[string]string)
 
@@ -487,5 +505,14 @@ func fetchAndFormatSecretsForShell(request models.GetAllSecretsParameters, proje
 		Variables:    env,
 		ETag:         util.GenerateETagFromSecrets(secrets),
 		SecretsCount: len(secretsByKey),
-	}, nil
+	}
+}
+
+func fetchAndFormatSecretsForShell(request models.GetMultiPathSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) (models.InjectableEnvironmentResult, error) {
+	secrets, err := fetchSecrets(request, projectConfigDir, secretOverriding, token)
+	if err != nil {
+		return models.InjectableEnvironmentResult{}, err
+	}
+
+	return formatSecretsForShell(secrets), nil
 }

--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -440,7 +440,7 @@ func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInt
 }
 
 func fetchSecrets(request models.GetMultiPathSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) ([]models.SingleEnvironmentVariable, error) {
-	secretsByKey := make(map[string]models.SingleEnvironmentVariable)
+	var allSecrets []models.SingleEnvironmentVariable
 
 	for _, path := range request.SecretsPaths {
 		params := models.GetAllSecretsParameters{
@@ -464,23 +464,16 @@ func fetchSecrets(request models.GetMultiPathSecretsParameters, projectConfigDir
 			return nil, fmt.Errorf("failed to fetch secrets for path %q: %w", path, err)
 		}
 
-		if secretOverriding {
-			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_PERSONAL)
-		} else {
-			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_SHARED)
-		}
-
-		for _, s := range secrets {
-			secretsByKey[s.Key] = s
-		}
+		allSecrets = append(allSecrets, secrets...)
 	}
 
-	result := make([]models.SingleEnvironmentVariable, 0, len(secretsByKey))
-	for _, s := range secretsByKey {
-		result = append(result, s)
+	if secretOverriding {
+		allSecrets = util.OverrideSecrets(allSecrets, util.SECRET_TYPE_PERSONAL)
+	} else {
+		allSecrets = util.OverrideSecrets(allSecrets, util.SECRET_TYPE_SHARED)
 	}
 
-	return result, nil
+	return allSecrets, nil
 }
 
 func formatSecretsForShell(secrets []models.SingleEnvironmentVariable) models.InjectableEnvironmentResult {

--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -220,7 +220,7 @@ func init() {
 	runCmd.Flags().Int("watch-interval", 10, "interval in seconds to check for secret changes")
 	runCmd.Flags().StringP("command", "c", "", "chained commands to execute (e.g. \"npm install && npm run dev; echo ...\")")
 	runCmd.Flags().StringP("tags", "t", "", "filter secrets by tag slugs ")
-	runCmd.Flags().StringArray("path", []string{"/"}, "get secrets within a folder path (can be specified multiple times, last path wins on conflicts)")
+	runCmd.Flags().StringArray("path", []string{"/"}, "get secrets within a folder path (can be specified multiple times)")
 	runCmd.Flags().String("project-config-dir", "", "explicitly set the directory where the .infisical.json resides")
 }
 

--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -440,7 +440,7 @@ func executeCommandWithWatchMode(commandFlag string, args []string, watchModeInt
 }
 
 func fetchSecrets(request models.GetMultiPathSecretsParameters, projectConfigDir string, secretOverriding bool, token *models.TokenDetails) ([]models.SingleEnvironmentVariable, error) {
-	var allSecrets []models.SingleEnvironmentVariable
+	secretsByKey := make(map[string]models.SingleEnvironmentVariable)
 
 	for _, path := range request.SecretsPaths {
 		params := models.GetAllSecretsParameters{
@@ -470,10 +470,17 @@ func fetchSecrets(request models.GetMultiPathSecretsParameters, projectConfigDir
 			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_SHARED)
 		}
 
-		allSecrets = append(allSecrets, secrets...)
+		for _, s := range secrets {
+			secretsByKey[s.Key] = s
+		}
 	}
 
-	return allSecrets, nil
+	result := make([]models.SingleEnvironmentVariable, 0, len(secretsByKey))
+	for _, s := range secretsByKey {
+		result = append(result, s)
+	}
+
+	return result, nil
 }
 
 func formatSecretsForShell(secrets []models.SingleEnvironmentVariable) models.InjectableEnvironmentResult {

--- a/packages/models/cli.go
+++ b/packages/models/cli.go
@@ -113,6 +113,16 @@ type SymmetricEncryptionResult struct {
 	AuthTag    []byte `json:"AuthTag"`
 }
 
+type GetMultiPathSecretsParameters struct {
+	Environment            string
+	WorkspaceId            string
+	TagSlugs               string
+	SecretsPaths           []string
+	IncludeImport          bool
+	Recursive              bool
+	ExpandSecretReferences bool
+}
+
 type GetAllSecretsParameters struct {
 	Environment              string
 	EnvironmentPassedViaFlag bool


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Users were injecting secrets from multiple paths by running:

```
infisical run --env=dev --path=/parameters/sdlc-tools/IES -- \
infisical run --env=dev --path=/secrets/sdlc-tools/IES -- \
command
```

Now we support multiple `--path` and load them all in one call:

```
infisical run --env=dev --path=/parameters/sdlc-tools/IES --path=/secrets/sdlc-tools/IES  -- \
command
```

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

- [x] To ensure retro-compatibility with  only one `--path`
  - [x] single path
  - [x] single path with `--recursive`
  - [x] single path with `--secret-overriding=false`
  - [x] single path with `--watch`
- [x] Multiple paths
  - [x] `/app1` and `/app2` and see if both sets of variables would be merged
  - [x] `/app1` and `/app2` to ensure conflicts would pick secrets from `app1`
  - [x] `/app2` and `/app1` to ensure conflicts would pick secrets from `app2` 
  - [x] `/app1` and `/app2` with `--secret-overriding=false` to ensure conflicts would pick from `/app2` (same behavior as `--recursive` with single path)
  - [x] `/app1` and `/app1/sub` to ensure subpaths are merged
  - [x] `/app1` and `/app1/sub` with `--recursive` to ensure conflicts would pick secrets from the `app1` (same behavior as SDK/CLI with single path)
  - [x] with `--watch`

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->