### PR TITLE
chore: pin GitHub workflow dependencies by SHA

### DIFF
--- a/.github/workflows/build-rdp-bridge.yml
+++ b/.github/workflows/build-rdp-bridge.yml
@@ -23,10 +23,10 @@ jobs:
           - target: armv7-unknown-linux-musleabihf
           - target: x86_64-pc-windows-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -46,7 +46,7 @@ jobs:
         run: cross build --release --target ${{ matrix.target }}
 
       - name: Upload static library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rdp-bridge-${{ matrix.target }}
           path: packages/pam/handlers/rdp/native/target/${{ matrix.target }}/release/libinfisical_rdp_bridge.a
@@ -65,10 +65,10 @@ jobs:
           - target: x86_64-apple-darwin
           - target: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -87,7 +87,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload static library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rdp-bridge-${{ matrix.target }}
           path: packages/pam/handlers/rdp/native/target/${{ matrix.target }}/release/libinfisical_rdp_bridge.a

--- a/.github/workflows/pre-tag-validation.yml
+++ b/.github/workflows/pre-tag-validation.yml
@@ -7,7 +7,7 @@ jobs:
   validate-tag-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -62,7 +62,7 @@ jobs:
       - validate-tag-branch
       - cli-tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -111,22 +111,22 @@ jobs:
       needs.build-rdp-bridge.result == 'success' &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
       - name: 🐋 Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: 🔧 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
       - run: git fetch --force --tags
       - run: echo "Ref name ${{github.ref_name}}"
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
           go-version: "1.25.9"
           cache: true
@@ -167,7 +167,7 @@ jobs:
             echo "/opt/musl-cross/${triple}/bin" >> "$GITHUB_PATH"
           done
       - name: Download RDP bridge static libs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: rdp-bridge-*
           path: /tmp/rdp-bridge-artifacts/
@@ -187,7 +187,7 @@ jobs:
           done
       - name: GoReleaser (dry-run snapshot)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
@@ -200,7 +200,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - name: Upload dry-run dist as workflow artifact
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: goreleaser-dist-linux
           path: dist/
