### PR TITLE
fix(gateway): --domain flag not working for non-enroll method

### DIFF
--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -230,6 +230,14 @@ var gatewayStartCmd = &cobra.Command{
 			util.HandleError(errors.New("gateway name is required (provide as positional argument)"))
 		}
 
+		if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
+			config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
+		} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" && enrollMethod != "" {
+			config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
+		} else if configFile, cfgErr := util.GetConfigFile(); cfgErr == nil && configFile.LoggedInUserDomain != "" {
+			config.INFISICAL_URL = util.AppendAPIEndpoint(configFile.LoggedInUserDomain)
+		}
+
 		// --- AWS Auth path ---
 		if enrollMethod == gatewayv2.EnrollMethodAws {
 			gatewayID, _ := cmd.Flags().GetString("gateway-id")
@@ -242,13 +250,6 @@ var gatewayStartCmd = &cobra.Command{
 			}
 			if gatewayID == "" {
 				util.HandleError(errors.New("--gateway-id is required when --enroll-method=aws"))
-			}
-
-			domain, _ := cmd.Flags().GetString("domain")
-			if domain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
-			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
 			}
 
 			httpClient, err := util.GetRestyClientWithCustomHeaders()
@@ -272,14 +273,8 @@ var gatewayStartCmd = &cobra.Command{
 				util.HandleError(err, "failed to save gateway id to config")
 			}
 
