### PR TITLE
feat(gateway): match systemd service name to gateway name

### DIFF
--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -708,7 +708,7 @@ var gatewaySystemdUninstallCmd = &cobra.Command{
 	Long:                  "Uninstall and remove systemd service for the gateway. Must be run with sudo on Linux.",
 	Example:               "sudo infisical gateway systemd uninstall my-gateway",
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(1),
+	Args:                  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if runtime.GOOS != "linux" {
 			util.HandleError(fmt.Errorf("systemd service uninstallation is only supported on Linux"))
@@ -716,6 +716,13 @@ var gatewaySystemdUninstallCmd = &cobra.Command{
 
 		if os.Geteuid() != 0 {
 			util.HandleError(fmt.Errorf("systemd service uninstallation requires root/sudo privileges"))
+		}
+
+		if len(args) == 0 {
+			if err := gatewayv2.UninstallLegacyGatewaySystemdService(); err != nil {
+				util.HandleError(err, "Failed to uninstall systemd service")
+			}
+			return
 		}
 
 		if err := gatewayv2.UninstallGatewaySystemdService(args[0]); err != nil {

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -571,7 +571,7 @@ var gatewaySystemdCmd = &cobra.Command{
 	Short: "Manage systemd service for Infisical gateway",
 	Long:  "Manage systemd service for Infisical gateway. Use 'systemd install' to install and enable the service.",
 	Example: `sudo infisical gateway systemd install my-gateway --token=<token> --domain=<domain>
-  sudo infisical gateway systemd uninstall`,
+  sudo infisical gateway systemd uninstall my-gateway`,
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.NoArgs,
 }
@@ -619,6 +619,8 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 
 		enrollMethod, _ := cmd.Flags().GetString("enroll-method")
 
+		var installedServiceName string
+
 		if enrollMethod == gatewayv2.EnrollMethodToken {
 			// --- Enrollment token path ---
 			enrollToken, flagErr := cmd.Flags().GetString("token")
@@ -642,9 +644,11 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 			}
 
 			// Install systemd service using the long-lived access token
-			if installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
+			svcName, installErr := gatewayv2.InstallEnrolledGatewaySystemdService(enrollResp.AccessToken, domain, gatewayName, relayName, serviceLogFile)
+			if installErr != nil {
 				util.HandleError(installErr, "Unable to install systemd service")
 			}
+			installedServiceName = svcName
 		} else if enrollMethod == gatewayv2.EnrollMethodAws {
 			// --- AWS Auth path ---
 			// Don't perform the AWS login at install time — the gateway does it on each service
@@ -656,9 +660,11 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 
 			relayName, _ := util.GetRelayName(cmd, false, "")
 
-			if installErr := gatewayv2.InstallAwsAuthGatewaySystemdService(gatewayID, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
+			svcName, installErr := gatewayv2.InstallAwsAuthGatewaySystemdService(gatewayID, domain, gatewayName, relayName, serviceLogFile)
+			if installErr != nil {
 				util.HandleError(installErr, "Unable to install systemd service")
 			}
+			installedServiceName = svcName
 		} else {
 			// --- Machine identity token path ---
 			token, tokenErr := util.GetInfisicalToken(cmd)
@@ -675,38 +681,44 @@ var gatewaySystemdInstallCmd = &cobra.Command{
 				util.HandleError(relayErr, "unable to get relay name")
 			}
 
-			if installErr := gatewayv2.InstallGatewaySystemdService(token.Token, domain, gatewayName, relayName, serviceLogFile); installErr != nil {
+			svcName, installErr := gatewayv2.InstallGatewaySystemdService(token.Token, domain, gatewayName, relayName, serviceLogFile)
+			if installErr != nil {
 				util.HandleError(installErr, "Unable to install systemd service")
 			}
+			installedServiceName = svcName
 		}
 
-		enableCmd := exec.Command("systemctl", "enable", "infisical-gateway")
+		if installedServiceName == "" {
+			return
+		}
+
+		enableCmd := exec.Command("systemctl", "enable", installedServiceName)
 		if err := enableCmd.Run(); err != nil {
 			util.HandleError(err, "Failed to enable systemd service")
 		}
 
-		log.Info().Msg("Successfully installed and enabled infisical-gateway service")
-		log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
+		log.Info().Msgf("Successfully installed and enabled %s service", installedServiceName)
+		log.Info().Msgf("To start the service, run: sudo systemctl start %s", installedServiceName)
 	},
 }
 
 var gatewaySystemdUninstallCmd = &cobra.Command{
-	Use:                   "uninstall",
+	Use:                   "uninstall [name]",
 	Short:                 "Uninstall and remove systemd service for the gateway (requires sudo)",
 	Long:                  "Uninstall and remove systemd service for the gateway. Must be run with sudo on Linux.",
-	Example:               "sudo infisical gateway systemd uninstall",
+	Example:               "sudo infisical gateway systemd uninstall my-gateway",
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.NoArgs,
+	Args:                  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if runtime.GOOS != "linux" {
-			util.HandleError(fmt.Errorf("systemd service installation is only supported on Linux"))
+			util.HandleError(fmt.Errorf("systemd service uninstallation is only supported on Linux"))
 		}
 
 		if os.Geteuid() != 0 {
-			util.HandleError(fmt.Errorf("systemd service installation requires root/sudo privileges"))
+			util.HandleError(fmt.Errorf("systemd service uninstallation requires root/sudo privileges"))
 		}
 
-		if err := gatewayv2.UninstallGatewaySystemdService(); err != nil {
+		if err := gatewayv2.UninstallGatewaySystemdService(args[0]); err != nil {
 			util.HandleError(err, "Failed to uninstall systemd service")
 		}
 	},

--- a/packages/gateway-v2/enroll.go
+++ b/packages/gateway-v2/enroll.go
@@ -30,19 +30,14 @@ func gatewayConfPath(name string) (string, error) {
 	return filepath.Join(homeDir, ".infisical", "gateways", name+".conf"), nil
 }
 
-// loadConfKey reads a key from the named gateway's config file. Returns empty string if not found.
-func loadConfKey(name, key string) (string, error) {
-	confPath, err := gatewayConfPath(name)
-	if err != nil {
-		return "", err
-	}
-
-	data, err := os.ReadFile(confPath)
+// readKeyFromConfFile reads a key=value pair from a config file at the given path.
+func readKeyFromConfFile(path, key string) (string, error) {
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return "", nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("failed to read gateway config: %w", err)
+		return "", fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	prefix := key + "="
@@ -54,6 +49,15 @@ func loadConfKey(name, key string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// loadConfKey reads a key from the named gateway's config file. Returns empty string if not found.
+func loadConfKey(name, key string) (string, error) {
+	confPath, err := gatewayConfPath(name)
+	if err != nil {
+		return "", err
+	}
+	return readKeyFromConfFile(confPath, key)
 }
 
 // saveConfKey writes a key=value pair to the named gateway's config file, preserving other keys.

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -41,7 +41,7 @@ func detectLegacyService() legacyInfo {
 }
 
 func logLegacyWarning(svcName string) {
-	log.Warn().Msgf("Using legacy service name '%s'. To migrate to the new naming format, run: sudo infisical gateway systemd uninstall %s && sudo infisical gateway systemd install %s <original-flags>", legacyServiceName, svcName, svcName)
+	log.Warn().Msgf("Using legacy service name '%s'. To migrate to the new naming format, run: sudo infisical gateway systemd uninstall %s, then get a fresh install command from the Infisical dashboard.", legacyServiceName, svcName)
 }
 
 type installResult struct {
@@ -319,4 +319,15 @@ func UninstallGatewaySystemdService(name string) error {
 
 	log.Info().Msgf("Successfully uninstalled gateway service '%s'", svcName)
 	return nil
+}
+
+func UninstallLegacyGatewaySystemdService() error {
+	legacy := detectLegacyService()
+	if !legacy.exists {
+		return fmt.Errorf("no legacy gateway service found. Please provide a gateway name: sudo infisical gateway systemd uninstall <name>")
+	}
+	if legacy.gatewayName == "" {
+		return fmt.Errorf("legacy gateway service found but has no gateway name in config")
+	}
+	return UninstallGatewaySystemdService(legacy.gatewayName)
 }

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -6,25 +6,106 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/util"
 	"github.com/rs/zerolog/log"
 )
 
-func InstallGatewaySystemdService(token string, domain string, name string, relayName string, serviceLogFile string) error {
+const (
+	legacyServiceName  = "infisical-gateway"
+	legacyConfigPath   = "/etc/infisical/gateway.conf"
+	legacyServicePath  = "/etc/systemd/system/infisical-gateway.service"
+	gatewaysConfigDir  = "/etc/infisical/gateways"
+)
+
+func serviceName(name string) string {
+	return name
+}
+
+func serviceFilePath(name string) string {
+	return fmt.Sprintf("/etc/systemd/system/%s.service", serviceName(name))
+}
+
+func gatewayConfigPath(name string) string {
+	return filepath.Join(gatewaysConfigDir, name+".conf")
+}
+
+type legacyInfo struct {
+	exists      bool
+	gatewayName string
+}
+
+func detectLegacyService() legacyInfo {
+	if _, err := os.Stat(legacyServicePath); os.IsNotExist(err) {
+		return legacyInfo{}
+	}
+
+	data, err := os.ReadFile(legacyConfigPath)
+	if err != nil {
+		return legacyInfo{exists: true}
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, GATEWAY_NAME_ENV_NAME+"=") {
+			return legacyInfo{
+				exists:      true,
+				gatewayName: strings.TrimPrefix(line, GATEWAY_NAME_ENV_NAME+"="),
+			}
+		}
+	}
+
+	return legacyInfo{exists: true}
+}
+
+func logLegacyWarning(svcName string) {
+	log.Warn().Msgf("Using legacy service name '%s'. To migrate to the new naming format, run: sudo infisical gateway systemd uninstall %s && sudo infisical gateway systemd install %s <original-flags>", legacyServiceName, svcName, svcName)
+}
+
+type installResult struct {
+	serviceName string
+	configPath  string
+	isLegacy    bool
+}
+
+func resolveInstallPaths(name string) installResult {
+	legacy := detectLegacyService()
+
+	if legacy.exists && legacy.gatewayName == name {
+		return installResult{
+			serviceName: legacyServiceName,
+			configPath:  legacyConfigPath,
+			isLegacy:    true,
+		}
+	}
+
+	if legacy.exists {
+		log.Warn().Msgf("A legacy gateway service '%s' was found for gateway '%s'. The new gateway '%s' will be installed alongside it.", legacyServiceName, legacy.gatewayName, name)
+	}
+
+	return installResult{
+		serviceName: serviceName(name),
+		configPath:  gatewayConfigPath(name),
+		isLegacy:    false,
+	}
+}
+
+func InstallGatewaySystemdService(token string, domain string, name string, relayName string, serviceLogFile string) (string, error) {
 	if runtime.GOOS != "linux" {
 		log.Info().Msg("Skipping systemd service installation - not on Linux")
-		return nil
+		return "", nil
 	}
 
 	if os.Geteuid() != 0 {
 		log.Info().Msg("Skipping systemd service installation - not running as root/sudo")
-		return nil
+		return "", nil
 	}
 
-	configDir := "/etc/infisical"
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %v", err)
+	paths := resolveInstallPaths(name)
+
+	if err := os.MkdirAll(filepath.Dir(paths.configPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create config directory: %v", err)
 	}
 
 	configContent := fmt.Sprintf("INFISICAL_TOKEN=%s\n", token)
@@ -39,48 +120,52 @@ func InstallGatewaySystemdService(token string, domain string, name string, rela
 		configContent += fmt.Sprintf("%s=%s\n", RELAY_NAME_ENV_NAME, relayName)
 	}
 
-	environmentFilePath := filepath.Join(configDir, "gateway.conf")
-	if err := os.WriteFile(environmentFilePath, []byte(configContent), 0600); err != nil {
-		return fmt.Errorf("failed to write environment file: %v", err)
+	if err := os.WriteFile(paths.configPath, []byte(configContent), 0600); err != nil {
+		return "", fmt.Errorf("failed to write environment file: %v", err)
 	}
 
-	if err := util.WriteSystemdServiceFile(serviceLogFile, environmentFilePath, "infisical-gateway", "gateway", "Infisical Gateway Service"); err != nil {
-		return fmt.Errorf("failed to write systemd service file: %v", err)
+	if err := util.WriteSystemdServiceFile(serviceLogFile, paths.configPath, paths.serviceName, "gateway", fmt.Sprintf("Infisical Gateway Service (%s)", name)); err != nil {
+		return "", fmt.Errorf("failed to write systemd service file: %v", err)
 	}
 
-	if err := util.WriteLogrotateFile(serviceLogFile, "infisical-gateway"); err != nil {
-		return fmt.Errorf("failed to write logrotate file: %v", err)
+	if err := util.WriteLogrotateFile(serviceLogFile, paths.serviceName); err != nil {
+		return "", fmt.Errorf("failed to write logrotate file: %v", err)
 	}
 
 	reloadCmd := exec.Command("systemctl", "daemon-reload")
 	if err := reloadCmd.Run(); err != nil {
-		return fmt.Errorf("failed to reload systemd: %v", err)
+		return "", fmt.Errorf("failed to reload systemd: %v", err)
 	}
 
-	log.Info().Msg("Successfully installed systemd service")
-	log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
-	log.Info().Msg("To enable the service on boot, run: sudo systemctl enable infisical-gateway")
+	if paths.isLegacy {
+		logLegacyWarning(name)
+	}
 
-	return nil
+	log.Info().Msgf("Successfully installed systemd service '%s'", paths.serviceName)
+	log.Info().Msgf("To start the service, run: sudo systemctl start %s", paths.serviceName)
+	log.Info().Msgf("To enable the service on boot, run: sudo systemctl enable %s", paths.serviceName)
+
+	return paths.serviceName, nil
 }
 
 // InstallEnrolledGatewaySystemdService installs the systemd service for a gateway that was
 // enrolled via the enrollment token flow. It writes the long-lived gateway access token
 // (not a machine identity token) into the environment file.
-func InstallEnrolledGatewaySystemdService(accessToken string, domain string, name string, relayName string, serviceLogFile string) error {
+func InstallEnrolledGatewaySystemdService(accessToken string, domain string, name string, relayName string, serviceLogFile string) (string, error) {
 	if runtime.GOOS != "linux" {
 		log.Info().Msg("Skipping systemd service installation - not on Linux")
-		return nil
+		return "", nil
 	}
 
 	if os.Geteuid() != 0 {
 		log.Info().Msg("Skipping systemd service installation - not running as root/sudo")
-		return nil
+		return "", nil
 	}
 
-	configDir := "/etc/infisical"
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %v", err)
+	paths := resolveInstallPaths(name)
+
+	if err := os.MkdirAll(filepath.Dir(paths.configPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create config directory: %v", err)
 	}
 
 	configContent := fmt.Sprintf("%s=%s\n", INFISICAL_GATEWAY_ACCESS_TOKEN_KEY, accessToken)
@@ -94,29 +179,32 @@ func InstallEnrolledGatewaySystemdService(accessToken string, domain string, nam
 		configContent += fmt.Sprintf("%s=%s\n", RELAY_NAME_ENV_NAME, relayName)
 	}
 
-	environmentFilePath := filepath.Join(configDir, "gateway.conf")
-	if err := os.WriteFile(environmentFilePath, []byte(configContent), 0600); err != nil {
-		return fmt.Errorf("failed to write environment file: %v", err)
+	if err := os.WriteFile(paths.configPath, []byte(configContent), 0600); err != nil {
+		return "", fmt.Errorf("failed to write environment file: %v", err)
 	}
 
-	if err := util.WriteSystemdServiceFile(serviceLogFile, environmentFilePath, "infisical-gateway", "gateway", "Infisical Gateway Service"); err != nil {
-		return fmt.Errorf("failed to write systemd service file: %v", err)
+	if err := util.WriteSystemdServiceFile(serviceLogFile, paths.configPath, paths.serviceName, "gateway", fmt.Sprintf("Infisical Gateway Service (%s)", name)); err != nil {
+		return "", fmt.Errorf("failed to write systemd service file: %v", err)
 	}
 
-	if err := util.WriteLogrotateFile(serviceLogFile, "infisical-gateway"); err != nil {
-		return fmt.Errorf("failed to write logrotate file: %v", err)
+	if err := util.WriteLogrotateFile(serviceLogFile, paths.serviceName); err != nil {
+		return "", fmt.Errorf("failed to write logrotate file: %v", err)
 	}
 
 	reloadCmd := exec.Command("systemctl", "daemon-reload")
 	if err := reloadCmd.Run(); err != nil {
-		return fmt.Errorf("failed to reload systemd: %v", err)
+		return "", fmt.Errorf("failed to reload systemd: %v", err)
 	}
 
-	log.Info().Msg("Successfully installed systemd service")
-	log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
-	log.Info().Msg("To enable the service on boot, run: sudo systemctl enable infisical-gateway")
+	if paths.isLegacy {
+		logLegacyWarning(name)
+	}
 
-	return nil
+	log.Info().Msgf("Successfully installed systemd service '%s'", paths.serviceName)
+	log.Info().Msgf("To start the service, run: sudo systemctl start %s", paths.serviceName)
+	log.Info().Msgf("To enable the service on boot, run: sudo systemctl enable %s", paths.serviceName)
+
+	return paths.serviceName, nil
 }
 
 // InstallAwsAuthGatewaySystemdService installs the systemd service for a gateway using AWS Auth.
@@ -124,20 +212,21 @@ func InstallEnrolledGatewaySystemdService(accessToken string, domain string, nam
 // fresh STS-signed login on each service start using whatever AWS credentials it can resolve
 // (instance role, env vars, shared profile). We just persist the gateway id, domain, and name
 // so `gateway start` can re-authenticate.
-func InstallAwsAuthGatewaySystemdService(gatewayID string, domain string, name string, relayName string, serviceLogFile string) error {
+func InstallAwsAuthGatewaySystemdService(gatewayID string, domain string, name string, relayName string, serviceLogFile string) (string, error) {
 	if runtime.GOOS != "linux" {
 		log.Info().Msg("Skipping systemd service installation - not on Linux")
-		return nil
+		return "", nil
 	}
 
 	if os.Geteuid() != 0 {
 		log.Info().Msg("Skipping systemd service installation - not running as root/sudo")
-		return nil
+		return "", nil
 	}
 
-	configDir := "/etc/infisical"
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %v", err)
+	paths := resolveInstallPaths(name)
+
+	if err := os.MkdirAll(filepath.Dir(paths.configPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create config directory: %v", err)
 	}
 
 	configContent := fmt.Sprintf("%s=%s\n", INFISICAL_GATEWAY_ID_KEY, gatewayID)
@@ -152,32 +241,35 @@ func InstallAwsAuthGatewaySystemdService(gatewayID string, domain string, name s
 		configContent += fmt.Sprintf("%s=%s\n", RELAY_NAME_ENV_NAME, relayName)
 	}
 
-	environmentFilePath := filepath.Join(configDir, "gateway.conf")
-	if err := os.WriteFile(environmentFilePath, []byte(configContent), 0600); err != nil {
-		return fmt.Errorf("failed to write environment file: %v", err)
+	if err := os.WriteFile(paths.configPath, []byte(configContent), 0600); err != nil {
+		return "", fmt.Errorf("failed to write environment file: %v", err)
 	}
 
-	if err := util.WriteSystemdServiceFile(serviceLogFile, environmentFilePath, "infisical-gateway", "gateway", "Infisical Gateway Service"); err != nil {
-		return fmt.Errorf("failed to write systemd service file: %v", err)
+	if err := util.WriteSystemdServiceFile(serviceLogFile, paths.configPath, paths.serviceName, "gateway", fmt.Sprintf("Infisical Gateway Service (%s)", name)); err != nil {
+		return "", fmt.Errorf("failed to write systemd service file: %v", err)
 	}
 
-	if err := util.WriteLogrotateFile(serviceLogFile, "infisical-gateway"); err != nil {
-		return fmt.Errorf("failed to write logrotate file: %v", err)
+	if err := util.WriteLogrotateFile(serviceLogFile, paths.serviceName); err != nil {
+		return "", fmt.Errorf("failed to write logrotate file: %v", err)
 	}
 
 	reloadCmd := exec.Command("systemctl", "daemon-reload")
 	if err := reloadCmd.Run(); err != nil {
-		return fmt.Errorf("failed to reload systemd: %v", err)
+		return "", fmt.Errorf("failed to reload systemd: %v", err)
 	}
 
-	log.Info().Msg("Successfully installed systemd service")
-	log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
-	log.Info().Msg("To enable the service on boot, run: sudo systemctl enable infisical-gateway")
+	if paths.isLegacy {
+		logLegacyWarning(name)
+	}
 
-	return nil
+	log.Info().Msgf("Successfully installed systemd service '%s'", paths.serviceName)
+	log.Info().Msgf("To start the service, run: sudo systemctl start %s", paths.serviceName)
+	log.Info().Msgf("To enable the service on boot, run: sudo systemctl enable %s", paths.serviceName)
+
+	return paths.serviceName, nil
 }
 
-func UninstallGatewaySystemdService() error {
+func UninstallGatewaySystemdService(name string) error {
 	if runtime.GOOS != "linux" {
 		log.Info().Msg("Skipping systemd service uninstallation - not on Linux")
 		return nil
@@ -188,42 +280,55 @@ func UninstallGatewaySystemdService() error {
 		return nil
 	}
 
-	// Stop the service if it's running
-	stopCmd := exec.Command("systemctl", "stop", "infisical-gateway")
+	namedServicePath := serviceFilePath(name)
+	svcName := serviceName(name)
+	configPath := gatewayConfigPath(name)
+	isLegacy := false
+
+	if _, err := os.Stat(namedServicePath); os.IsNotExist(err) {
+		legacy := detectLegacyService()
+		if !legacy.exists || legacy.gatewayName != name {
+			return fmt.Errorf("no gateway service found for '%s'", name)
+		}
+		svcName = legacyServiceName
+		configPath = legacyConfigPath
+		isLegacy = true
+		log.Warn().Msgf("Removing legacy service '%s' for gateway '%s'", legacyServiceName, name)
+	}
+
+	stopCmd := exec.Command("systemctl", "stop", svcName)
 	if err := stopCmd.Run(); err != nil {
 		log.Warn().Msgf("Failed to stop service: %v", err)
 	}
 
-	// Disable the service
-	disableCmd := exec.Command("systemctl", "disable", "infisical-gateway")
+	disableCmd := exec.Command("systemctl", "disable", svcName)
 	if err := disableCmd.Run(); err != nil {
 		log.Warn().Msgf("Failed to disable service: %v", err)
 	}
 
-	// Remove the service file
-	servicePath := "/etc/systemd/system/infisical-gateway.service"
-	if err := os.Remove(servicePath); err != nil && !os.IsNotExist(err) {
+	svcFilePath := namedServicePath
+	if isLegacy {
+		svcFilePath = legacyServicePath
+	}
+	if err := os.Remove(svcFilePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove systemd service file: %v", err)
 	}
 
-	// Remove the legacy configuration file
-	configPath := "/etc/infisical/gateway.conf"
 	if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove config file: %v", err)
 	}
 
-	// Remove per-gateway config files from enrollment flow
-	gatewaysDir := "/etc/infisical/gateways"
-	if err := os.RemoveAll(gatewaysDir); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove gateways config directory: %v", err)
+	if isLegacy {
+		if err := os.RemoveAll(gatewaysConfigDir); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove gateways config directory: %v", err)
+		}
 	}
 
-	// Reload systemd to apply changes
 	reloadCmd := exec.Command("systemctl", "daemon-reload")
 	if err := reloadCmd.Run(); err != nil {
 		return fmt.Errorf("failed to reload systemd: %v", err)
 	}
 
-	log.Info().Msg("Successfully uninstalled Infisical Gateway systemd service")
+	log.Info().Msgf("Successfully uninstalled gateway service '%s'", svcName)
 	return nil
 }

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/util"
 	"github.com/rs/zerolog/log"
@@ -41,22 +40,8 @@ func detectLegacyService() legacyInfo {
 		return legacyInfo{}
 	}
 
-	data, err := os.ReadFile(legacyConfigPath)
-	if err != nil {
-		return legacyInfo{exists: true}
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, GATEWAY_NAME_ENV_NAME+"=") {
-			return legacyInfo{
-				exists:      true,
-				gatewayName: strings.TrimPrefix(line, GATEWAY_NAME_ENV_NAME+"="),
-			}
-		}
-	}
-
-	return legacyInfo{exists: true}
+	name, _ := readKeyFromConfFile(legacyConfigPath, GATEWAY_NAME_ENV_NAME)
+	return legacyInfo{exists: true, gatewayName: name}
 }
 
 func logLegacyWarning(svcName string) {

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -18,12 +18,8 @@ const (
 	gatewaysConfigDir  = "/etc/infisical/gateways"
 )
 
-func serviceName(name string) string {
-	return name
-}
-
 func serviceFilePath(name string) string {
-	return fmt.Sprintf("/etc/systemd/system/%s.service", serviceName(name))
+	return fmt.Sprintf("/etc/systemd/system/%s.service", name)
 }
 
 func gatewayConfigPath(name string) string {
@@ -70,7 +66,7 @@ func resolveInstallPaths(name string) installResult {
 	}
 
 	return installResult{
-		serviceName: serviceName(name),
+		serviceName: name,
 		configPath:  gatewayConfigPath(name),
 		isLegacy:    false,
 	}
@@ -266,7 +262,7 @@ func UninstallGatewaySystemdService(name string) error {
 	}
 
 	namedServicePath := serviceFilePath(name)
-	svcName := serviceName(name)
+	svcName := name
 	configPath := gatewayConfigPath(name)
 	isLegacy := false
 

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -50,7 +50,7 @@ type installResult struct {
 	isLegacy    bool
 }
 
-func resolveInstallPaths(name string) installResult {
+func resolveInstallPaths(name string) (installResult, error) {
 	legacy := detectLegacyService()
 
 	if legacy.exists && legacy.gatewayName == name {
@@ -58,7 +58,11 @@ func resolveInstallPaths(name string) installResult {
 			serviceName: legacyServiceName,
 			configPath:  legacyConfigPath,
 			isLegacy:    true,
-		}
+		}, nil
+	}
+
+	if legacy.exists && name == legacyServiceName {
+		return installResult{}, fmt.Errorf("cannot use '%s' as a gateway name because it conflicts with the legacy gateway service", legacyServiceName)
 	}
 
 	if legacy.exists {
@@ -69,7 +73,7 @@ func resolveInstallPaths(name string) installResult {
 		serviceName: name,
 		configPath:  gatewayConfigPath(name),
 		isLegacy:    false,
-	}
+	}, nil
 }
 
 func InstallGatewaySystemdService(token string, domain string, name string, relayName string, serviceLogFile string) (string, error) {
@@ -83,7 +87,10 @@ func InstallGatewaySystemdService(token string, domain string, name string, rela
 		return "", nil
 	}
 
-	paths := resolveInstallPaths(name)
+	paths, err := resolveInstallPaths(name)
+	if err != nil {
+		return "", err
+	}
 
 	if err := os.MkdirAll(filepath.Dir(paths.configPath), 0755); err != nil {
 		return "", fmt.Errorf("failed to create config directory: %v", err)
@@ -143,7 +150,10 @@ func InstallEnrolledGatewaySystemdService(accessToken string, domain string, nam
 		return "", nil
 	}
 
-	paths := resolveInstallPaths(name)
+	paths, err := resolveInstallPaths(name)
+	if err != nil {
+		return "", err
+	}
 
 	if err := os.MkdirAll(filepath.Dir(paths.configPath), 0755); err != nil {
 		return "", fmt.Errorf("failed to create config directory: %v", err)
@@ -204,7 +214,10 @@ func InstallAwsAuthGatewaySystemdService(gatewayID string, domain string, name s
 		return "", nil
 	}
 
-	paths := resolveInstallPaths(name)
+	paths, err := resolveInstallPaths(name)
+	if err != nil {
+		return "", err
+	}
 
 	if err := os.MkdirAll(filepath.Dir(paths.configPath), 0755); err != nil {
 		return "", fmt.Errorf("failed to create config directory: %v", err)

--- a/packages/gateway-v2/systemd.go
+++ b/packages/gateway-v2/systemd.go
@@ -303,12 +303,6 @@ func UninstallGatewaySystemdService(name string) error {
 		return fmt.Errorf("failed to remove config file: %v", err)
 	}
 
-	if isLegacy {
-		if err := os.RemoveAll(gatewaysConfigDir); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove gateways config directory: %v", err)
-		}
-	}
-
 	reloadCmd := exec.Command("systemctl", "daemon-reload")
 	if err := reloadCmd.Run(); err != nil {
 		return fmt.Errorf("failed to reload systemd: %v", err)


### PR DESCRIPTION
## Summary
The systemd service name now matches the gateway name directly (e.g. `my-gateway.service` instead of the hardcoded `infisical-gateway.service`), with config at `/etc/infisical/gateways/<name>.conf`. Legacy installs are detected and updated in place with a warning to migrate. The `systemd uninstall` command now requires a gateway name argument.

Companion docs PR: https://github.com/Infisical/infisical/pull/6624

## Test plan
- [x] All install/uninstall edge cases tested in Docker with systemd