### PR TITLE
improvement: decrease gateway health check interval for HA

### DIFF
--- a/packages/gateway-v2/connection.go
+++ b/packages/gateway-v2/connection.go
@@ -273,3 +273,9 @@ func handlePing(ctx context.Context, conn *tls.Conn, reader *bufio.Reader) error
 	conn.Write([]byte("PONG\n"))
 	return nil
 }
+
+func handleHealth(ctx context.Context, conn *tls.Conn, reader *bufio.Reader, heartbeatTTL int) error {
+	response := fmt.Sprintf(`{"status":"ok","heartbeatTTL":%d}`, heartbeatTTL)
+	conn.Write([]byte(response + "\n"))
+	return nil
+}

--- a/packages/gateway-v2/gateway.go
+++ b/packages/gateway-v2/gateway.go
@@ -365,8 +365,8 @@ func (g *Gateway) registerHeartBeat(ctx context.Context, errCh chan error) {
 			}
 		}()
 
-		// Phase 2: Regular heartbeat every 30 minutes
-		regularTicker := time.NewTicker(30 * time.Minute)
+		// Phase 2: Regular heartbeat every 3 minutes
+		regularTicker := time.NewTicker(3 * time.Minute)
 		defer regularTicker.Stop()
 
 		for {

--- a/packages/gateway-v2/gateway.go
+++ b/packages/gateway-v2/gateway.go
@@ -38,6 +38,7 @@ const (
 	ForwardModePAMCancellation ForwardMode = "PAM_CANCELLATION"
 	ForwardModePAMCapabilities ForwardMode = "PAM_CAPABILITIES"
 	ForwardModePing            ForwardMode = "PING"
+	ForwardModeHealth          ForwardMode = "HEALTH"
 )
 
 type ActorType string
@@ -46,6 +47,8 @@ const (
 	ActorTypePlatform ActorType = "platform"
 	ActorTypeUser     ActorType = "user"
 )
+
+const heartbeatInterval = 3 * time.Minute
 
 const GATEWAY_ROUTING_INFO_OID = "1.3.6.1.4.1.12345.100.1"
 const GATEWAY_ACTOR_OID = "1.3.6.1.4.1.12345.100.2"
@@ -365,8 +368,8 @@ func (g *Gateway) registerHeartBeat(ctx context.Context, errCh chan error) {
 			}
 		}()
 
-		// Phase 2: Regular heartbeat every 3 minutes
-		regularTicker := time.NewTicker(3 * time.Minute)
+		// Phase 2: Regular heartbeat
+		regularTicker := time.NewTicker(heartbeatInterval)
 		defer regularTicker.Stop()
 
 		for {
@@ -669,7 +672,7 @@ func (g *Gateway) setupTLSConfig() error {
 		ClientCAs:  clientCAPool,
 		ClientAuth: tls.RequireAndVerifyClientCert,
 		MinVersion: tls.VersionTLS12,
-		NextProtos: []string{"infisical-http-proxy", "infisical-tcp-proxy", "infisical-ping", "infisical-pam-proxy", "infisical-pam-session-cancellation", "infisical-pam-capabilities"},
+		NextProtos: []string{"infisical-http-proxy", "infisical-tcp-proxy", "infisical-health", "infisical-ping", "infisical-pam-proxy", "infisical-pam-session-cancellation", "infisical-pam-capabilities"},
 	}
 
 	return nil
@@ -873,6 +876,14 @@ func (g *Gateway) handleIncomingChannel(newChannel ssh.NewChannel) {
 			log.Info().Msg("Ping handler completed")
 		}
 		return
+	} else if forwardConfig.Mode == ForwardModeHealth {
+		log.Info().Msg("Starting health handler")
+		if err := handleHealth(g.ctx, tlsConn, reader, int(heartbeatInterval.Seconds())); err != nil {
+			log.Error().Err(err).Msg("Health handler ended with error")
+		} else {
+			log.Info().Msg("Health handler completed")
+		}
+		return
 	}
 }
 
@@ -917,6 +928,10 @@ func (g *Gateway) parseForwardConfigFromALPN(tlsConn *tls.Conn, reader *bufio.Re
 
 	case "infisical-ping":
 		config.Mode = ForwardModePing
+		return config, nil
+
+	case "infisical-health":
+		config.Mode = ForwardModeHealth
 		return config, nil
 
 	default:


### PR DESCRIPTION
# Description 📣

Reduces gateway heartbeat interval from 30 min to 3 min so the backend can detect dead gateways within 5 minutes for pool load balancing.

Companion Infisical PR: https://github.com/Infisical/infisical/pull/6432

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->