### PR TITLE
fix(release): revert build/smoke/publish split

### DIFF
--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -218,14 +218,26 @@ jobs:
             mkdir -p "$target_dir"
             cp "/tmp/rdp-bridge-artifacts/rdp-bridge-$triple/libinfisical_rdp_bridge.a" "$target_dir/"
           done
-      - name: GoReleaser (build, no publish)
+      - name: GoReleaser (dry-run snapshot)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
-          args: >-
-            release --clean --skip=publish,announce
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--snapshot' || '' }}
+          args: release --clean --snapshot --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
+          POSTHOG_API_KEY_FOR_CLI: ${{ secrets.POSTHOG_API_KEY_FOR_CLI }}
+          FURY_TOKEN: ${{ secrets.FURYPUSHTOKEN }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      - name: GoReleaser (release)
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: v1.26.2-pro
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
           POSTHOG_API_KEY_FOR_CLI: ${{ secrets.POSTHOG_API_KEY_FOR_CLI }}
@@ -239,62 +251,6 @@ jobs:
           name: goreleaser-dist-linux
           path: dist/
           retention-days: 7
-      - name: Smoke test linux binary across supported distros
-        run: |
-          set -uo pipefail
-          fail=0
-          echo "::group::Static-link assertion (file)"
-          for d in dist/linux-*-rdp_linux_*; do
-            bin="$d/infisical"
-            [ -f "$bin" ] || continue
-            info=$(file "$bin")
-            echo "$info"
-            if ! echo "$info" | grep -q "statically linked"; then
-              echo "::error file=$bin::not statically linked"
-              fail=1
-            fi
-          done
-          echo "::endgroup::"
-
-          BIN=dist/linux-amd64-rdp_linux_amd64_v1/infisical
-          if [ ! -f "$BIN" ]; then
-            echo "::error::expected $BIN missing from dist/"
-            exit 1
-          fi
-          echo "::group::Smoke test linux-amd64 binary across distro floor"
-          for img in \
-              ubuntu:22.04 \
-              ubuntu:20.04 \
-              rockylinux:9 \
-              rockylinux:8 \
-              amazonlinux:2023 \
-              amazonlinux:2 \
-              alpine:3.19 \
-              gcr.io/distroless/static-debian12; do
-            echo "--- $img ---"
-            if ! docker run --rm --platform linux/amd64 \
-                    -v "$PWD/$BIN":/infisical:ro \
-                    "$img" /infisical --version; then
-              echo "::error::binary failed to run on $img"
-              fail=1
-            fi
-          done
-          echo "::endgroup::"
-
-          [ "$fail" -eq 0 ] || exit 1
-      - name: GoReleaser (publish)
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser-pro
-          version: v1.26.2-pro
-          args: release --skip=build,validate,before
-        env:
-          GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
-          POSTHOG_API_KEY_FOR_CLI: ${{ secrets.POSTHOG_API_KEY_FOR_CLI }}
-          FURY_TOKEN: ${{ secrets.FURYPUSHTOKEN }}
-          AUR_KEY: ${{ secrets.AUR_KEY }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"


### PR DESCRIPTION
# Description 📣

`--skip=build` (used in PR #222's publish step) isn't valid in goreleaser-pro v1.26.2 — only added in v2.x. Publish step crashed at startup, so v0.43.83 shipped with only darwin+windows artifacts and no linux. Reverts the workflow to the pre-PR-222 single-step pattern.

## Type ✨

- [x] Bug fix

# Tests 🛠️

Manual: cut a fresh release tag and confirm linux/.deb/.rpm/.apk artifacts ship alongside darwin+windows.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