### PR TITLE
fix(release): remove --skip=build flag unsupported in goreleaser v1.26.2

### DIFF
--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -31,37 +31,6 @@ jobs:
   build-rdp-bridge:
     uses: ./.github/workflows/build-rdp-bridge.yml
 
-  # Create the GitHub release draft up front so both goreleaser
-  # (ubuntu) and goreleaser-darwin (macos) can append to it in
-  # parallel instead of serializing on ubuntu creating the draft.
-  # Skipped on dry-run since --snapshot doesn't touch GitHub at all.
-  create-release-draft:
-    if: |
-      always() &&
-      (needs.validate-tag-branch.result == 'success' || needs.validate-tag-branch.result == 'skipped') &&
-      needs.cli-tests.result == 'success' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run))
-    needs:
-      - validate-tag-branch
-      - cli-tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Create GitHub release draft (idempotent)
-        run: |
-          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            echo "Release for ${{ github.ref_name }} already exists, skipping creation"
-          else
-            gh release create "${{ github.ref_name }}" \
-              --draft \
-              --title "${{ github.ref_name }}" \
-              --generate-notes
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
-
   # cli-integration-tests:
   #   name: Run tests before deployment
   #   uses: ./.github/workflows/run-cli-tests.yml
@@ -136,12 +105,10 @@ jobs:
       - validate-tag-branch
       - cli-tests
       - build-rdp-bridge
-      - create-release-draft
     if: |
       always() &&
       needs.cli-tests.result == 'success' &&
       needs.build-rdp-bridge.result == 'success' &&
-      (needs.create-release-draft.result == 'success' || needs.create-release-draft.result == 'skipped') &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     steps:
       - uses: actions/checkout@v3
@@ -218,14 +185,13 @@ jobs:
             mkdir -p "$target_dir"
             cp "/tmp/rdp-bridge-artifacts/rdp-bridge-$triple/libinfisical_rdp_bridge.a" "$target_dir/"
           done
-      - name: GoReleaser (build, no publish)
+      - name: GoReleaser (dry-run snapshot)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
-          args: >-
-            release --clean --skip=publish,announce
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--snapshot' || '' }}
+          args: release --clean --snapshot --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
           POSTHOG_API_KEY_FOR_CLI: ${{ secrets.POSTHOG_API_KEY_FOR_CLI }}
@@ -240,6 +206,7 @@ jobs:
           path: dist/
           retention-days: 7
       - name: Smoke test linux binary across supported distros
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
         run: |
           set -uo pipefail
           fail=0
@@ -282,13 +249,13 @@ jobs:
           echo "::endgroup::"
 
           [ "$fail" -eq 0 ] || exit 1
-      - name: GoReleaser (publish)
+      - name: GoReleaser (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
-          args: release --skip=build,validate,before
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
           POSTHOG_API_KEY_FOR_CLI: ${{ secrets.POSTHOG_API_KEY_FOR_CLI }}
@@ -344,12 +311,10 @@ jobs:
       - validate-tag-branch
       - cli-tests
       - build-rdp-bridge
-      - create-release-draft
     if: |
       always() &&
       needs.cli-tests.result == 'success' &&
       needs.build-rdp-bridge.result == 'success' &&
-      (needs.create-release-draft.result == 'success' || needs.create-release-draft.result == 'skipped') &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     steps:
       - uses: actions/checkout@v4
@@ -426,11 +391,9 @@ jobs:
     needs:
       - validate-tag-branch
       - cli-tests
-      - create-release-draft
     if: |
       always() &&
       needs.cli-tests.result == 'success' &&
-      (needs.create-release-draft.result == 'success' || needs.create-release-draft.result == 'skipped') &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     steps:
       - uses: actions/checkout@v3

--- a/.goreleaser-darwin.yaml
+++ b/.goreleaser-darwin.yaml
@@ -45,9 +45,7 @@ archives:
       - manpages/*
       - completions/*
 
-# Append to the release draft created by the ubuntu goreleaser job.
 release:
-  replace_existing_draft: false
   mode: append
 
 checksum:

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -1,6 +1,4 @@
-# Append to the release draft created by the ubuntu goreleaser job.
 release:
-  replace_existing_draft: false
   mode: append
 
 builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -161,10 +161,6 @@ archives:
       - completions/*
 
 release:
-  # The draft is created up front by the create-release-draft workflow
-  # job, so both this config and .goreleaser-darwin.yaml use append mode
-  # to add their artifacts in parallel.
-  replace_existing_draft: false
   mode: append
 
 checksum:


### PR DESCRIPTION
Split the goreleaser step into two mutually exclusive paths:
- Dry-run: --snapshot --skip=publish, then smoke test, then artifact upload
- Real release: single release --clean call (build + publish in one step)

# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->