### PR TITLE
feat: expose PROJECT_ID via environment variable

### DIFF
--- a/packages/cmd/dynamic_secrets.go
+++ b/packages/cmd/dynamic_secrets.go
@@ -43,7 +43,7 @@ func getDynamicSecretList(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -171,7 +171,7 @@ func createDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -342,7 +342,7 @@ func renewDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -477,7 +477,7 @@ func revokeDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -605,7 +605,7 @@ func listDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/packages/cmd/dynamic_secrets.go
+++ b/packages/cmd/dynamic_secrets.go
@@ -43,7 +43,7 @@ func getDynamicSecretList(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -171,7 +171,7 @@ func createDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -342,7 +342,7 @@ func renewDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -477,7 +477,7 @@ func revokeDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -605,7 +605,7 @@ func listDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/packages/cmd/export.go
+++ b/packages/cmd/export.go
@@ -52,7 +52,7 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err)
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err)
 		}

--- a/packages/cmd/export.go
+++ b/packages/cmd/export.go
@@ -52,7 +52,7 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err)
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err)
 		}

--- a/packages/cmd/folder.go
+++ b/packages/cmd/folder.go
@@ -33,7 +33,7 @@ var getCmd = &cobra.Command{
 			}
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -110,7 +110,7 @@ var createCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -202,7 +202,7 @@ var deleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/packages/cmd/folder.go
+++ b/packages/cmd/folder.go
@@ -33,7 +33,7 @@ var getCmd = &cobra.Command{
 			}
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -110,7 +110,7 @@ var createCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -202,7 +202,7 @@ var deleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -77,7 +77,7 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/packages/cmd/run.go
+++ b/packages/cmd/run.go
@@ -77,7 +77,7 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/packages/cmd/secrets.go
+++ b/packages/cmd/secrets.go
@@ -38,7 +38,7 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -191,7 +191,7 @@ var secretsSetCmd = &cobra.Command{
 			}
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -341,7 +341,7 @@ var secretsDeleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -454,7 +454,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -597,7 +597,7 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/packages/cmd/secrets.go
+++ b/packages/cmd/secrets.go
@@ -38,7 +38,7 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -191,7 +191,7 @@ var secretsSetCmd = &cobra.Command{
 			}
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -341,7 +341,7 @@ var secretsDeleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -454,7 +454,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -597,7 +597,7 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/packages/cmd/ssh.go
+++ b/packages/cmd/ssh.go
@@ -884,7 +884,7 @@ func sshAddHost(cmd *cobra.Command, args []string) {
 		infisicalToken = loggedInUserDetails.UserCredentials.JTWToken
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse --projectId flag")
 	}

--- a/packages/cmd/ssh.go
+++ b/packages/cmd/ssh.go
@@ -884,7 +884,7 @@ func sshAddHost(cmd *cobra.Command, args []string) {
 		infisicalToken = loggedInUserDetails.UserCredentials.JTWToken
 	}
 
-	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+	projectId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 	if err != nil {
 		util.HandleError(err, "Unable to parse --projectId flag")
 	}

--- a/packages/cmd/tokens.go
+++ b/packages/cmd/tokens.go
@@ -53,7 +53,7 @@ var tokensCreateCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		workspaceId, err := cmd.Flags().GetString("projectId")
+		workspaceId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/packages/cmd/tokens.go
+++ b/packages/cmd/tokens.go
@@ -53,7 +53,7 @@ var tokensCreateCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		workspaceId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME, "PROJECT_ID"}, "")
+		workspaceId, err := util.GetCmdFlagOrEnvWithDefaultValue(cmd, "projectId", []string{util.INFISICAL_PROJECT_ID_NAME}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/packages/util/constants.go
+++ b/packages/util/constants.go
@@ -7,6 +7,7 @@ const (
 	INFISICAL_DEFAULT_EU_URL                   = "https://eu.infisical.com"
 	INFISICAL_WORKSPACE_CONFIG_FILE_NAME       = ".infisical.json"
 	INFISICAL_TOKEN_NAME                       = "INFISICAL_TOKEN"
+	INFISICAL_PROJECT_ID_NAME                  = "INFISICAL_PROJECT_ID"
 	INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN_NAME = "INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN"
 	INFISICAL_VAULT_FILE_PASSPHRASE_ENV_NAME   = "INFISICAL_VAULT_FILE_PASSPHRASE" // This works because we've forked the keyring package and added support for this env variable. This explains why you won't find any occurrences of it in the CLI codebase.
 


### PR DESCRIPTION
Fixes #213

This PR allows users to pass the project ID via the `INFISICAL_PROJECT_ID` or `PROJECT_ID` environment variables across all CLI commands.

Previously, users using CI/CD pipelines had to explicitly pass `--projectId=...` as a flag, even if they had `PROJECT_ID` exported in their environment (unlike `INFISICAL_TOKEN` which was automatically picked up). This update uses `GetCmdFlagOrEnvWithDefaultValue` to cleanly fall back to the environment variables if the flag is omitted.