### PR TITLE
feat(pam): add MFA and interactive reason support to new access flow

### DIFF
--- a/packages/pam/local/access.go
+++ b/packages/pam/local/access.go
@@ -64,11 +64,11 @@ func StartPAMAccess(accessToken, path, reason, durationStr string, port int) {
 	httpClient.SetAuthToken(accessToken)
 	httpClient.SetHeader("User-Agent", api.USER_AGENT)
 
-	pamResponse, err := api.CallPAMAccess(httpClient, api.PAMAccessRequest{
+	pamResponse, err := CallPAMAccessWithMFA(httpClient, api.PAMAccessRequest{
 		Path:     path,
 		Duration: durationStr,
 		Reason:   reason,
-	})
+	}, true)
 	if err != nil {
 		util.HandleError(err, "Failed to create PAM session")
 		return


### PR DESCRIPTION
## Context

Switches `access.go` to use `CallPAMAccessWithMFA` instead of direct `CallPAMAccess`. The new path-based access flow (`infisical pam access /folder/account`) was missing both MFA handling and interactive reason prompting -- it would just fail with a generic error if either was required.

`CallPAMAccessWithMFA` (already in `base-proxy.go`) catches `PAM_REASON_REQUIRED` and prompts interactively, then catches `SESSION_MFA_REQUIRED` and opens the browser for MFA verification. One function swap, both features for free across all account types (Postgres, SSH, MySQL, MSSQL, MongoDB, Oracle).

Companion backend/frontend PR: Infisical/infisical#6993

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation