### PR TITLE
fix(pam): bind and advertise local session proxies on loopback

### DIFF
--- a/packages/pam/local/database-proxy.go
+++ b/packages/pam/local/database-proxy.go
@@ -119,19 +119,19 @@ func StartDatabaseLocalProxy(accessToken string, accessParams PAMAccessParams, p
 
 	switch pamResponse.ResourceType {
 	case session.ResourceTypePostgres:
-		util.PrintfStderr("postgres://%s@localhost:%d/%s", username, proxy.port, database)
+		util.PrintfStderr("postgres://%s@127.0.0.1:%d/%s", username, proxy.port, database)
 	case session.ResourceTypeMysql:
-		util.PrintfStderr("mysql://%s@localhost:%d/%s", username, proxy.port, database)
+		util.PrintfStderr("mysql://%s@127.0.0.1:%d/%s", username, proxy.port, database)
 	case session.ResourceTypeMssql:
-		util.PrintfStderr("sqlserver://%s@localhost:%d?database=%s&encrypt=false&trustServerCertificate=true", username, proxy.port, database)
+		util.PrintfStderr("sqlserver://%s@127.0.0.1:%d?database=%s&encrypt=false&trustServerCertificate=true", username, proxy.port, database)
 	case session.ResourceTypeMongodb:
-		util.PrintfStderr("mongodb://localhost:%d/%s?serverSelectionTimeoutMS=15000", proxy.port, database)
+		util.PrintfStderr("mongodb://127.0.0.1:%d/%s?serverSelectionTimeoutMS=15000", proxy.port, database)
 	case session.ResourceTypeOracledb:
-		util.PrintfStderr("%s/%s@localhost:%d/%s", username, oracle.ProxyPasswordPlaceholder, proxy.port, database)
-		util.PrintfStderr("\njdbc:oracle:thin:@localhost:%d/%s  (user: %s, password: %s)", proxy.port, database, username, oracle.ProxyPasswordPlaceholder)
+		util.PrintfStderr("%s/%s@127.0.0.1:%d/%s", username, oracle.ProxyPasswordPlaceholder, proxy.port, database)
+		util.PrintfStderr("\njdbc:oracle:thin:@127.0.0.1:%d/%s  (user: %s, password: %s)", proxy.port, database, username, oracle.ProxyPasswordPlaceholder)
 		util.PrintfStderr("\n\nNote: the password shown is a protocol placeholder required by Oracle, not a secret.")
 	default:
-		util.PrintfStderr("localhost:%d", proxy.port)
+		util.PrintfStderr("127.0.0.1:%d", proxy.port)
 	}
 	util.PrintfStderr("\n**********************************************************************\n")
 	util.PrintfStderr("\n")
@@ -151,9 +151,9 @@ func StartDatabaseLocalProxy(accessToken string, accessParams PAMAccessParams, p
 func (p *DatabaseProxyServer) Start(port int) error {
 	var err error
 	if port == 0 {
-		p.server, err = net.Listen("tcp", ":0")
+		p.server, err = net.Listen("tcp", "127.0.0.1:0") // Bind to 127.0.0.1 only
 	} else {
-		p.server, err = net.Listen("tcp", fmt.Sprintf(":%d", port))
+		p.server, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	}
 
 	if err != nil {

--- a/packages/pam/local/kubernetes-proxy.go
+++ b/packages/pam/local/kubernetes-proxy.go
@@ -113,7 +113,7 @@ func StartKubernetesLocalProxy(accessToken string, accessParams PAMAccessParams,
 	clusterName := fmt.Sprintf("infisical-k8s-pam/%s/%s", accessParams.ResourceName, accessParams.AccountName)
 
 	config.Clusters[clusterName] = &k8sapi.Cluster{
-		Server: fmt.Sprintf("http://localhost:%d", proxy.port),
+		Server: fmt.Sprintf("http://127.0.0.1:%d", proxy.port),
 	}
 	config.AuthInfos[clusterName] = &k8sapi.AuthInfo{}
 	config.Contexts[clusterName] = &k8sapi.Context{
@@ -158,9 +158,9 @@ func StartKubernetesLocalProxy(accessToken string, accessParams PAMAccessParams,
 func (p *KubernetesProxyServer) Start(port int) error {
 	var err error
 	if port == 0 {
-		p.server, err = net.Listen("tcp", ":0")
+		p.server, err = net.Listen("tcp", "127.0.0.1:0") // Bind to 127.0.0.1 only
 	} else {
-		p.server, err = net.Listen("tcp", fmt.Sprintf(":%d", port))
+		p.server, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	}
 
 	if err != nil {

--- a/packages/pam/local/proxy_loopback_test.go
+++ b/packages/pam/local/proxy_loopback_test.go
@@ -17,6 +17,7 @@ func TestLocalProxiesBindLoopback(t *testing.T) {
 		{"database", func() (net.Listener, error) { p := &DatabaseProxyServer{}; err := p.Start(0); return p.server, err }},
 		{"redis", func() (net.Listener, error) { p := &RedisProxyServer{}; err := p.Start(0); return p.server, err }},
 		{"kubernetes", func() (net.Listener, error) { p := &KubernetesProxyServer{}; err := p.Start(0); return p.server, err }},
+		{"rdp", func() (net.Listener, error) { p := &RDPProxyServer{}; err := p.Start(0); return p.server, err }},
 	}
 
 	for _, tc := range cases {

--- a/packages/pam/local/proxy_loopback_test.go
+++ b/packages/pam/local/proxy_loopback_test.go
@@ -1,0 +1,39 @@
+package pam
+
+import (
+	"net"
+	"testing"
+)
+
+// TestLocalProxiesBindLoopback guards that the local PAM proxies bind to a
+// loopback address rather than all interfaces. Start() only creates the
+// listener (the accept loop lives in Run), so it can be exercised in isolation
+// without a gateway or an active session.
+func TestLocalProxiesBindLoopback(t *testing.T) {
+	cases := []struct {
+		name  string
+		start func() (net.Listener, error)
+	}{
+		{"database", func() (net.Listener, error) { p := &DatabaseProxyServer{}; err := p.Start(0); return p.server, err }},
+		{"redis", func() (net.Listener, error) { p := &RedisProxyServer{}; err := p.Start(0); return p.server, err }},
+		{"kubernetes", func() (net.Listener, error) { p := &KubernetesProxyServer{}; err := p.Start(0); return p.server, err }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := tc.start()
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			defer func() { _ = ln.Close() }()
+
+			addr, ok := ln.Addr().(*net.TCPAddr)
+			if !ok {
+				t.Fatalf("unexpected listener address type %T", ln.Addr())
+			}
+			if !addr.IP.IsLoopback() {
+				t.Fatalf("%s proxy bound to %s; must bind a loopback address, not all interfaces", tc.name, addr.IP)
+			}
+		})
+	}
+}

--- a/packages/pam/local/redis-proxy.go
+++ b/packages/pam/local/redis-proxy.go
@@ -107,9 +107,9 @@ func StartRedisLocalProxy(accessToken string, accessParams PAMAccessParams, proj
 	util.PrintfStderr("\n")
 	util.PrintfStderr("You can now connect to your Redis instance using:\n")
 	if username != "" {
-		util.PrintfStderr("redis://%s@localhost:%d", username, proxy.port)
+		util.PrintfStderr("redis://%s@127.0.0.1:%d", username, proxy.port)
 	} else {
-		util.PrintfStderr("redis://localhost:%d", proxy.port)
+		util.PrintfStderr("redis://127.0.0.1:%d", proxy.port)
 	}
 	util.PrintfStderr("\n**********************************************************************\n")
 	util.PrintfStderr("\n")
@@ -129,9 +129,9 @@ func StartRedisLocalProxy(accessToken string, accessParams PAMAccessParams, proj
 func (p *RedisProxyServer) Start(port int) error {
 	var err error
 	if port == 0 {
-		p.server, err = net.Listen("tcp", ":0")
+		p.server, err = net.Listen("tcp", "127.0.0.1:0") // Bind to 127.0.0.1 only
 	} else {
-		p.server, err = net.Listen("tcp", fmt.Sprintf(":%d", port))
+		p.server, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Context

The local PAM proxies for database, redis, and kubernetes sessions create their TCP listener with an
empty host (`":0"` / `":<port>"`), which Go resolves to all interfaces (`0.0.0.0` / `[::]`). These
proxies are consumed by the local client on the same machine, so they should only accept loopback
connections. This binds them to `127.0.0.1` and advertises `127.0.0.1` in the printed connection
string, so the client connects to exactly the address the proxy listens on. The rdp proxy already
binds and advertises `127.0.0.1`; this brings the other three in line.

Behavior: the proxy now accepts connections only from the local host. A client running on the same
machine connects via the printed `127.0.0.1` URL, as it already does for rdp sessions. Reaching the
proxy from another host, or from outside a container via a published port, no longer works (run the
client on the same machine). The printed connection string changes from `localhost:<port>` to
`127.0.0.1:<port>`.

- Before: listener on `:0` / `:<port>` (all interfaces); connection string used `localhost`.
- After: listener on `127.0.0.1:0` / `127.0.0.1:<port>` (loopback only); connection string uses
  `127.0.0.1`.

Changed files:

- `packages/pam/local/database-proxy.go`
- `packages/pam/local/redis-proxy.go`
- `packages/pam/local/kubernetes-proxy.go`
- `packages/pam/local/proxy_loopback_test.go` (test)

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

- Unit test (included in this PR): `go test ./packages/pam/local/ -run TestLocalProxiesBindLoopback`.
  It drives each proxy's `Start()` and asserts the listener binds a loopback address.
- Manual: start a database / redis / kubernetes PAM session and confirm the proxy port listens on
  `127.0.0.1` only (for example `lsof -iTCP -sTCP:LISTEN` or `netstat`), and that the local client
  still connects via the printed `127.0.0.1` URL.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