-			effectiveDomain := domain
-			if effectiveDomain == "" {
-				effectiveDomain = config.INFISICAL_URL
-			}
-			if effectiveDomain != "" {
-				if err := gatewayv2.SaveDomain(gatewayName, effectiveDomain); err != nil {
-					util.HandleError(err, "failed to save domain to config")
-				}
+			if err := gatewayv2.SaveDomain(gatewayName, config.INFISICAL_URL); err != nil {
+				util.HandleError(err, "failed to save domain to config")
 			}
 
 			log.Info().Msgf("Gateway authenticated via AWS Auth. State saved to %s", gatewayv2.GetConfPathDisplay(gatewayName))
@@ -301,11 +296,6 @@ var gatewayStartCmd = &cobra.Command{
 			if alreadyEnrolled {
 				log.Info().Msg("Enrollment token matches stored token. Skipping enrollment.")
 			} else {
-				domain, _ := cmd.Flags().GetString("domain")
-				if domain != "" {
-					config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
-				}
-
 				httpClient, err := util.GetRestyClientWithCustomHeaders()
 				if err != nil {
 					util.HandleError(err, "unable to create HTTP client")
@@ -328,15 +318,8 @@ var gatewayStartCmd = &cobra.Command{
 					util.HandleError(err, "failed to save enrollment token to config")
 				}
 
-				// Always persist the effective domain so restarts use the same backend
-				effectiveDomain := domain
-				if effectiveDomain == "" {
-					effectiveDomain = config.INFISICAL_URL
-				}
-				if effectiveDomain != "" {
-					if err := gatewayv2.SaveDomain(gatewayName, effectiveDomain); err != nil {
-						util.HandleError(err, "failed to save domain to config")
-					}
+				if err := gatewayv2.SaveDomain(gatewayName, config.INFISICAL_URL); err != nil {
+					util.HandleError(err, "failed to save domain to config")
 				}
 
 				log.Info().Msgf("Gateway enrolled successfully. Access token saved to %s", gatewayv2.GetConfPathDisplay(gatewayName))
@@ -345,18 +328,7 @@ var gatewayStartCmd = &cobra.Command{
 			log.Info().Msg("Starting gateway...")
 		}
 
-		// --- Stored token / post-enrollment path ---
-		// --domain flag takes priority; fall back to domain saved at enrollment time.
-		// For enrollment flow with alreadyEnrolled, domain was set during original enrollment
-		// and needs to be loaded from config.
 		isResourceAuth := enrollMethod == gatewayv2.EnrollMethodToken || enrollMethod == gatewayv2.EnrollMethodAws
-		if !isResourceAuth || alreadyEnrolled {
-			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
-			} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
-			}
-		}
 
 		// Only use the stored token when no explicit identity credentials are provided.
 		// If --token or --auth-method is set, the user wants the identity-based path.
@@ -388,8 +360,8 @@ var gatewayStartCmd = &cobra.Command{
 		}
 
 		var accessToken atomic.Value
-		cancelSdk := func() {}                              // noop by default
-		var sdkTokenGetter func() string                    // nil when using stored token
+		cancelSdk := func() {}           // noop by default
+		var sdkTokenGetter func() string // nil when using stored token
 		if runningWithStoredToken {
 			if enrolledAccessToken != "" {
 				// Fresh enrollment: use the token directly to avoid env var interference

--- a/packages/cmd/gateway.go
+++ b/packages/cmd/gateway.go
@@ -232,7 +232,7 @@ var gatewayStartCmd = &cobra.Command{
 
 		if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
 			config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
-		} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" && enrollMethod != "" {
+		} else if storedDomain, _ := gatewayv2.LoadStoredDomain(gatewayName); storedDomain != "" {
 			config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
 		} else if configFile, cfgErr := util.GetConfigFile(); cfgErr == nil && configFile.LoggedInUserDomain != "" {
 			config.INFISICAL_URL = util.AppendAPIEndpoint(configFile.LoggedInUserDomain)

--- a/packages/cmd/relay.go
+++ b/packages/cmd/relay.go
@@ -62,7 +62,7 @@ var relayStartCmd = &cobra.Command{
 
 		if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
 			config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
-		} else if storedDomain, _ := relay.LoadStoredDomain(relayName); storedDomain != "" && enrollMethod != "" {
+		} else if storedDomain, _ := relay.LoadStoredDomain(relayName); storedDomain != "" {
 			config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
 		} else if configFile, cfgErr := util.GetConfigFile(); cfgErr == nil && configFile.LoggedInUserDomain != "" {
 			config.INFISICAL_URL = util.AppendAPIEndpoint(configFile.LoggedInUserDomain)

--- a/packages/cmd/relay.go
+++ b/packages/cmd/relay.go
@@ -60,6 +60,14 @@ var relayStartCmd = &cobra.Command{
 			util.HandleError(err, fmt.Sprintf("unable to get type flag or %s env", gatewayv2.RELAY_TYPE_ENV_NAME))
 		}
 
+		if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
+			config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
+		} else if storedDomain, _ := relay.LoadStoredDomain(relayName); storedDomain != "" && enrollMethod != "" {
+			config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
+		} else if configFile, cfgErr := util.GetConfigFile(); cfgErr == nil && configFile.LoggedInUserDomain != "" {
+			config.INFISICAL_URL = util.AppendAPIEndpoint(configFile.LoggedInUserDomain)
+		}
+
 		var enrolledAccessToken string
 
 		// --- AWS Auth path ---
@@ -74,13 +82,6 @@ var relayStartCmd = &cobra.Command{
 			}
 			if relayID == "" {
 				util.HandleError(errors.New("--relay-id is required when --enroll-method=aws"))
-			}
-
-			domain, _ := cmd.Flags().GetString("domain")
-			if domain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
-			} else if storedDomain, _ := relay.LoadStoredDomain(relayName); storedDomain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
 			}
 
 			httpClient, err := util.GetRestyClientWithCustomHeaders()
@@ -100,14 +101,8 @@ var relayStartCmd = &cobra.Command{
 				util.HandleError(err, "failed to save relay id to config")
 			}
 
-			effectiveDomain := domain
-			if effectiveDomain == "" {
-				effectiveDomain = config.INFISICAL_URL
-			}
-			if effectiveDomain != "" {
-				if err := relay.SaveDomain(relayName, effectiveDomain); err != nil {
-					util.HandleError(err, "failed to save domain to config")
-				}
+			if err := relay.SaveDomain(relayName, config.INFISICAL_URL); err != nil {
+				util.HandleError(err, "failed to save domain to config")
 			}
 
 			log.Info().Msgf("Relay authenticated via AWS Auth. State saved to %s", relay.GetConfPathDisplay(relayName))
@@ -127,13 +122,6 @@ var relayStartCmd = &cobra.Command{
 			if alreadyEnrolled {
 				log.Info().Msg("Enrollment token matches stored token. Skipping enrollment.")
 			} else {
-				domain, _ := cmd.Flags().GetString("domain")
-				if domain != "" {
-					config.INFISICAL_URL = util.AppendAPIEndpoint(domain)
-				} else if storedDomain, _ := relay.LoadStoredDomain(relayName); storedDomain != "" {
-					config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
-				}
-
 				httpClient, err := util.GetRestyClientWithCustomHeaders()
 				if err != nil {
 					util.HandleError(err, "unable to create HTTP client")
@@ -156,14 +144,8 @@ var relayStartCmd = &cobra.Command{
 					util.HandleError(err, "failed to save enrollment token to config")
 				}
 
-				effectiveDomain := domain
-				if effectiveDomain == "" {
-					effectiveDomain = config.INFISICAL_URL
-				}
-				if effectiveDomain != "" {
-					if err := relay.SaveDomain(relayName, effectiveDomain); err != nil {
-						util.HandleError(err, "failed to save domain to config")
-					}
+				if err := relay.SaveDomain(relayName, config.INFISICAL_URL); err != nil {
+					util.HandleError(err, "failed to save domain to config")
 				}
 
 				log.Info().Msgf("Relay enrolled successfully. Access token saved to %s", relay.GetConfPathDisplay(relayName))
@@ -172,15 +154,7 @@ var relayStartCmd = &cobra.Command{
 			log.Info().Msg("Starting relay...")
 		}
 
-		// --- Domain resolution for resource auth / stored token ---
 		isResourceAuth := enrollMethod == relay.EnrollMethodToken || enrollMethod == relay.EnrollMethodAws
-		if isResourceAuth {
-			if flagDomain, _ := cmd.Flags().GetString("domain"); flagDomain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(flagDomain)
-			} else if storedDomain, _ := relay.LoadStoredDomain(relayName); storedDomain != "" {
-				config.INFISICAL_URL = util.AppendAPIEndpoint(storedDomain)
-			}
-		}
 
 		relayInstance, err := relay.NewRelay(&relay.RelayConfig{
 			RelayName:    relayName,


### PR DESCRIPTION
# Description 📣

Old enrollment method gateway commands such as:
```
infisical relay start --name=test --token=... --domain=http://localhost:8080 --host=1.1.1.1
```

Did not work.

The --domain flag never gets used, and when removed the logged in domain never gets used either. It's ALWAYS app.infisical.com.

This change makes it prioritize domains in the following order:
- `--domain` flag
- StoredDomain (only if using the new enrollment method)
- Logged in domain

This fix makes domains work for both the old and new enrollment methods.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->