### PR TITLE
fix(release): exclude PKCS#11 archives from AUR package generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -296,6 +296,8 @@ winget:
 
 aurs:
   - name: infisical-bin
+    ids:
+      - default
     homepage: "https://infisical.com"
     description: "The official Infisical CLI"
     maintainers:


### PR DESCRIPTION
# Description 📣

Fixes duplicate architecture and `source_*` entries in the generated AUR `PKGBUILD`.

The AUR publisher was consuming artifacts from both the `default` and `pkcs11` archives, causing duplicate entries for Linux architectures in the generated package. For the duplicated arches (`aarch64`, `x86_64`) the `pkcs11` tarball won the last-write, so `install ./infisical` would have failed for those arches since that binary is not present in the PKCS#11 tarball.

This change limits the AUR publisher to artifacts from the `default` archive only:

```yaml
aurs:
  - ids:
      - default
```

The PKCS#11 archives continue to be published as GitHub release artifacts and are fetched at runtime by the launcher (`packages/gateway-v2/pkcs11_launcher.go`), so the PKCS#11 feature is unaffected.

## Type ✨

- [x] Bug fix

# Tests 🛠️

Reproduced the goreleaser `aurs.ids` filter behavior against a minimal project mirroring the two-archive layout.

**Before** (no `ids` filter):
```
arch=('aarch64' 'aarch64' 'armv7h' 'i686' 'x86_64' 'x86_64')
source_aarch64=(... cli_..._linux_arm64.tar.gz)
source_aarch64=(... infisical-pkcs11_..._linux_arm64.tar.gz)
source_x86_64=(... cli_..._linux_amd64.tar.gz)
source_x86_64=(... infisical-pkcs11_..._linux_amd64.tar.gz)
```

**After** (`ids: [default]`):
```
arch=('aarch64' 'armv7h' 'i686' 'x86_64')
source_aarch64=(... cli_..._linux_arm64.tar.gz)
source_armv7h=(... cli_..._linux_armv7.tar.gz)
source_i686=(... cli_..._linux_386.tar.gz)
source_x86_64=(... cli_..._linux_amd64.tar.gz)
```

# Impact 🎯

- 🎯 Affects only AUR package generation.
- ➖ No changes to GitHub Releases, Homebrew, Scoop, Winget, Docker, or NFPM packages.
- ➖ PKCS#11 artifacts continue to be published as standalone release assets.
- ✅ Eliminates duplicate `arch` and `source_*` entries in the generated AUR `PKGBUILD`.

---

Mirror of #287 — the original author does not have access to the release workflow secrets needed to run the goreleaser test, so this branch is opened to run that workflow internally.

Caused by: https://github.com/Infisical/cli/pull/270
Closes https://github.com/Infisical/cli/issues/278

🤖 Generated with [Claude Code](https://claude.com/claude-code)