### PR TITLE
fix(release): exclude PKCS#11 archives from AUR package generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -297,7 +297,7 @@ winget:
 aurs:
   - name: infisical-bin
     ids:
-      - default    
+      - default
     homepage: "https://infisical.com"
     description: "The official Infisical CLI"
     maintainers:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -296,6 +296,8 @@ winget:
 
 aurs:
   - name: infisical-bin
+    ids:
+      - default    
     homepage: "https://infisical.com"
     description: "The official Infisical CLI"
     maintainers:


### PR DESCRIPTION
# Description 📣

Fixes duplicate architecture and `source_*` entries in the generated AUR `PKGBUILD`.

The AUR publisher was consuming artifacts from both the `default` and `pkcs11` archives, causing duplicate entries for Linux architectures in the generated package.

This change limits the AUR publisher to artifacts from the `default` archive only:

```yaml
aurs:
  - ids:
      - default
```

The PKCS#11 archives continue to be published as GitHub release artifacts but are no longer considered when generating the AUR package.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

- Reproduced the issue by generating the AUR package with both `default` and `pkcs11` archives.
  - Verified duplicate `arch` entries.
  - Verified duplicate `source_*` definitions in the generated `PKGBUILD`.
- Added `ids: [default]` to the `aurs` configuration.
- Regenerated the package and verified:
  - No duplicate architecture entries.
  - No duplicate `source_*` definitions.
  - The generated `PKGBUILD` references only the default CLI archives.
  
diff from the test:
```
- arch=('aarch64' 'aarch64' 'armv7h' 'armv7h' 'i686' 'i686' 'x86_64' 'x86_64')
+ arch=('aarch64' 'armv7h' 'i686' 'x86_64')

- source_aarch64=("${pkgname}_${pkgver}_aarch64.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/infisical-pkcs11_0.43.99-devel_linux_arm64.tar.gz")
- sha256sums_aarch64=('355177330aaa7e9de6aa5a905e705d04589aaec73a4b9657cd6d67698d093943')

  source_aarch64=("${pkgname}_${pkgver}_aarch64.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/cli_0.43.99-devel_linux_arm64.tar.gz")
  sha256sums_aarch64=('355177330aaa7e9de6aa5a905e705d04589aaec73a4b9657cd6d67698d093943')

- source_armv7h=("${pkgname}_${pkgver}_armv7h.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/infisical-pkcs11_0.43.99-devel_linux_arm.tar.gz")
- sha256sums_armv7h=('00fe17bf2ee27b489042ce5a925af9e92acf6eedda401639f03bbcd5433b9e78')

  source_armv7h=("${pkgname}_${pkgver}_armv7h.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/cli_0.43.99-devel_linux_armv7.tar.gz")
  sha256sums_armv7h=('00fe17bf2ee27b489042ce5a925af9e92acf6eedda401639f03bbcd5433b9e78')

  source_i686=("${pkgname}_${pkgver}_i686.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/cli_0.43.99-devel_linux_386.tar.gz")
  sha256sums_i686=('6b7d731ba8a6f301d7c5557689f13c4cd70b4d72ae1ce915e9d903be777531e2')

- source_i686=("${pkgname}_${pkgver}_i686.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/infisical-pkcs11_0.43.99-devel_linux_386.tar.gz")
- sha256sums_i686=('6b7d731ba8a6f301d7c5557689f13c4cd70b4d72ae1ce915e9d903be777531e2')

- source_x86_64=("${pkgname}_${pkgver}_x86_64.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/infisical-pkcs11_0.43.99-devel_linux_amd64.tar.gz")
-  sha256sums_x86_64=('ffda973e99c4cb6cd1c58bb32df1d52905d0cfe364a19aaef19d96e266a2a327')

  source_x86_64=("${pkgname}_${pkgver}_x86_64.tar.gz::https://github.com/Infisical/cli/releases/download/v0.43.99/cli_0.43.99-devel_linux_amd64.tar.gz")
  sha256sums_x86_64=('ffda973e99c4cb6cd1c58bb32df1d52905d0cfe364a19aaef19d96e266a2a327')
  ```

# Impact 🎯

This change only affects AUR package generation.

- 🎯 Affects only AUR package generation.
- ➖ No changes to GitHub Releases, Homebrew, Scoop, Winget, Docker, or NFPM packages.
- ➖ PKCS#11 artifacts continue to be published as standalone release assets.
- ✅ Eliminates duplicate `arch` and `source_*` entries in the generated AUR `PKGBUILD`.

# What's Next? 🔮

If Arch users need the PKCS#11 companion in the future, there are a couple of options:

- 📦 **Create a separate AUR package** (recommended), e.g. `infisical-pkcs11-bin`, to package the PKCS#11 companion independently.
- 📚 **Bundle both binaries in the existing AUR package** if the PKCS#11 companion is intended to be installed alongside the main CLI for all users.

Caused by: https://github.com/Infisical/cli/pull/270
Closes https://github.com/Infisical/cli/issues/278
Closes https://github.com/Infisical/infisical/issues/7058

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->