### PR TITLE
fix(relay): support --enroll-method in systemd install

### DIFF
--- a/packages/cmd/relay.go
+++ b/packages/cmd/relay.go
@@ -337,8 +337,13 @@ var relaySystemdInstallCmd = &cobra.Command{
 			}
 
 			enrollToken, flagErr := cmd.Flags().GetString("token")
+			if flagErr == nil && enrollToken == "" {
+				// Fall back to INFISICAL_RELAY_ENROLLMENT_TOKEN (not INFISICAL_TOKEN) so the
+				// token stays out of argv/process listings in automated installs.
+				enrollToken = os.Getenv(relay.INFISICAL_RELAY_ENROLLMENT_TOKEN_KEY)
+			}
 			if flagErr != nil || enrollToken == "" {
-				util.HandleError(errors.New("--token is required when --enroll-method=token"))
+				util.HandleError(fmt.Errorf("--token flag or %s env is required when --enroll-method=token", relay.INFISICAL_RELAY_ENROLLMENT_TOKEN_KEY))
 			}
 
 			httpClient, clientErr := util.GetRestyClientWithCustomHeaders()
@@ -502,7 +507,7 @@ func init() {
 	relayStartCmd.Flags().String("jwt", "", "JWT for jwt-based auth methods [oidc-auth, jwt-auth]")
 
 	// systemd install command flags
-	relaySystemdInstallCmd.Flags().String("token", "", "enrollment token for authenticating with Infisical")
+	relaySystemdInstallCmd.Flags().String("token", "", "enrollment token for authenticating with Infisical (or set INFISICAL_RELAY_ENROLLMENT_TOKEN)")
 	relaySystemdInstallCmd.Flags().String("enroll-method", "", "relay auth method [token, aws]")
 	relaySystemdInstallCmd.Flags().String("relay-id", "", "relay id (required when --enroll-method=aws)")
 	relaySystemdInstallCmd.Flags().String("log-file", "", "path to write service logs (e.g. /var/log/infisical/relay.log)")


### PR DESCRIPTION
## Description

Closes #261

### The bug (high level)

`infisical relay start` supports `--enroll-method=token` (and `aws`), which uses a one-time
enrollment token to authenticate against the V2 relay API. This avoids the legacy
machine-identity auth path that triggers the dashboard warning:

> "Authenticated via Machine Identity (Legacy) — This relay is still using machine identity.
> We recommend creating a new relay."

However, `infisical relay systemd install` did **not** expose `--enroll-method`. The generated
systemd unit runs `infisical relay start` with no flags, relying entirely on
`/etc/infisical/relay.conf`. Since that file never contained any enrollment variables, a
systemd-managed relay always fell back to legacy machine-identity auth on every boot — there
was no way to run a systemd relay using the newer enrollment flow.

### The fix (low level)

1. **`packages/cmd/relay.go` (`relay systemd install`)** — added `--enroll-method` (`token|aws`)
   and `--relay-id` flags. Auth validation is now a `switch` on the enroll method:
   - `token`: requires `--token` (treated as a one-time enrollment token)
   - `aws`: requires `--relay-id` (falls back to the `INFISICAL_RELAY_ID` env)
   - `""` (legacy): unchanged behavior
   - anything else: rejected with a clear error
2. **`packages/relay/systemd.go` (`InstallRelaySystemdService`)** — extended to accept
   `enrollMethod` and `relayID`, and to write the matching variables to `relay.conf`:
   - `token` → `INFISICAL_RELAY_ENROLL_METHOD=token` + `INFISICAL_RELAY_ENROLLMENT_TOKEN=<token>`
   - `aws` → `INFISICAL_RELAY_ENROLL_METHOD=aws` + `INFISICAL_RELAY_ID=<id>`
   - legacy → `INFISICAL_TOKEN` / `INFISICAL_RELAY_AUTH_SECRET` exactly as before
3. **`packages/cmd/relay.go` (`relay start`)** — the enrollment-token path now falls back to the
   `INFISICAL_RELAY_ENROLLMENT_TOKEN` env var (it previously read the token only from `--token`,
   so a flagless systemd invocation could never supply it). Mirrors how the `aws` path already
   falls back to `INFISICAL_RELAY_ID`.
4. **`packages/relay/enroll.go`** — added the `INFISICAL_RELAY_ENROLL_METHOD_KEY` constant (the
   env name was previously a string literal) and reused it in both `relay start` and the
   systemd installer.

### Backward compatibility

When `--enroll-method` is omitted, behavior is identical to before: `INFISICAL_TOKEN` (org) or
`INFISICAL_RELAY_AUTH_SECRET` (instance) is written, and no enrollment variables are added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Built and tested on a real Linux server (systemd):

```
sudo infisical relay systemd install --name=homelab --enroll-method=token \
  --token=gwe_... --domain=https://<instance> --host=192.168.1.35
sudo systemctl start infisical-relay
```

Service logs confirm the enrollment flow (no machine identity):

```
INF Enrolling relay with enrollment token...
INF Relay enrolled successfully. Access token saved to /etc/infisical/relays/homelab.conf
INF Successfully connected relay and received certificates via v2 API
INF Relay server started successfully
INF TLS server listening on :8443 for clients
INF SSH server listening on :2222 for gateways
```

`/etc/infisical/relay.conf` contains `INFISICAL_RELAY_ENROLL_METHOD=token` and
`INFISICAL_RELAY_ENROLLMENT_TOKEN=...`, and no `INFISICAL_TOKEN`. Legacy install (no
`--enroll-method`) was verified to still write `INFISICAL_TOKEN` as before.

**Before (current `main`) — flag doesn't exist:**
<img width="1224" height="806" alt="SCR-20260613-sxri" src="https://github.com/user-attachments/assets/f951c6fd-1b26-4cc6-b855-f22b04952348" />


**After — enrollment install + service starts and enrolls:**
<img width="1206" height="973" alt="SCR-20260613-swtt" src="https://github.com/user-attachments/assets/fd54299d-eadd-489a-bb93-01b59075a976" />


**Dashboard confirms Token Auth (not Machine Identity Legacy):**
<img width="1442" height="840" alt="SCR-20260613-swib" src="https://github.com/user-attachments/assets/1005b4bd-97d9-4b7b-bfe7-2d65e77bb3e3" />


## Checklist

- [x] I have read the [contributing guidelines](https://infisical.com/docs/contributing/getting-started/overview)
- [x] My changes are backward compatible
- [x] I have tested my changes