### PR TITLE
Add free disk space step to agent e2e test job

### DIFF
--- a/.github/workflows/run-cli-e2e-tests.yml
+++ b/.github/workflows/run-cli-e2e-tests.yml
@@ -62,6 +62,14 @@ jobs:
         with:
           repository: infisical/infisical
           path: infisical
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af
+          df -h
       - name: Test Certificate Agent
         run: go test -v -timeout 30m -count=1 github.com/infisical/cli/e2e-tests/agent
         working-directory: ./e2e


### PR DESCRIPTION
Adds the same free disk space cleanup step used by the other e2e jobs to the agent-test job, which failed the v0.43.92 release run with "No space left on device" while building the backend Docker image.