@@ -251,7 +251,7 @@ jobs:
           [ "$fail" -eq 0 ] || exit 1
       - name: GoReleaser (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
@@ -262,7 +262,7 @@ jobs:
           FURY_TOKEN: ${{ secrets.FURYPUSHTOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: "3.12"
       - name: Install mkrepo and dependencies
@@ -271,7 +271,7 @@ jobs:
         run: pip install awscli
       - name: Install rpm-sign
         run: sudo apt-get install -y rpm
-      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252
+      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
         with:
           ruby-version: "3.3" # Not needed with a .ruby-version, .tool-versions or mise.toml
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -317,21 +317,21 @@ jobs:
       needs.build-rdp-bridge.result == 'success' &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Fetch all tags
         run: git fetch --force --tags
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25.9"
           cache: true
           cache-dependency-path: go.sum
 
       - name: Download darwin RDP bridge static libs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: rdp-bridge-*-apple-darwin
           path: /tmp/rdp-bridge-artifacts/
@@ -347,7 +347,7 @@ jobs:
 
       - name: GoReleaser Darwin (dry-run snapshot)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
@@ -359,7 +359,7 @@ jobs:
 
       - name: GoReleaser Darwin (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
@@ -371,7 +371,7 @@ jobs:
 
       - name: Upload dry-run dist as workflow artifact
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: goreleaser-dist-darwin
           path: dist/
@@ -396,7 +396,7 @@ jobs:
       needs.cli-tests.result == 'success' &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -404,14 +404,14 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
           go-version: "1.25.9"
           cache: true
           cache-dependency-path: go.sum
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -433,14 +433,14 @@ jobs:
         run: cargo build --release --target x86_64-pc-windows-gnu
 
       - name: 🐋 Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: GoReleaser Windows (dry-run snapshot)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
@@ -452,7 +452,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - name: GoReleaser Windows (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
@@ -464,7 +464,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - name: Upload dry-run dist as workflow artifact
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: goreleaser-dist-windows
           path: dist/

--- a/.github/workflows/run-cli-e2e-tests.yml
+++ b/.github/workflows/run-cli-e2e-tests.yml
@@ -12,9 +12,9 @@ jobs:
     name: CLI End-to-End Testing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
       - name: Install dependencies
@@ -22,7 +22,7 @@ jobs:
       - name: Build the CLI
         run: go build -o infisical-cli
       - name: Checkout infisical repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: infisical/infisical
           path: infisical
@@ -48,9 +48,9 @@ jobs:
     name: Agent End-to-End Testing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Build the CLI
         run: go build -o infisical-cli
       - name: Checkout infisical repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: infisical/infisical
           path: infisical
@@ -75,9 +75,9 @@ jobs:
     name: PAM End-to-End Testing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
       - name: Install dependencies
@@ -85,7 +85,7 @@ jobs:
       - name: Build the CLI
         run: go build -o infisical-cli
       - name: Checkout infisical repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: infisical/infisical
           path: infisical

--- a/.github/workflows/run-cli-rdp-smoke.yml
+++ b/.github/workflows/run-cli-rdp-smoke.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25.9"
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/run-cli-tests.yml
+++ b/.github/workflows/run-cli-tests.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: "1.25.9"
       - name: Install dependencies

--- a/.github/workflows/test-update-instructions.yml
+++ b/.github/workflows/test-update-instructions.yml
@@ -8,8 +8,8 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: "1.25.9"
       - name: Run unit tests
@@ -18,8 +18,8 @@ jobs:
   integration-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: "1.25.9"
       - name: Build test helper
@@ -67,8 +67,8 @@ jobs:
   integration-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: "1.25.9"
       - name: Build test helper
@@ -94,8 +94,8 @@ jobs:
   integration-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: "1.25.9"
       - name: Build test helper


### PR DESCRIPTION
# Description 📣


  Pinned all external GitHub Action dependencies to immutable commit SHAs across all CLI workflow files. Version tags (e.g., `@v4`) are mutable — the tag owner can re-point them to arbitrary code at any time.
  Commit SHAs are the only truly immutable reference, preventing supply chain attacks via compromised or re-tagged actions.

  This matches the approach already applied to the platform repo in https://github.com/Infisical/infisical/pull/6435 and is required by the org-level SHA-pinning policy that was recently enabled.


| Action | Version | Count | What it does |
|---|---|---|---|
| **actions/checkout** | v3.6.0 | 8 | Clones the repo into the runner (release + windows + validation + update-tests workflows) |
| | v4.3.1 | 5 | Same — clones the repo (RDP bridge, darwin release, smoke test, CLI tests) |
| | v6.0.2 | 6 | Same — clones the repo (E2E tests — self checkout + infisical platform checkout) |
| **actions/setup-go** | v3.6.1 | 2 | Installs Go toolchain (goreleaser linux + windows jobs) |
| | v4.3.0 | 5 | Same (CLI tests + update instruction tests) |
| | v5.6.0 | 2 | Same (darwin release + RDP smoke test) |
| | v6.4.0 | 3 | Same (E2E tests) |
| **goreleaser/goreleaser-action** | v4.6.0 | 6 | Runs GoReleaser Pro to build + publish CLI binaries (linux, darwin, windows — dry-run + release each) |
| **actions/upload-artifact** | v4.6.2 | 5 | Uploads build artifacts (RDP bridge libs, goreleaser dist dirs) |
| **actions/cache** | v4.3.0 | 4 | Caches cargo registry / Go modules between runs |
| **actions/download-artifact** | v4.3.0 | 2 | Downloads RDP bridge static libs built in earlier jobs |
| **docker/login-action** | v2.2.0 | 2 | Authenticates to Docker Hub for pushing CLI container images |
| **docker/setup-qemu-action** | v3.7.0 | 1 | Enables QEMU for multi-arch Docker builds (linux/arm64 etc.) |
| **docker/setup-buildx-action** | v2.10.0 | 1 | Sets up Docker Buildx for multi-platform image builds |
| **actions/setup-python** | v4.9.1 | 1 | Installs Python (for mkrepo, cloudsmith CLI, AWS CLI in release job) |
| **actions/setup-node** | v4.0.0 | 1 | Installs Node.js (for NPM package publishing in release job) |
| **ruby/setup-ruby** | v1.229.0 | 1 | Installs Ruby (for deb-s3 gem used to publish .deb packages) |


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->