### PR TITLE
feat(export): add --quote flag to control dotenv quote character

### DIFF
--- a/packages/cmd/export.go
+++ b/packages/cmd/export.go
@@ -27,6 +27,12 @@ const (
 	FormatDotEnvEval   string = "dotenv-eval"
 )
 
+const (
+	QuoteSingle string = "single"
+	QuoteDouble string = "double"
+	QuoteNone   string = "none"
+)
+
 // exportCmd represents the export command
 var exportCmd = &cobra.Command{
 	Use:                   "export",
@@ -64,6 +70,16 @@ var exportCmd = &cobra.Command{
 		}
 
 		format, err := cmd.Flags().GetString("format")
+		if err != nil {
+			util.HandleError(err)
+		}
+
+		quoteFlag, err := cmd.Flags().GetString("quote")
+		if err != nil {
+			util.HandleError(err)
+		}
+
+		quote, err := quoteCharacter(quoteFlag)
 		if err != nil {
 			util.HandleError(err)
 		}
@@ -142,7 +158,7 @@ var exportCmd = &cobra.Command{
 		secrets = util.FilterSecretsByTag(secrets, tagSlugs)
 		secrets = util.SortSecretsByKeys(secrets)
 
-		output, err = formatEnvs(secrets, format)
+		output, err = formatEnvs(secrets, format, quote)
 		if err != nil {
 			util.HandleError(err)
 		}
@@ -267,6 +283,7 @@ func init() {
 	exportCmd.Flags().StringP("env", "e", "dev", "Set the environment (dev, prod, etc.) from which your secrets should be pulled from")
 	exportCmd.Flags().Bool("expand", true, "Parse shell parameter expansions in your secrets")
 	exportCmd.Flags().StringP("format", "f", "dotenv", "Set the format of the output file (dotenv, dotenv-export, dotenv-eval, json, csv, yaml)")
+	exportCmd.Flags().String("quote", "single", "Set the quote character wrapping values for the dotenv and dotenv-export formats (single, double, none)")
 	exportCmd.Flags().Bool("secret-overriding", true, "Prioritizes personal secrets, if any, with the same name over shared secrets")
 	exportCmd.Flags().Bool("include-imports", true, "Imported linked secrets")
 	exportCmd.Flags().String("token", "", "Fetch secrets using service token or machine identity access token")
@@ -278,12 +295,12 @@ func init() {
 }
 
 // Format according to the format flag
-func formatEnvs(envs []models.SingleEnvironmentVariable, format string) (string, error) {
+func formatEnvs(envs []models.SingleEnvironmentVariable, format string, quote string) (string, error) {
 	switch strings.ToLower(format) {
 	case FormatDotenv:
-		return formatAsDotEnv(envs), nil
+		return formatAsDotEnv(envs, quote), nil
 	case FormatDotEnvExport:
-		return formatAsDotEnvExport(envs), nil
+		return formatAsDotEnvExport(envs, quote), nil
 	case FormatDotEnvEval:
 		return formatAsDotEnvEval(envs), nil
 	case FormatJson:
@@ -309,22 +326,40 @@ func formatAsCSV(envs []models.SingleEnvironmentVariable) string {
 	return csvString.String()
 }
 
-// Format environment variables as a dotenv file
-func formatAsDotEnv(envs []models.SingleEnvironmentVariable) string {
+// Format environment variables as a dotenv file. quote is the character used to
+// wrap each value ("'", "\"", or "" for none); resolve it via quoteCharacter.
+func formatAsDotEnv(envs []models.SingleEnvironmentVariable, quote string) string {
 	var dotenv string
 	for _, env := range envs {
-		dotenv += fmt.Sprintf("%s='%s'\n", env.Key, escapeNewLinesIfRequired(env))
+		dotenv += fmt.Sprintf("%s=%s%s%s\n", env.Key, quote, escapeNewLinesIfRequired(env), quote)
 	}
 	return dotenv
 }
 
-// Format environment variables as a dotenv file with export at the beginning
-func formatAsDotEnvExport(envs []models.SingleEnvironmentVariable) string {
+// Format environment variables as a dotenv file with export at the beginning.
+// quote behaves as in formatAsDotEnv.
+func formatAsDotEnvExport(envs []models.SingleEnvironmentVariable, quote string) string {
 	var dotenv string
 	for _, env := range envs {
-		dotenv += fmt.Sprintf("export %s='%s'\n", env.Key, escapeNewLinesIfRequired(env))
+		dotenv += fmt.Sprintf("export %s=%s%s%s\n", env.Key, quote, escapeNewLinesIfRequired(env), quote)
 	}
 	return dotenv
+}
+
+// quoteCharacter maps the --quote flag value to the character used to wrap
+// dotenv values. An empty value defaults to single quotes so existing exports
+// are unaffected.
+func quoteCharacter(quote string) (string, error) {
+	switch strings.ToLower(quote) {
+	case QuoteSingle, "":
+		return "'", nil
+	case QuoteDouble:
+		return "\"", nil
+	case QuoteNone:
+		return "", nil
+	default:
+		return "", fmt.Errorf("invalid quote type: %s. Available quote types are [%s]", quote, strings.Join([]string{QuoteSingle, QuoteDouble, QuoteNone}, ", "))
+	}
 }
 
 // Format environment variables for shell eval/source. Values are wrapped in

--- a/packages/cmd/export_test.go
+++ b/packages/cmd/export_test.go
@@ -153,3 +153,105 @@ func TestPosixShellQuote(t *testing.T) {
 		})
 	}
 }
+
+func TestQuoteCharacter(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  string
+		expectErr bool
+	}{
+		{name: "single", input: "single", expected: "'"},
+		{name: "double", input: "double", expected: "\""},
+		{name: "none", input: "none", expected: ""},
+		{name: "empty defaults to single", input: "", expected: "'"},
+		{name: "case insensitive", input: "DOUBLE", expected: "\""},
+		{name: "invalid value returns error", input: "backtick", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := quoteCharacter(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestFormatAsDotEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []models.SingleEnvironmentVariable
+		quote    string
+		expected string
+	}{
+		{
+			name:     "single quote keeps the existing default behavior",
+			input:    []models.SingleEnvironmentVariable{{Key: "KEY1", Value: "VALUE1"}, {Key: "KEY2", Value: "VALUE2"}},
+			quote:    "'",
+			expected: "KEY1='VALUE1'\nKEY2='VALUE2'\n",
+		},
+		{
+			name:     "double quote wraps values in double quotes",
+			input:    []models.SingleEnvironmentVariable{{Key: "KEY1", Value: "VALUE1"}},
+			quote:    "\"",
+			expected: "KEY1=\"VALUE1\"\n",
+		},
+		{
+			name:     "none emits bare values for docker --env-file",
+			input:    []models.SingleEnvironmentVariable{{Key: "KEY1", Value: "VALUE1"}},
+			quote:    "",
+			expected: "KEY1=VALUE1\n",
+		},
+		{
+			name:     "double quote with multiline-encoded value emits escaped newlines for dotenv expansion",
+			input:    []models.SingleEnvironmentVariable{{Key: "PRIVATE_KEY", Value: "line1\nline2", SkipMultilineEncoding: true}},
+			quote:    "\"",
+			expected: "PRIVATE_KEY=\"line1\\nline2\"\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatAsDotEnv(tt.input, tt.quote))
+		})
+	}
+}
+
+func TestFormatAsDotEnvExport(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []models.SingleEnvironmentVariable
+		quote    string
+		expected string
+	}{
+		{
+			name:     "single quote keeps the existing default behavior",
+			input:    []models.SingleEnvironmentVariable{{Key: "KEY1", Value: "VALUE1"}},
+			quote:    "'",
+			expected: "export KEY1='VALUE1'\n",
+		},
+		{
+			name:     "double quote wraps values in double quotes",
+			input:    []models.SingleEnvironmentVariable{{Key: "KEY1", Value: "VALUE1"}},
+			quote:    "\"",
+			expected: "export KEY1=\"VALUE1\"\n",
+		},
+		{
+			name:     "none emits bare values",
+			input:    []models.SingleEnvironmentVariable{{Key: "KEY1", Value: "VALUE1"}},
+			quote:    "",
+			expected: "export KEY1=VALUE1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatAsDotEnvExport(tt.input, tt.quote))
+		})
+	}
+}


### PR DESCRIPTION
## Description

The `dotenv` and `dotenv-export` formats hardcode single quotes (`KEY='value'`). This breaks two common cases reported in Infisical/infisical#1103:

- **Multiline values** (e.g. a Google reCAPTCHA / PEM private key): dotenv loaders do not expand `\n` inside single quotes, so the key isn't parsed as multiline.
- **Docker `--env-file`**: treats the surrounding single quotes as part of the value.

## Change

Adds a `--quote` flag with values `single | double | none` (default `single`).

- Applies to the `dotenv` and `dotenv-export` formats.
- `dotenv-eval` is intentionally untouched (it relies on POSIX single-quote semantics for safe shell evaluation).
- Default preserves current output exactly — fully backward compatible.

```bash
infisical export --quote=double      # KEY="value"  (multiline-friendly)
infisical export --quote=none        # KEY=value     (docker --env-file)
```

## Tests

Added table tests for `quoteCharacter`, `formatAsDotEnv`, and `formatAsDotEnvExport`, including a multiline-encoded value exported with `--quote=double`. All existing tests pass.

## Notes

- Escaping of the chosen quote character *inside* a value is unchanged from prior behavior (out of scope here; happy to follow up).
- CLI docs live in the main repo (`docs/cli/commands/export.mdx`) — happy to open a companion docs PR.

Resolves Infisical/infisical#1103
