### PR TITLE
fix(relay): fix misleading "packet length too long" error when gateway is unreachable

### DIFF
--- a/packages/relay/relay.go
+++ b/packages/relay/relay.go
@@ -420,23 +420,24 @@ func (r *Relay) handleSSHAgent(conn net.Conn) {
 	gatewayName := sshConn.Permissions.Extensions["gateway-name"]
 	log.Info().Msgf("SSH handshake successful for gateway: %s (%s)", gatewayName, gatewayId)
 
-	// Store the connection, replacing any stale one from a previous session.
+	// Store the connection (ensure only one connection per gateway)
 	r.mu.Lock()
-	if old, exists := r.tunnels[gatewayId]; exists {
-		log.Warn().Msgf("Gateway %s (%s) reconnected, closing stale SSH connection", gatewayName, gatewayId)
-		old.Close()
+	if _, exists := r.tunnels[gatewayId]; exists {
+		r.mu.Unlock()
+		log.Warn().Msgf("Gateway %s (%s) already has an active connection, rejecting new connection", gatewayName, gatewayId)
+		sshConn.Close()
+		return
 	}
+
 	r.tunnels[gatewayId] = sshConn
 	r.mu.Unlock()
 
 	// Clean up when agent disconnects
 	defer func() {
 		r.mu.Lock()
-		if r.tunnels[gatewayId] == sshConn {
-			delete(r.tunnels, gatewayId)
-			log.Info().Msgf("Gateway %s (%s) disconnected", gatewayName, gatewayId)
-		}
+		delete(r.tunnels, gatewayId)
 		r.mu.Unlock()
+		log.Info().Msgf("Gateway %s (%s) disconnected", gatewayName, gatewayId)
 	}()
 
 	// Handle global requests (reject all for security)

--- a/packages/relay/relay.go
+++ b/packages/relay/relay.go
@@ -420,24 +420,23 @@ func (r *Relay) handleSSHAgent(conn net.Conn) {
 	gatewayName := sshConn.Permissions.Extensions["gateway-name"]
 	log.Info().Msgf("SSH handshake successful for gateway: %s (%s)", gatewayName, gatewayId)
 
-	// Store the connection (ensure only one connection per gateway)
+	// Store the connection, replacing any stale one from a previous session.
 	r.mu.Lock()
-	if _, exists := r.tunnels[gatewayId]; exists {
-		r.mu.Unlock()
-		log.Warn().Msgf("Gateway %s (%s) already has an active connection, rejecting new connection", gatewayName, gatewayId)
-		sshConn.Close()
-		return
+	if old, exists := r.tunnels[gatewayId]; exists {
+		log.Warn().Msgf("Gateway %s (%s) reconnected, closing stale SSH connection", gatewayName, gatewayId)
+		old.Close()
 	}
-
 	r.tunnels[gatewayId] = sshConn
 	r.mu.Unlock()
 
 	// Clean up when agent disconnects
 	defer func() {
 		r.mu.Lock()
-		delete(r.tunnels, gatewayId)
+		if r.tunnels[gatewayId] == sshConn {
+			delete(r.tunnels, gatewayId)
+			log.Info().Msgf("Gateway %s (%s) disconnected", gatewayName, gatewayId)
+		}
 		r.mu.Unlock()
-		log.Info().Msgf("Gateway %s (%s) disconnected", gatewayName, gatewayId)
 	}()
 
 	// Handle global requests (reject all for security)

--- a/packages/relay/relay.go
+++ b/packages/relay/relay.go
@@ -559,7 +559,6 @@ func (r *Relay) handleClient(tlsConn *tls.Conn) {
 
 	if !exists {
 		log.Warn().Msgf("Gateway '%s' (%s) not connected", gatewayName, gatewayId)
-		tlsConn.Write([]byte("ERROR: Gateway not connected\n"))
 		return
 	}
 
@@ -568,7 +567,6 @@ func (r *Relay) handleClient(tlsConn *tls.Conn) {
 	channel, _, err := conn.OpenChannel("direct-tcpip", nil)
 	if err != nil {
 		log.Error().Msgf("Failed to connect to gateway: %v", err)
-		tlsConn.Write([]byte("ERROR: Failed to connect to gateway\n"))
 		return
 	}
 	defer channel.Close()


### PR DESCRIPTION
# Description 📣

When the relay can't route a client to a gateway, it wrote plaintext error strings on the TLS connection. The client performs a nested TLS handshake over this connection, so its TLS parser misinterprets the plaintext as a malformed TLS record — producing a cryptic OpenSSL "packet length too long" error.

Remove the plaintext writes. The connection close alone signals the failure, producing a clear "socket disconnected before secure TLS connection was established" message instead.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->