### PR TITLE
feat(agent-proxy): dynamic secret support for proxied services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	go.mozilla.org/pkcs7 v0.9.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	gopkg.in/ini.v1 v1.62.0
@@ -198,7 +199,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/api v0.267.0 // indirect

--- a/packages/agentproxy/cache.go
+++ b/packages/agentproxy/cache.go
@@ -30,6 +30,13 @@ const agentInactiveTTL = 10 * time.Minute
 // so actively-used agents keep their cache and only idle scopes are dropped.
 const maxAgentCacheEntries = 4096
 
+// dynamicCredentialRef points a credential at a lease in the lease store. The value is resolved per-request
+// (materialized) rather than stored here, so poll re-resolves and agent eviction never touch live leases.
+type dynamicCredentialRef struct {
+	key   leaseKey
+	field string
+}
+
 type resolvedCredential struct {
 	role          string
 	headerName    string
@@ -38,6 +45,7 @@ type resolvedCredential struct {
 	placeholder   string
 	surfaces      []string
 	value         string
+	dynamic       *dynamicCredentialRef
 }
 
 type resolvedService struct {
@@ -66,16 +74,33 @@ func cacheKey(jwt string, scope agentScope) string {
 
 type agentCache struct {
 	proxyToken func() string
+	leases     *leaseStore
 
 	mu      sync.Mutex
 	entries map[string]*agentEntry
 }
 
-func newAgentCache(proxyToken func() string) *agentCache {
+func newAgentCache(proxyToken func() string, leases *leaseStore) *agentCache {
 	return &agentCache{
 		proxyToken: proxyToken,
+		leases:     leases,
 		entries:    make(map[string]*agentEntry),
 	}
+}
+
+// activeJWTs returns the cache keys (cacheKey(jwt, scope)) of non-evicted sessions, so the lease store can
+// stop refreshing leases whose agent session is gone.
+func (a *agentCache) activeJWTs() map[string]struct{} {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	live := make(map[string]struct{}, len(a.entries))
+	now := time.Now()
+	for key, entry := range a.entries {
+		if now.Sub(entry.lastSeen) <= agentInactiveTTL {
+			live[key] = struct{}{}
+		}
+	}
+	return live
 }
 
 func (a *agentCache) get(jwt string, scope agentScope) ([]*resolvedService, error) {
@@ -164,6 +189,30 @@ func (a *agentCache) resolve(jwt string, scope agentScope) ([]*resolvedService, 
 			isEnabled:    svc.IsEnabled,
 		}
 		for _, cred := range svc.Credentials {
+			// dynamic-secret-backed credential: register a lease and defer value resolution to request time
+			if cred.DynamicSecretName != "" {
+				key := leaseKey{
+					jwt:        jwt,
+					scope:      scope,
+					secretName: cred.DynamicSecretName,
+					configHash: canonicalConfigHash(cred.DynamicSecretConfig),
+				}
+				a.leases.register(key, leaseSpec{projectSlug: listResp.ProjectSlug, config: cred.DynamicSecretConfig})
+				rs.credentials = append(rs.credentials, resolvedCredential{
+					role:          cred.Role,
+					headerName:    cred.HeaderName,
+					headerPrefix:  cred.HeaderPrefix,
+					headerPurpose: cred.HeaderPurpose,
+					placeholder:   cred.PlaceholderValue,
+					surfaces:      cred.SubstitutionSurfaces,
+					dynamic:       &dynamicCredentialRef{key: key, field: cred.DynamicSecretField},
+				})
+				continue
+			}
+
+			if cred.SecretKey == "" {
+				continue
+			}
 			value, ok := secretValues[cred.SecretKey]
 			if !ok {
 				log.Warn().Msgf("proxied service %q references missing secret %q; skipping", svc.Name, cred.SecretKey)

--- a/packages/agentproxy/cache.go
+++ b/packages/agentproxy/cache.go
@@ -30,8 +30,6 @@ const agentInactiveTTL = 10 * time.Minute
 // so actively-used agents keep their cache and only idle scopes are dropped.
 const maxAgentCacheEntries = 4096
 
-// dynamicCredentialRef points a credential at a lease in the lease store. The value is resolved per-request
-// (materialized) rather than stored here, so poll re-resolves and agent eviction never touch live leases.
 type dynamicCredentialRef struct {
 	key   leaseKey
 	field string
@@ -88,8 +86,6 @@ func newAgentCache(proxyToken func() string, leases *leaseStore) *agentCache {
 	}
 }
 
-// activeJWTs returns the cache keys (cacheKey(jwt, scope)) of non-evicted sessions, so the lease store can
-// stop refreshing leases whose agent session is gone.
 func (a *agentCache) activeJWTs() map[string]struct{} {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -189,7 +185,6 @@ func (a *agentCache) resolve(jwt string, scope agentScope) ([]*resolvedService, 
 			isEnabled:    svc.IsEnabled,
 		}
 		for _, cred := range svc.Credentials {
-			// dynamic-secret-backed credential: register a lease and defer value resolution to request time
 			if cred.DynamicSecretName != "" {
 				key := leaseKey{
 					jwt:        jwt,

--- a/packages/agentproxy/cache.go
+++ b/packages/agentproxy/cache.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Infisical/infisical-merge/packages/api"
-	"github.com/Infisical/infisical-merge/packages/models"
 	"github.com/Infisical/infisical-merge/packages/util"
 	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
@@ -169,10 +168,7 @@ func (a *agentCache) resolve(jwt string, scope agentScope) ([]*resolvedService, 
 		return nil, fmt.Errorf("failed to discover proxied services: %w", err)
 	}
 
-	secretValues, err := a.fetchSecretValues(scope)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch secret values: %w", err)
-	}
+	secretValues := a.fetchSecretValues(scope, referencedStaticKeys(listResp.Services))
 
 	var services []*resolvedService
 	for _, svc := range listResp.Services {
@@ -228,24 +224,40 @@ func (a *agentCache) resolve(jwt string, scope agentScope) ([]*resolvedService, 
 	return services, nil
 }
 
-func (a *agentCache) fetchSecretValues(scope agentScope) (map[string]string, error) {
-	params := models.GetAllSecretsParameters{
-		Environment:              scope.environment,
-		WorkspaceId:              scope.projectID,
-		SecretsPath:              scope.secretPath,
-		UniversalAuthAccessToken: a.proxyToken(),
-		ExpandSecretReferences:   true,
-		IncludeImport:            true,
+func referencedStaticKeys(services []api.ProxiedService) []string {
+	seen := make(map[string]struct{})
+	var keys []string
+	for _, svc := range services {
+		if !svc.CanProxy {
+			continue
+		}
+		for _, cred := range svc.Credentials {
+			if cred.DynamicSecretName != "" || cred.SecretKey == "" {
+				continue
+			}
+			if _, ok := seen[cred.SecretKey]; ok {
+				continue
+			}
+			seen[cred.SecretKey] = struct{}{}
+			keys = append(keys, cred.SecretKey)
+		}
 	}
-	secrets, err := util.GetAllEnvironmentVariables(params, "")
-	if err != nil {
-		return nil, err
+	return keys
+}
+
+// fetchSecretValues resolves referenced static secrets individually so a key the proxy can't read is
+// skipped rather than failing the whole agent.
+func (a *agentCache) fetchSecretValues(scope agentScope, keys []string) map[string]string {
+	values := make(map[string]string, len(keys))
+	for _, key := range keys {
+		secret, _, err := util.GetSinglePlainTextSecretByNameV3(a.proxyToken(), scope.projectID, scope.environment, scope.secretPath, key)
+		if err != nil {
+			log.Warn().Err(err).Msgf("agent proxy: skipping static secret %q; proxy identity cannot read it", key)
+			continue
+		}
+		values[key] = secret.Value
 	}
-	values := make(map[string]string, len(secrets))
-	for _, s := range secrets {
-		values[s.Key] = s.Value
-	}
-	return values, nil
+	return values
 }
 
 func (a *agentCache) refreshActive() {

--- a/packages/agentproxy/cache_test.go
+++ b/packages/agentproxy/cache_test.go
@@ -9,7 +9,7 @@ import (
 // When the cache is full, inserting a new scope must evict the least-recently-seen entry (keeping
 // actively-used agents cached) rather than reject the new one or grow the map without bound.
 func TestAgentCacheEvictsLeastRecentlySeenWhenFull(t *testing.T) {
-	a := newAgentCache(func() string { return "" })
+	a := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 
 	base := time.Now()
 	for i := 0; i < maxAgentCacheEntries; i++ {
@@ -36,7 +36,7 @@ func TestAgentCacheEvictsLeastRecentlySeenWhenFull(t *testing.T) {
 
 // A key already present must not trigger eviction — updating an existing scope isn't growth.
 func TestAgentCacheNoEvictionWhenReplacing(t *testing.T) {
-	a := newAgentCache(func() string { return "" })
+	a := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 
 	base := time.Now()
 	for i := 0; i < maxAgentCacheEntries; i++ {

--- a/packages/agentproxy/connect_live_test.go
+++ b/packages/agentproxy/connect_live_test.go
@@ -39,7 +39,7 @@ func TestConnectTunnelLiveOverTCP(t *testing.T) {
 	}}
 
 	ca, interCert := newTestCA(t)
-	cache := newAgentCache(func() string { return "" })
+	cache := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 	cache.entries[cacheKey(jwt, scope)] = &agentEntry{jwt: jwt, scope: scope, services: services, lastSeen: time.Now()}
 
 	// Upstream transport must trust the httptest upstream's real cert (the proxy does a real TLS leg to it).

--- a/packages/agentproxy/connect_test.go
+++ b/packages/agentproxy/connect_test.go
@@ -93,7 +93,7 @@ func TestConnectTunnelInjectsCredentialsAndKeepsAlive(t *testing.T) {
 
 	ca, interCert := newTestCA(t)
 	stub := &stubRoundTripper{respBody: "ok"}
-	cache := newAgentCache(func() string { return "" })
+	cache := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 	cache.entries[cacheKey(jwt, scope)] = &agentEntry{jwt: jwt, scope: scope, services: services, lastSeen: time.Now()}
 	ps := &proxyServer{
 		opts:      Options{UnmatchedHost: UnmatchedAllow},
@@ -171,7 +171,7 @@ func TestConnectTunnelInjectsCredentialsAndKeepsAlive(t *testing.T) {
 // hijack — exercising the pre-hijack error path through the ResponseWriter.
 func TestConnectRequiresProxyAuth(t *testing.T) {
 	ca, _ := newTestCA(t)
-	cache := newAgentCache(func() string { return "" })
+	cache := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 	ps := &proxyServer{
 		opts:      Options{UnmatchedHost: UnmatchedAllow},
 		ca:        ca,

--- a/packages/agentproxy/forward_test.go
+++ b/packages/agentproxy/forward_test.go
@@ -21,7 +21,7 @@ func proxyAuthHeader(projectID, environment, secretPath, jwt string) string {
 
 func newTestProxy(t *testing.T, unmatchedHost, jwt string, scope agentScope, services []*resolvedService) net.Conn {
 	t.Helper()
-	cache := newAgentCache(func() string { return "" })
+	cache := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 	cache.entries[cacheKey(jwt, scope)] = &agentEntry{
 		jwt:      jwt,
 		scope:    scope,

--- a/packages/agentproxy/leases.go
+++ b/packages/agentproxy/leases.go
@@ -19,8 +19,6 @@ import (
 const (
 	// serve a cached lease only while this much validity remains, so a value isn't injected right as it expires
 	leaseExpirySkew = 5 * time.Second
-	// keep at most this many superseded value-sets per credential for response redaction across a re-mint
-	maxRetiredValueSets = 2
 	// re-mint backoff bounds while the old lease is still valid
 	minMintBackoff = 5 * time.Second
 	maxMintBackoff = 60 * time.Second
@@ -58,11 +56,6 @@ type leaseSpec struct {
 	config      map[string]interface{}
 }
 
-type retiredValues struct {
-	values   []string
-	expireAt time.Time
-}
-
 type leaseEntry struct {
 	key             leaseKey
 	spec            leaseSpec
@@ -70,7 +63,6 @@ type leaseEntry struct {
 	expireAt        time.Time
 	ttl             time.Duration
 	data            map[string]string
-	retired         []retiredValues
 	lastUsed        time.Time
 	mintFailures    int
 	nextMintAttempt time.Time
@@ -217,8 +209,8 @@ func (s *leaseStore) value(key leaseKey, field string) (string, bool) {
 }
 
 // mintLease mints (or re-mints) a fresh lease for the key, singleflighted so concurrent callers share one
-// network mint. Make-before-break: the old value-set is retired for redaction and the old lease is left for
-// the server's scheduled revocation to reap (never proactively revoked here).
+// network mint. Make-before-break: the new lease swaps in atomically and the old lease is left for the
+// server's scheduled revocation to reap (never proactively revoked here).
 func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 	v, err, _ := s.group.Do(key.string(), func() (interface{}, error) {
 		s.mu.Lock()
@@ -233,8 +225,6 @@ func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 			return e, nil
 		}
 		spec := e.spec
-		oldValues := valuesOf(e.data)
-		oldExpireAt := e.expireAt
 		s.mu.Unlock()
 
 		res, mintErr := s.mint(leaseMintArgs{
@@ -259,12 +249,6 @@ func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 		}
 
 		now := time.Now()
-		if len(oldValues) > 0 && oldExpireAt.After(now) {
-			e.retired = append(e.retired, retiredValues{values: oldValues, expireAt: oldExpireAt})
-			if len(e.retired) > maxRetiredValueSets {
-				e.retired = e.retired[len(e.retired)-maxRetiredValueSets:]
-			}
-		}
 		e.leaseID = res.leaseID
 		e.expireAt = res.expireAt
 		e.ttl = res.expireAt.Sub(now)
@@ -294,54 +278,6 @@ func mintBackoff(failures int) time.Duration {
 	return d
 }
 
-func valuesOf(data map[string]string) []string {
-	if len(data) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(data))
-	for _, v := range data {
-		if v != "" {
-			out = append(out, v)
-		}
-	}
-	return out
-}
-
-func pruneRetired(retired []retiredValues, now time.Time) []retiredValues {
-	kept := retired[:0]
-	for _, r := range retired {
-		if r.expireAt.After(now) {
-			kept = append(kept, r)
-		}
-	}
-	return kept
-}
-
-// redactionValues returns every value (current + not-yet-expired retired) for the given lease keys, so a
-// value reflected back in a response header is scrubbed even briefly after a re-mint swap.
-func (s *leaseStore) redactionValues(keys []leaseKey) []string {
-	if len(keys) == 0 {
-		return nil
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	var out []string
-	now := time.Now()
-	for _, k := range keys {
-		e, ok := s.entries[k]
-		if !ok {
-			continue
-		}
-		out = append(out, valuesOf(e.data)...)
-		for _, r := range e.retired {
-			if r.expireAt.After(now) {
-				out = append(out, r.values...)
-			}
-		}
-	}
-	return out
-}
-
 // refreshPass re-mints leases nearing expiry and prunes dead ones. liveKeys is the set of agent-cache keys
 // (cacheKey(jwt, scope)) for still-active sessions; leases whose session is gone are left to expire (no
 // revoke). Returns the earliest future deadline the loop should wake for, or the zero time if none.
@@ -351,13 +287,12 @@ func (s *leaseStore) refreshPass(liveKeys map[string]struct{}) time.Time {
 	s.mu.Lock()
 	var due []leaseKey
 	for k, e := range s.entries {
-		e.retired = pruneRetired(e.retired, now)
 		agentKey := cacheKey(k.jwt, k.scope)
 		_, live := liveKeys[agentKey]
 
 		if !live {
-			// session gone: drop once the lease and all retired values have expired; otherwise let it lapse
-			if (e.leaseID == "" || !e.expireAt.After(now)) && len(e.retired) == 0 {
+			// session gone: drop once the lease has expired; otherwise let it lapse
+			if e.leaseID == "" || !e.expireAt.After(now) {
 				delete(s.entries, k)
 			}
 			continue
@@ -367,7 +302,7 @@ func (s *leaseStore) refreshPass(liveKeys map[string]struct{}) time.Time {
 		}
 		// unused for a full TTL: drop after it expires so the next use re-mints on demand
 		if e.ttl > 0 && now.Sub(e.lastUsed) > e.ttl {
-			if !e.expireAt.After(now) && len(e.retired) == 0 {
+			if !e.expireAt.After(now) {
 				delete(s.entries, k)
 			}
 			continue
@@ -392,9 +327,18 @@ func (s *leaseStore) refreshPass(liveKeys map[string]struct{}) time.Time {
 }
 
 func (s *leaseStore) nextDeadline(liveKeys map[string]struct{}) time.Time {
+	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var next time.Time
+	consider := func(t time.Time) {
+		if t.IsZero() {
+			return
+		}
+		if next.IsZero() || t.Before(next) {
+			next = t
+		}
+	}
 	for k, e := range s.entries {
 		if _, live := liveKeys[cacheKey(k.jwt, k.scope)]; !live {
 			continue
@@ -404,15 +348,15 @@ func (s *leaseStore) nextDeadline(liveKeys map[string]struct{}) time.Time {
 		if e.leaseID == "" {
 			continue
 		}
-		deadline := e.expireAt.Add(-refreshBuffer(e.ttl))
-		if !e.nextMintAttempt.IsZero() && e.nextMintAttempt.Before(deadline) {
-			deadline = e.nextMintAttempt
-		}
-		if deadline.IsZero() {
+		// unused for a full TTL: refreshPass won't re-mint it, only delete it once expired. Schedule the
+		// wake for expiry, not the (already-past) re-mint deadline, else the loop spins at its 1s floor.
+		if e.ttl > 0 && now.Sub(e.lastUsed) > e.ttl {
+			consider(e.expireAt)
 			continue
 		}
-		if next.IsZero() || deadline.Before(next) {
-			next = deadline
+		consider(e.expireAt.Add(-refreshBuffer(e.ttl)))
+		if !e.nextMintAttempt.IsZero() {
+			consider(e.nextMintAttempt)
 		}
 	}
 	return next

--- a/packages/agentproxy/leases.go
+++ b/packages/agentproxy/leases.go
@@ -17,15 +17,11 @@ import (
 )
 
 const (
-	// serve a cached lease only while this much validity remains, so a value isn't injected right as it expires
 	leaseExpirySkew = 5 * time.Second
-	// re-mint backoff bounds while the old lease is still valid
-	minMintBackoff = 5 * time.Second
-	maxMintBackoff = 60 * time.Second
+	minMintBackoff  = 5 * time.Second
+	maxMintBackoff  = 60 * time.Second
 )
 
-// refreshBuffer is how far before expiry the proxy re-mints. Proportional to the TTL so very short
-// leases (e.g. ~30s TOTP) don't get a buffer larger than their own lifetime.
 func refreshBuffer(ttl time.Duration) time.Duration {
 	if ttl <= 0 {
 		return time.Minute
@@ -37,9 +33,6 @@ func refreshBuffer(ttl time.Duration) time.Duration {
 	return buf
 }
 
-// leaseKey identifies a per-agent lease. jwt+scope scope it to a single agent session (matching the agent
-// cache key), so each session gets its own ephemeral credentials; secretName+configHash separate leases for
-// the same dynamic secret minted with different per-lease config.
 type leaseKey struct {
 	jwt        string
 	scope      agentScope
@@ -112,8 +105,7 @@ func defaultLeaseMinter(proxyToken func() string) leaseMinter {
 			Environment:       args.environment,
 			SecretPath:        args.path,
 			DynamicSecretName: args.secretName,
-			// empty TTL: the server applies the dynamic secret's configured defaultTTL
-			Config: args.config,
+			Config:            args.config,
 		})
 		if err != nil {
 			return leaseMintResult{}, err
@@ -135,9 +127,6 @@ func defaultLeaseRevoker(proxyToken func() string) leaseRevoker {
 	}
 }
 
-// canonicalConfigHash produces a stable hash of the per-lease config so two credentials with the same
-// config share a lease and differing configs get separate leases. json.Marshal sorts map keys recursively;
-// nil and empty both normalize to "".
 func canonicalConfigHash(config map[string]interface{}) string {
 	if len(config) == 0 {
 		return ""
@@ -150,8 +139,6 @@ func canonicalConfigHash(config map[string]interface{}) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// register records (or refreshes) the spec for a lease key without minting. Called from resolve() on every
-// discovery/refresh, so an existing live lease is preserved across agent-cache rebuilds.
 func (s *leaseStore) register(key leaseKey, spec leaseSpec) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -178,9 +165,6 @@ func stringifyData(data map[string]interface{}) map[string]string {
 	return out
 }
 
-// value returns the current lease value for a field, minting lazily on first use. Returns ok=false when the
-// lease can't be minted or the field is absent, so the caller skips the credential (fail-open, like a missing
-// static secret).
 func (s *leaseStore) value(key leaseKey, field string) (string, bool) {
 	s.mu.Lock()
 	e, ok := s.entries[key]
@@ -190,7 +174,6 @@ func (s *leaseStore) value(key leaseKey, field string) (string, bool) {
 		s.mu.Unlock()
 		return v, has
 	}
-	// respect the re-mint backoff so a request storm against a failing provider doesn't hammer the mint endpoint
 	inBackoff := ok && !e.nextMintAttempt.IsZero() && time.Now().Before(e.nextMintAttempt)
 	s.mu.Unlock()
 	if !ok || inBackoff {
@@ -208,9 +191,6 @@ func (s *leaseStore) value(key leaseKey, field string) (string, bool) {
 	return v, has
 }
 
-// mintLease mints (or re-mints) a fresh lease for the key, singleflighted so concurrent callers share one
-// network mint. Make-before-break: the new lease swaps in atomically and the old lease is left for the
-// server's scheduled revocation to reap (never proactively revoked here).
 func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 	v, err, _ := s.group.Do(key.string(), func() (interface{}, error) {
 		s.mu.Lock()
@@ -219,7 +199,6 @@ func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 			s.mu.Unlock()
 			return nil, fmt.Errorf("lease entry no longer registered")
 		}
-		// another flight may have already minted a still-valid lease
 		if e.leaseID != "" && time.Until(e.expireAt) > leaseExpirySkew {
 			s.mu.Unlock()
 			return e, nil
@@ -240,7 +219,6 @@ func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 		if mintErr != nil {
 			e.mintFailures++
 			e.nextMintAttempt = time.Now().Add(mintBackoff(e.mintFailures))
-			// once the old lease has expired, drop stale data so requests fail open instead of injecting a dead value
 			if !e.expireAt.IsZero() && e.expireAt.Before(time.Now()) {
 				e.data = nil
 				e.leaseID = ""
@@ -253,9 +231,7 @@ func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
 		e.expireAt = res.expireAt
 		e.ttl = res.expireAt.Sub(now)
 		e.data = stringifyData(res.data)
-		// deliberately do NOT touch lastUsed here: the request path (value) owns it. If a proactive re-mint
-		// bumped lastUsed, the "unused for a full TTL" prune could never fire and orphaned leases (e.g. after
-		// a config change made a new leaseKey) would be re-minted forever.
+		// don't touch lastUsed here (the request path owns it); bumping it would break the unused-TTL prune
 		e.mintFailures = 0
 		e.nextMintAttempt = time.Time{}
 		return e, nil
@@ -278,9 +254,6 @@ func mintBackoff(failures int) time.Duration {
 	return d
 }
 
-// refreshPass re-mints leases nearing expiry and prunes dead ones. liveKeys is the set of agent-cache keys
-// (cacheKey(jwt, scope)) for still-active sessions; leases whose session is gone are left to expire (no
-// revoke). Returns the earliest future deadline the loop should wake for, or the zero time if none.
 func (s *leaseStore) refreshPass(liveKeys map[string]struct{}) time.Time {
 	now := time.Now()
 
@@ -291,16 +264,14 @@ func (s *leaseStore) refreshPass(liveKeys map[string]struct{}) time.Time {
 		_, live := liveKeys[agentKey]
 
 		if !live {
-			// session gone: drop once the lease has expired; otherwise let it lapse
 			if e.leaseID == "" || !e.expireAt.After(now) {
 				delete(s.entries, k)
 			}
 			continue
 		}
 		if e.leaseID == "" {
-			continue // not yet minted; minted lazily on first request
+			continue
 		}
-		// unused for a full TTL: drop after it expires so the next use re-mints on demand
 		if e.ttl > 0 && now.Sub(e.lastUsed) > e.ttl {
 			if !e.expireAt.After(now) {
 				delete(s.entries, k)
@@ -343,13 +314,11 @@ func (s *leaseStore) nextDeadline(liveKeys map[string]struct{}) time.Time {
 		if _, live := liveKeys[cacheKey(k.jwt, k.scope)]; !live {
 			continue
 		}
-		// never-minted entries (leaseID == "") are minted lazily on the next request, not proactively.
-		// refreshPass skips them, so scheduling on their nextMintAttempt here would busy-spin the loop.
+		// never-minted entries mint lazily; scheduling on their nextMintAttempt would busy-spin the loop
 		if e.leaseID == "" {
 			continue
 		}
-		// unused for a full TTL: refreshPass won't re-mint it, only delete it once expired. Schedule the
-		// wake for expiry, not the (already-past) re-mint deadline, else the loop spins at its 1s floor.
+		// unused-TTL entries: wake for expiry, not the already-past re-mint deadline, else the loop spins
 		if e.ttl > 0 && now.Sub(e.lastUsed) > e.ttl {
 			consider(e.expireAt)
 			continue
@@ -362,8 +331,6 @@ func (s *leaseStore) nextDeadline(liveKeys map[string]struct{}) time.Time {
 	return next
 }
 
-// refreshLoop drives lease re-minting on a timer that wakes at the earliest lease deadline (bounded by
-// pollInterval), plus an out-of-band wake whenever a fresh short-TTL lease is minted.
 func (s *leaseStore) refreshLoop(stop <-chan struct{}, pollInterval time.Duration, liveKeys func() map[string]struct{}) {
 	if pollInterval <= 0 {
 		pollInterval = 60 * time.Second
@@ -386,7 +353,6 @@ func (s *leaseStore) refreshLoop(stop <-chan struct{}, pollInterval time.Duratio
 			timer.Reset(clampDuration(time.Until(next), time.Second, pollInterval, next.IsZero()))
 			continue
 		}
-		// woken out-of-band: recompute the deadline without a full pass
 		next := s.nextDeadline(liveKeys())
 		timer.Reset(clampDuration(time.Until(next), time.Second, pollInterval, next.IsZero()))
 	}
@@ -412,8 +378,6 @@ func (s *leaseStore) signalWake() {
 	}
 }
 
-// revokeAll best-effort revokes every live lease on shutdown, bounded by ctx. Failures are logged; the
-// server's per-lease scheduled revocation is the backstop.
 func (s *leaseStore) revokeAll(ctx context.Context) {
 	type target struct {
 		leaseID     string

--- a/packages/agentproxy/leases.go
+++ b/packages/agentproxy/leases.go
@@ -1,0 +1,518 @@
+package agentproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Infisical/infisical-merge/packages/api"
+	"github.com/go-resty/resty/v2"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// serve a cached lease only while this much validity remains, so a value isn't injected right as it expires
+	leaseExpirySkew = 5 * time.Second
+	// keep at most this many superseded value-sets per credential for response redaction across a re-mint
+	maxRetiredValueSets = 2
+	// re-mint backoff bounds while the old lease is still valid
+	minMintBackoff = 5 * time.Second
+	maxMintBackoff = 60 * time.Second
+)
+
+// refreshBuffer is how far before expiry the proxy re-mints. Proportional to the TTL so very short
+// leases (e.g. ~30s TOTP) don't get a buffer larger than their own lifetime.
+func refreshBuffer(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return time.Minute
+	}
+	buf := ttl / 5
+	if buf > time.Minute {
+		return time.Minute
+	}
+	return buf
+}
+
+// leaseKey identifies a per-agent lease. jwt+scope scope it to a single agent session (matching the agent
+// cache key), so each session gets its own ephemeral credentials; secretName+configHash separate leases for
+// the same dynamic secret minted with different per-lease config.
+type leaseKey struct {
+	jwt        string
+	scope      agentScope
+	secretName string
+	configHash string
+}
+
+func (k leaseKey) string() string {
+	return strings.Join([]string{k.jwt, k.scope.projectID, k.scope.environment, k.scope.secretPath, k.secretName, k.configHash}, "\x00")
+}
+
+type leaseSpec struct {
+	projectSlug string
+	config      map[string]interface{}
+}
+
+type retiredValues struct {
+	values   []string
+	expireAt time.Time
+}
+
+type leaseEntry struct {
+	key             leaseKey
+	spec            leaseSpec
+	leaseID         string
+	expireAt        time.Time
+	ttl             time.Duration
+	data            map[string]string
+	retired         []retiredValues
+	lastUsed        time.Time
+	mintFailures    int
+	nextMintAttempt time.Time
+}
+
+type leaseMintArgs struct {
+	secretName  string
+	projectSlug string
+	environment string
+	path        string
+	config      map[string]interface{}
+}
+
+type leaseMintResult struct {
+	leaseID  string
+	expireAt time.Time
+	data     map[string]interface{}
+}
+
+type leaseMinter func(args leaseMintArgs) (leaseMintResult, error)
+type leaseRevoker func(leaseID, projectSlug, environment, path string) error
+
+type leaseStore struct {
+	mint   leaseMinter
+	revoke leaseRevoker
+
+	mu      sync.Mutex
+	entries map[leaseKey]*leaseEntry
+	group   singleflight.Group
+	wake    chan struct{}
+}
+
+func newLeaseStore(proxyToken func() string) *leaseStore {
+	return &leaseStore{
+		mint:    defaultLeaseMinter(proxyToken),
+		revoke:  defaultLeaseRevoker(proxyToken),
+		entries: make(map[leaseKey]*leaseEntry),
+		wake:    make(chan struct{}, 1),
+	}
+}
+
+func defaultLeaseMinter(proxyToken func() string) leaseMinter {
+	return func(args leaseMintArgs) (leaseMintResult, error) {
+		client := resty.New().SetAuthToken(proxyToken())
+		resp, err := api.CallCreateDynamicSecretLeaseV1(client, api.CreateDynamicSecretLeaseV1Request{
+			ProjectSlug:       args.projectSlug,
+			Environment:       args.environment,
+			SecretPath:        args.path,
+			DynamicSecretName: args.secretName,
+			// empty TTL: the server applies the dynamic secret's configured defaultTTL
+			Config: args.config,
+		})
+		if err != nil {
+			return leaseMintResult{}, err
+		}
+		return leaseMintResult{leaseID: resp.Lease.Id, expireAt: resp.Lease.ExpireAt, data: resp.Data}, nil
+	}
+}
+
+func defaultLeaseRevoker(proxyToken func() string) leaseRevoker {
+	return func(leaseID, projectSlug, environment, path string) error {
+		client := resty.New().SetAuthToken(proxyToken())
+		_, err := api.CallRevokeDynamicSecretLeaseV1(client, api.RevokeDynamicSecretLeaseV1Request{
+			LeaseID:     leaseID,
+			ProjectSlug: projectSlug,
+			Environment: environment,
+			SecretPath:  path,
+		})
+		return err
+	}
+}
+
+// canonicalConfigHash produces a stable hash of the per-lease config so two credentials with the same
+// config share a lease and differing configs get separate leases. json.Marshal sorts map keys recursively;
+// nil and empty both normalize to "".
+func canonicalConfigHash(config map[string]interface{}) string {
+	if len(config) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(config)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// register records (or refreshes) the spec for a lease key without minting. Called from resolve() on every
+// discovery/refresh, so an existing live lease is preserved across agent-cache rebuilds.
+func (s *leaseStore) register(key leaseKey, spec leaseSpec) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.entries[key]; ok {
+		e.spec = spec
+		return
+	}
+	s.entries[key] = &leaseEntry{key: key, spec: spec}
+}
+
+func stringifyData(data map[string]interface{}) map[string]string {
+	out := make(map[string]string, len(data))
+	for k, v := range data {
+		switch val := v.(type) {
+		case string:
+			out[k] = val
+		default:
+			b, err := json.Marshal(v)
+			if err == nil {
+				out[k] = string(b)
+			}
+		}
+	}
+	return out
+}
+
+// value returns the current lease value for a field, minting lazily on first use. Returns ok=false when the
+// lease can't be minted or the field is absent, so the caller skips the credential (fail-open, like a missing
+// static secret).
+func (s *leaseStore) value(key leaseKey, field string) (string, bool) {
+	s.mu.Lock()
+	e, ok := s.entries[key]
+	if ok && e.leaseID != "" && time.Until(e.expireAt) > leaseExpirySkew {
+		e.lastUsed = time.Now()
+		v, has := e.data[field]
+		s.mu.Unlock()
+		return v, has
+	}
+	// respect the re-mint backoff so a request storm against a failing provider doesn't hammer the mint endpoint
+	inBackoff := ok && !e.nextMintAttempt.IsZero() && time.Now().Before(e.nextMintAttempt)
+	s.mu.Unlock()
+	if !ok || inBackoff {
+		return "", false
+	}
+
+	entry, err := s.mintLease(key)
+	if err != nil {
+		return "", false
+	}
+	s.mu.Lock()
+	entry.lastUsed = time.Now()
+	v, has := entry.data[field]
+	s.mu.Unlock()
+	return v, has
+}
+
+// mintLease mints (or re-mints) a fresh lease for the key, singleflighted so concurrent callers share one
+// network mint. Make-before-break: the old value-set is retired for redaction and the old lease is left for
+// the server's scheduled revocation to reap (never proactively revoked here).
+func (s *leaseStore) mintLease(key leaseKey) (*leaseEntry, error) {
+	v, err, _ := s.group.Do(key.string(), func() (interface{}, error) {
+		s.mu.Lock()
+		e, ok := s.entries[key]
+		if !ok {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("lease entry no longer registered")
+		}
+		// another flight may have already minted a still-valid lease
+		if e.leaseID != "" && time.Until(e.expireAt) > leaseExpirySkew {
+			s.mu.Unlock()
+			return e, nil
+		}
+		spec := e.spec
+		oldValues := valuesOf(e.data)
+		oldExpireAt := e.expireAt
+		s.mu.Unlock()
+
+		res, mintErr := s.mint(leaseMintArgs{
+			secretName:  key.secretName,
+			projectSlug: spec.projectSlug,
+			environment: key.scope.environment,
+			path:        key.scope.secretPath,
+			config:      spec.config,
+		})
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if mintErr != nil {
+			e.mintFailures++
+			e.nextMintAttempt = time.Now().Add(mintBackoff(e.mintFailures))
+			// once the old lease has expired, drop stale data so requests fail open instead of injecting a dead value
+			if !e.expireAt.IsZero() && e.expireAt.Before(time.Now()) {
+				e.data = nil
+				e.leaseID = ""
+			}
+			return nil, mintErr
+		}
+
+		now := time.Now()
+		if len(oldValues) > 0 && oldExpireAt.After(now) {
+			e.retired = append(e.retired, retiredValues{values: oldValues, expireAt: oldExpireAt})
+			if len(e.retired) > maxRetiredValueSets {
+				e.retired = e.retired[len(e.retired)-maxRetiredValueSets:]
+			}
+		}
+		e.leaseID = res.leaseID
+		e.expireAt = res.expireAt
+		e.ttl = res.expireAt.Sub(now)
+		e.data = stringifyData(res.data)
+		// deliberately do NOT touch lastUsed here: the request path (value) owns it. If a proactive re-mint
+		// bumped lastUsed, the "unused for a full TTL" prune could never fire and orphaned leases (e.g. after
+		// a config change made a new leaseKey) would be re-minted forever.
+		e.mintFailures = 0
+		e.nextMintAttempt = time.Time{}
+		return e, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.signalWake()
+	return v.(*leaseEntry), nil
+}
+
+func mintBackoff(failures int) time.Duration {
+	d := minMintBackoff
+	for i := 1; i < failures; i++ {
+		d *= 2
+		if d >= maxMintBackoff {
+			return maxMintBackoff
+		}
+	}
+	return d
+}
+
+func valuesOf(data map[string]string) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(data))
+	for _, v := range data {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func pruneRetired(retired []retiredValues, now time.Time) []retiredValues {
+	kept := retired[:0]
+	for _, r := range retired {
+		if r.expireAt.After(now) {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
+// redactionValues returns every value (current + not-yet-expired retired) for the given lease keys, so a
+// value reflected back in a response header is scrubbed even briefly after a re-mint swap.
+func (s *leaseStore) redactionValues(keys []leaseKey) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	now := time.Now()
+	for _, k := range keys {
+		e, ok := s.entries[k]
+		if !ok {
+			continue
+		}
+		out = append(out, valuesOf(e.data)...)
+		for _, r := range e.retired {
+			if r.expireAt.After(now) {
+				out = append(out, r.values...)
+			}
+		}
+	}
+	return out
+}
+
+// refreshPass re-mints leases nearing expiry and prunes dead ones. liveKeys is the set of agent-cache keys
+// (cacheKey(jwt, scope)) for still-active sessions; leases whose session is gone are left to expire (no
+// revoke). Returns the earliest future deadline the loop should wake for, or the zero time if none.
+func (s *leaseStore) refreshPass(liveKeys map[string]struct{}) time.Time {
+	now := time.Now()
+
+	s.mu.Lock()
+	var due []leaseKey
+	for k, e := range s.entries {
+		e.retired = pruneRetired(e.retired, now)
+		agentKey := cacheKey(k.jwt, k.scope)
+		_, live := liveKeys[agentKey]
+
+		if !live {
+			// session gone: drop once the lease and all retired values have expired; otherwise let it lapse
+			if (e.leaseID == "" || !e.expireAt.After(now)) && len(e.retired) == 0 {
+				delete(s.entries, k)
+			}
+			continue
+		}
+		if e.leaseID == "" {
+			continue // not yet minted; minted lazily on first request
+		}
+		// unused for a full TTL: drop after it expires so the next use re-mints on demand
+		if e.ttl > 0 && now.Sub(e.lastUsed) > e.ttl {
+			if !e.expireAt.After(now) && len(e.retired) == 0 {
+				delete(s.entries, k)
+			}
+			continue
+		}
+		deadline := e.expireAt.Add(-refreshBuffer(e.ttl))
+		if !e.nextMintAttempt.IsZero() && e.nextMintAttempt.After(deadline) {
+			deadline = e.nextMintAttempt
+		}
+		if !now.Before(deadline) {
+			due = append(due, k)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, k := range due {
+		if _, err := s.mintLease(k); err != nil {
+			log.Warn().Err(err).Msgf("failed to re-mint lease for dynamic secret %q", k.secretName)
+		}
+	}
+
+	return s.nextDeadline(liveKeys)
+}
+
+func (s *leaseStore) nextDeadline(liveKeys map[string]struct{}) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var next time.Time
+	for k, e := range s.entries {
+		if _, live := liveKeys[cacheKey(k.jwt, k.scope)]; !live {
+			continue
+		}
+		// never-minted entries (leaseID == "") are minted lazily on the next request, not proactively.
+		// refreshPass skips them, so scheduling on their nextMintAttempt here would busy-spin the loop.
+		if e.leaseID == "" {
+			continue
+		}
+		deadline := e.expireAt.Add(-refreshBuffer(e.ttl))
+		if !e.nextMintAttempt.IsZero() && e.nextMintAttempt.Before(deadline) {
+			deadline = e.nextMintAttempt
+		}
+		if deadline.IsZero() {
+			continue
+		}
+		if next.IsZero() || deadline.Before(next) {
+			next = deadline
+		}
+	}
+	return next
+}
+
+// refreshLoop drives lease re-minting on a timer that wakes at the earliest lease deadline (bounded by
+// pollInterval), plus an out-of-band wake whenever a fresh short-TTL lease is minted.
+func (s *leaseStore) refreshLoop(stop <-chan struct{}, pollInterval time.Duration, liveKeys func() map[string]struct{}) {
+	if pollInterval <= 0 {
+		pollInterval = 60 * time.Second
+	}
+	timer := time.NewTimer(pollInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-s.wake:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		case <-timer.C:
+			next := s.refreshPass(liveKeys())
+			timer.Reset(clampDuration(time.Until(next), time.Second, pollInterval, next.IsZero()))
+			continue
+		}
+		// woken out-of-band: recompute the deadline without a full pass
+		next := s.nextDeadline(liveKeys())
+		timer.Reset(clampDuration(time.Until(next), time.Second, pollInterval, next.IsZero()))
+	}
+}
+
+func clampDuration(d, min, max time.Duration, useMax bool) time.Duration {
+	if useMax {
+		return max
+	}
+	if d < min {
+		return min
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+func (s *leaseStore) signalWake() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// revokeAll best-effort revokes every live lease on shutdown, bounded by ctx. Failures are logged; the
+// server's per-lease scheduled revocation is the backstop.
+func (s *leaseStore) revokeAll(ctx context.Context) {
+	type target struct {
+		leaseID     string
+		projectSlug string
+		environment string
+		path        string
+		secretName  string
+	}
+	s.mu.Lock()
+	var targets []target
+	for k, e := range s.entries {
+		if e.leaseID == "" {
+			continue
+		}
+		targets = append(targets, target{
+			leaseID:     e.leaseID,
+			projectSlug: e.spec.projectSlug,
+			environment: k.scope.environment,
+			path:        k.scope.secretPath,
+			secretName:  k.secretName,
+		})
+	}
+	s.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, t := range targets {
+		wg.Add(1)
+		go func(t target) {
+			defer wg.Done()
+			if err := s.revoke(t.leaseID, t.projectSlug, t.environment, t.path); err != nil {
+				log.Warn().Err(err).Msgf("failed to revoke lease for dynamic secret %q on shutdown", t.secretName)
+			}
+		}(t)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		log.Warn().Msg("timed out revoking leases on shutdown; relying on server-side lease expiry")
+	}
+}

--- a/packages/agentproxy/leases_test.go
+++ b/packages/agentproxy/leases_test.go
@@ -17,8 +17,6 @@ func testKey(name string) leaseKey {
 	return leaseKey{jwt: "jwt", scope: testScope(), secretName: name, configHash: ""}
 }
 
-// newTestLeaseStore builds a store with an injected minter that returns a deterministic value per mint and
-// counts invocations.
 func newTestLeaseStore(ttl time.Duration, mintCount *int64) *leaseStore {
 	s := &leaseStore{
 		entries: make(map[leaseKey]*leaseEntry),
@@ -125,18 +123,15 @@ func TestValueMissingField(t *testing.T) {
 
 func TestRefreshPassReMintsNearExpiry(t *testing.T) {
 	var mints int64
-	// long TTL so a re-minted lease is served from cache (not re-minted again by the skew guard)
 	s := newTestLeaseStore(time.Hour, &mints)
 	var revokes int64
 	s.revoke = func(_, _, _, _ string) error { atomic.AddInt64(&revokes, 1); return nil }
 	key := testKey("db")
 	s.register(key, leaseSpec{})
 
-	// initial lazy mint
 	if _, ok := s.value(key, "TOKEN"); !ok {
 		t.Fatal("initial mint failed")
 	}
-	// force the lease within its refresh buffer so refreshPass re-mints it
 	s.mu.Lock()
 	s.entries[key].expireAt = time.Now().Add(100 * time.Millisecond)
 	s.mu.Unlock()
@@ -150,7 +145,6 @@ func TestRefreshPassReMintsNearExpiry(t *testing.T) {
 	if atomic.LoadInt64(&revokes) != 0 {
 		t.Fatal("re-mint must never proactively revoke the old lease")
 	}
-	// the fresh lease value is now what gets served
 	if v, ok := s.value(key, "TOKEN"); !ok || v != "value-2" {
 		t.Fatalf("expected the re-minted value-2 to be served, got %q ok=%v", v, ok)
 	}
@@ -164,7 +158,6 @@ func TestRefreshPassSkipsNonLiveSessions(t *testing.T) {
 	s.value(key, "TOKEN")
 	before := atomic.LoadInt64(&mints)
 
-	// empty live set: the session is gone, so no re-mint
 	s.refreshPass(map[string]struct{}{})
 	if atomic.LoadInt64(&mints) != before {
 		t.Fatal("leases for non-live sessions must not be re-minted")
@@ -181,14 +174,12 @@ func TestRefreshBufferProportionalToTTL(t *testing.T) {
 }
 
 func TestFailedFirstMintDoesNotScheduleProactiveWork(t *testing.T) {
-	// a never-minted entry whose first mint failed must not produce a scheduling deadline (else the
-	// refresh loop would busy-spin at the 1s floor until the session goes inactive)
 	s := &leaseStore{entries: make(map[leaseKey]*leaseEntry), wake: make(chan struct{}, 1)}
 	s.mint = func(args leaseMintArgs) (leaseMintResult, error) { return leaseMintResult{}, fmt.Errorf("boom") }
 	s.revoke = func(_, _, _, _ string) error { return nil }
 	key := testKey("db")
 	s.register(key, leaseSpec{})
-	s.value(key, "TOKEN") // fails, sets nextMintAttempt but leaseID stays ""
+	s.value(key, "TOKEN")
 
 	live := map[string]struct{}{cacheKey(key.jwt, key.scope): {}}
 	if next := s.nextDeadline(live); !next.IsZero() {
@@ -207,15 +198,13 @@ func TestValueRespectsMintBackoff(t *testing.T) {
 	key := testKey("db")
 	s.register(key, leaseSpec{})
 
-	s.value(key, "TOKEN") // first attempt fails, arms backoff
-	s.value(key, "TOKEN") // within backoff: must not attempt again
+	s.value(key, "TOKEN")
+	s.value(key, "TOKEN")
 	if got := atomic.LoadInt64(&attempts); got != 1 {
 		t.Fatalf("second request within backoff should not re-attempt mint, got %d attempts", got)
 	}
 }
 
-// Two credentials referencing the same dynamic secret (e.g. basic-auth username + password) must draw
-// from ONE minted lease, so the values actually belong together. Different fields, same key => 1 mint.
 func TestSameSecretMultipleFieldsShareOneLease(t *testing.T) {
 	var mints int64
 	s := &leaseStore{entries: make(map[leaseKey]*leaseEntry), wake: make(chan struct{}, 1)}
@@ -230,7 +219,6 @@ func TestSameSecretMultipleFieldsShareOneLease(t *testing.T) {
 	s.revoke = func(_, _, _, _ string) error { return nil }
 
 	key := testKey("pg")
-	// both credentials build the same key (same secret + config), so both register the same entry
 	s.register(key, leaseSpec{})
 	s.register(key, leaseSpec{})
 

--- a/packages/agentproxy/leases_test.go
+++ b/packages/agentproxy/leases_test.go
@@ -1,0 +1,291 @@
+package agentproxy
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testScope() agentScope {
+	return agentScope{projectID: "proj", environment: "prod", secretPath: "/"}
+}
+
+func testKey(name string) leaseKey {
+	return leaseKey{jwt: "jwt", scope: testScope(), secretName: name, configHash: ""}
+}
+
+// newTestLeaseStore builds a store with an injected minter that returns a deterministic value per mint and
+// counts invocations.
+func newTestLeaseStore(ttl time.Duration, mintCount *int64) *leaseStore {
+	s := &leaseStore{
+		entries: make(map[leaseKey]*leaseEntry),
+		wake:    make(chan struct{}, 1),
+	}
+	var seq int64
+	s.mint = func(args leaseMintArgs) (leaseMintResult, error) {
+		atomic.AddInt64(mintCount, 1)
+		n := atomic.AddInt64(&seq, 1)
+		return leaseMintResult{
+			leaseID:  fmt.Sprintf("lease-%d", n),
+			expireAt: time.Now().Add(ttl),
+			data:     map[string]interface{}{"TOKEN": fmt.Sprintf("value-%d", n)},
+		}, nil
+	}
+	s.revoke = func(_, _, _, _ string) error { return nil }
+	return s
+}
+
+func TestCanonicalConfigHash(t *testing.T) {
+	if canonicalConfigHash(nil) != "" {
+		t.Fatal("nil config should hash to empty string")
+	}
+	if canonicalConfigHash(map[string]interface{}{}) != "" {
+		t.Fatal("empty config should hash to empty string")
+	}
+	a := canonicalConfigHash(map[string]interface{}{"namespace": "prod", "extra": "x"})
+	b := canonicalConfigHash(map[string]interface{}{"extra": "x", "namespace": "prod"})
+	if a != b {
+		t.Fatal("hash must be independent of key order")
+	}
+	if canonicalConfigHash(map[string]interface{}{"namespace": "prod"}) == a {
+		t.Fatal("different config must hash differently")
+	}
+}
+
+func TestRegisterDoesNotMint(t *testing.T) {
+	var mints int64
+	s := newTestLeaseStore(time.Hour, &mints)
+	s.register(testKey("db"), leaseSpec{projectSlug: "slug"})
+	if atomic.LoadInt64(&mints) != 0 {
+		t.Fatalf("register should not mint, got %d mints", mints)
+	}
+}
+
+func TestValueLazyMintAndReuse(t *testing.T) {
+	var mints int64
+	s := newTestLeaseStore(time.Hour, &mints)
+	key := testKey("db")
+	s.register(key, leaseSpec{projectSlug: "slug"})
+
+	v, ok := s.value(key, "TOKEN")
+	if !ok || v != "value-1" {
+		t.Fatalf("expected value-1, got %q ok=%v", v, ok)
+	}
+	if _, ok := s.value(key, "TOKEN"); !ok {
+		t.Fatal("second read should hit cache")
+	}
+	if atomic.LoadInt64(&mints) != 1 {
+		t.Fatalf("expected exactly 1 mint, got %d", mints)
+	}
+}
+
+func TestValueConcurrentSingleMint(t *testing.T) {
+	var mints int64
+	s := newTestLeaseStore(time.Hour, &mints)
+	key := testKey("db")
+	s.register(key, leaseSpec{projectSlug: "slug"})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.value(key, "TOKEN")
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt64(&mints); got != 1 {
+		t.Fatalf("singleflight should collapse concurrent mints to 1, got %d", got)
+	}
+}
+
+func TestValueMintFailureFailsOpen(t *testing.T) {
+	s := &leaseStore{entries: make(map[leaseKey]*leaseEntry), wake: make(chan struct{}, 1)}
+	s.mint = func(args leaseMintArgs) (leaseMintResult, error) { return leaseMintResult{}, fmt.Errorf("boom") }
+	s.revoke = func(_, _, _, _ string) error { return nil }
+	key := testKey("db")
+	s.register(key, leaseSpec{})
+	if v, ok := s.value(key, "TOKEN"); ok || v != "" {
+		t.Fatalf("mint failure should return ok=false, got %q ok=%v", v, ok)
+	}
+}
+
+func TestValueMissingField(t *testing.T) {
+	var mints int64
+	s := newTestLeaseStore(time.Hour, &mints)
+	key := testKey("db")
+	s.register(key, leaseSpec{})
+	if _, ok := s.value(key, "NONEXISTENT"); ok {
+		t.Fatal("missing field should return ok=false")
+	}
+}
+
+func TestRefreshPassReMintsNearExpiryAndRetiresOldValue(t *testing.T) {
+	var mints int64
+	// short TTL so the entry is immediately within the refresh buffer
+	s := newTestLeaseStore(2*time.Second, &mints)
+	var revokes int64
+	s.revoke = func(_, _, _, _ string) error { atomic.AddInt64(&revokes, 1); return nil }
+	key := testKey("db")
+	s.register(key, leaseSpec{})
+
+	// initial lazy mint
+	if _, ok := s.value(key, "TOKEN"); !ok {
+		t.Fatal("initial mint failed")
+	}
+	// force the lease within its refresh buffer (still valid, so the old value is retained on re-mint)
+	s.mu.Lock()
+	s.entries[key].expireAt = time.Now().Add(100 * time.Millisecond)
+	s.mu.Unlock()
+	live := map[string]struct{}{cacheKey(key.jwt, key.scope): {}}
+
+	s.refreshPass(live)
+
+	if atomic.LoadInt64(&mints) < 2 {
+		t.Fatalf("expected a re-mint, got %d mints", mints)
+	}
+	if atomic.LoadInt64(&revokes) != 0 {
+		t.Fatal("re-mint must never proactively revoke the old lease")
+	}
+	// the old value must be retained for redaction
+	redaction := s.redactionValues([]leaseKey{key})
+	found := false
+	for _, v := range redaction {
+		if v == "value-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("old lease value should be retained for redaction after re-mint")
+	}
+}
+
+func TestRefreshPassSkipsNonLiveSessions(t *testing.T) {
+	var mints int64
+	s := newTestLeaseStore(2*time.Second, &mints)
+	key := testKey("db")
+	s.register(key, leaseSpec{})
+	s.value(key, "TOKEN")
+	before := atomic.LoadInt64(&mints)
+
+	// empty live set: the session is gone, so no re-mint
+	s.refreshPass(map[string]struct{}{})
+	if atomic.LoadInt64(&mints) != before {
+		t.Fatal("leases for non-live sessions must not be re-minted")
+	}
+}
+
+func TestRetiredValuesCappedAndPruned(t *testing.T) {
+	e := &leaseEntry{}
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		e.retired = append(e.retired, retiredValues{values: []string{fmt.Sprintf("v%d", i)}, expireAt: now.Add(time.Hour)})
+		if len(e.retired) > maxRetiredValueSets {
+			e.retired = e.retired[len(e.retired)-maxRetiredValueSets:]
+		}
+	}
+	if len(e.retired) != maxRetiredValueSets {
+		t.Fatalf("retired should cap at %d, got %d", maxRetiredValueSets, len(e.retired))
+	}
+	e.retired = append(e.retired, retiredValues{values: []string{"expired"}, expireAt: now.Add(-time.Hour)})
+	e.retired = pruneRetired(e.retired, now)
+	for _, r := range e.retired {
+		for _, v := range r.values {
+			if v == "expired" {
+				t.Fatal("expired retired values should be pruned")
+			}
+		}
+	}
+}
+
+func TestRefreshBufferProportionalToTTL(t *testing.T) {
+	if refreshBuffer(30*time.Second) != 6*time.Second {
+		t.Fatalf("expected ttl/5 for short ttl, got %v", refreshBuffer(30*time.Second))
+	}
+	if refreshBuffer(time.Hour) != time.Minute {
+		t.Fatalf("expected 60s cap for long ttl, got %v", refreshBuffer(time.Hour))
+	}
+}
+
+func TestFailedFirstMintDoesNotScheduleProactiveWork(t *testing.T) {
+	// a never-minted entry whose first mint failed must not produce a scheduling deadline (else the
+	// refresh loop would busy-spin at the 1s floor until the session goes inactive)
+	s := &leaseStore{entries: make(map[leaseKey]*leaseEntry), wake: make(chan struct{}, 1)}
+	s.mint = func(args leaseMintArgs) (leaseMintResult, error) { return leaseMintResult{}, fmt.Errorf("boom") }
+	s.revoke = func(_, _, _, _ string) error { return nil }
+	key := testKey("db")
+	s.register(key, leaseSpec{})
+	s.value(key, "TOKEN") // fails, sets nextMintAttempt but leaseID stays ""
+
+	live := map[string]struct{}{cacheKey(key.jwt, key.scope): {}}
+	if next := s.nextDeadline(live); !next.IsZero() {
+		t.Fatalf("never-minted failed entry must not schedule proactive work, got %v", next)
+	}
+}
+
+func TestValueRespectsMintBackoff(t *testing.T) {
+	var attempts int64
+	s := &leaseStore{entries: make(map[leaseKey]*leaseEntry), wake: make(chan struct{}, 1)}
+	s.mint = func(args leaseMintArgs) (leaseMintResult, error) {
+		atomic.AddInt64(&attempts, 1)
+		return leaseMintResult{}, fmt.Errorf("boom")
+	}
+	s.revoke = func(_, _, _, _ string) error { return nil }
+	key := testKey("db")
+	s.register(key, leaseSpec{})
+
+	s.value(key, "TOKEN") // first attempt fails, arms backoff
+	s.value(key, "TOKEN") // within backoff: must not attempt again
+	if got := atomic.LoadInt64(&attempts); got != 1 {
+		t.Fatalf("second request within backoff should not re-attempt mint, got %d attempts", got)
+	}
+}
+
+// Two credentials referencing the same dynamic secret (e.g. basic-auth username + password) must draw
+// from ONE minted lease, so the values actually belong together. Different fields, same key => 1 mint.
+func TestSameSecretMultipleFieldsShareOneLease(t *testing.T) {
+	var mints int64
+	s := &leaseStore{entries: make(map[leaseKey]*leaseEntry), wake: make(chan struct{}, 1)}
+	s.mint = func(args leaseMintArgs) (leaseMintResult, error) {
+		atomic.AddInt64(&mints, 1)
+		return leaseMintResult{
+			leaseID:  "lease-1",
+			expireAt: time.Now().Add(time.Hour),
+			data:     map[string]interface{}{"DB_USERNAME": "u1", "DB_PASSWORD": "p1"},
+		}, nil
+	}
+	s.revoke = func(_, _, _, _ string) error { return nil }
+
+	key := testKey("pg")
+	// both credentials build the same key (same secret + config), so both register the same entry
+	s.register(key, leaseSpec{})
+	s.register(key, leaseSpec{})
+
+	user, okU := s.value(key, "DB_USERNAME")
+	pass, okP := s.value(key, "DB_PASSWORD")
+	if !okU || !okP || user != "u1" || pass != "p1" {
+		t.Fatalf("expected u1/p1 from one lease, got %q/%q (ok %v/%v)", user, pass, okU, okP)
+	}
+	if got := atomic.LoadInt64(&mints); got != 1 {
+		t.Fatalf("same secret referenced twice must mint exactly one lease, got %d", got)
+	}
+}
+
+func TestRevokeAllRevokesLiveLeases(t *testing.T) {
+	var mints int64
+	s := newTestLeaseStore(time.Hour, &mints)
+	var revoked int64
+	s.revoke = func(_, _, _, _ string) error { atomic.AddInt64(&revoked, 1); return nil }
+	for i := 0; i < 3; i++ {
+		key := testKey(fmt.Sprintf("db-%d", i))
+		s.register(key, leaseSpec{})
+		s.value(key, "TOKEN")
+	}
+	s.revokeAll(context.Background())
+	if atomic.LoadInt64(&revoked) != 3 {
+		t.Fatalf("expected 3 revokes, got %d", revoked)
+	}
+}

--- a/packages/agentproxy/leases_test.go
+++ b/packages/agentproxy/leases_test.go
@@ -123,10 +123,10 @@ func TestValueMissingField(t *testing.T) {
 	}
 }
 
-func TestRefreshPassReMintsNearExpiryAndRetiresOldValue(t *testing.T) {
+func TestRefreshPassReMintsNearExpiry(t *testing.T) {
 	var mints int64
-	// short TTL so the entry is immediately within the refresh buffer
-	s := newTestLeaseStore(2*time.Second, &mints)
+	// long TTL so a re-minted lease is served from cache (not re-minted again by the skew guard)
+	s := newTestLeaseStore(time.Hour, &mints)
 	var revokes int64
 	s.revoke = func(_, _, _, _ string) error { atomic.AddInt64(&revokes, 1); return nil }
 	key := testKey("db")
@@ -136,7 +136,7 @@ func TestRefreshPassReMintsNearExpiryAndRetiresOldValue(t *testing.T) {
 	if _, ok := s.value(key, "TOKEN"); !ok {
 		t.Fatal("initial mint failed")
 	}
-	// force the lease within its refresh buffer (still valid, so the old value is retained on re-mint)
+	// force the lease within its refresh buffer so refreshPass re-mints it
 	s.mu.Lock()
 	s.entries[key].expireAt = time.Now().Add(100 * time.Millisecond)
 	s.mu.Unlock()
@@ -150,16 +150,9 @@ func TestRefreshPassReMintsNearExpiryAndRetiresOldValue(t *testing.T) {
 	if atomic.LoadInt64(&revokes) != 0 {
 		t.Fatal("re-mint must never proactively revoke the old lease")
 	}
-	// the old value must be retained for redaction
-	redaction := s.redactionValues([]leaseKey{key})
-	found := false
-	for _, v := range redaction {
-		if v == "value-1" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatal("old lease value should be retained for redaction after re-mint")
+	// the fresh lease value is now what gets served
+	if v, ok := s.value(key, "TOKEN"); !ok || v != "value-2" {
+		t.Fatalf("expected the re-minted value-2 to be served, got %q ok=%v", v, ok)
 	}
 }
 
@@ -175,29 +168,6 @@ func TestRefreshPassSkipsNonLiveSessions(t *testing.T) {
 	s.refreshPass(map[string]struct{}{})
 	if atomic.LoadInt64(&mints) != before {
 		t.Fatal("leases for non-live sessions must not be re-minted")
-	}
-}
-
-func TestRetiredValuesCappedAndPruned(t *testing.T) {
-	e := &leaseEntry{}
-	now := time.Now()
-	for i := 0; i < 5; i++ {
-		e.retired = append(e.retired, retiredValues{values: []string{fmt.Sprintf("v%d", i)}, expireAt: now.Add(time.Hour)})
-		if len(e.retired) > maxRetiredValueSets {
-			e.retired = e.retired[len(e.retired)-maxRetiredValueSets:]
-		}
-	}
-	if len(e.retired) != maxRetiredValueSets {
-		t.Fatalf("retired should cap at %d, got %d", maxRetiredValueSets, len(e.retired))
-	}
-	e.retired = append(e.retired, retiredValues{values: []string{"expired"}, expireAt: now.Add(-time.Hour)})
-	e.retired = pruneRetired(e.retired, now)
-	for _, r := range e.retired {
-		for _, v := range r.values {
-			if v == "expired" {
-				t.Fatal("expired retired values should be pruned")
-			}
-		}
 	}
 }
 

--- a/packages/agentproxy/proxy.go
+++ b/packages/agentproxy/proxy.go
@@ -1,6 +1,7 @@
 package agentproxy
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
@@ -8,8 +9,11 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -48,6 +52,9 @@ const (
 	// maxConcurrentConns caps simultaneous client connections so a flood of sockets can't exhaust file
 	// descriptors or goroutines. A live tunnel holds its slot for the tunnel's lifetime.
 	maxConcurrentConns = 512
+
+	// bound for best-effort lease revocation on shutdown before falling back to server-side expiry
+	leaseRevokeShutdownTimeout = 5 * time.Second
 )
 
 var errHostBlocked = errors.New("host blocked by policy")
@@ -63,14 +70,17 @@ type proxyServer struct {
 	opts      Options
 	ca        *caManager
 	cache     *agentCache
+	leases    *leaseStore
 	transport http.RoundTripper
 }
 
 func newProxyServer(opts Options) *proxyServer {
+	leases := newLeaseStore(opts.ProxyToken)
 	return &proxyServer{
 		opts:      opts,
 		ca:        newCaManager(opts.ProxyToken),
-		cache:     newAgentCache(opts.ProxyToken),
+		cache:     newAgentCache(opts.ProxyToken, leases),
+		leases:    leases,
 		transport: newUpstreamTransport(),
 	}
 }
@@ -108,6 +118,9 @@ func Start(opts Options) error {
 
 	go ps.pollLoop()
 
+	leaseStop := make(chan struct{})
+	go ps.leases.refreshLoop(leaseStop, opts.PollInterval, ps.cache.activeJWTs)
+
 	if addr := portInUse(opts.Port); addr != "" {
 		return fmt.Errorf("port %d is already in use (%s); another process is listening. Choose a free port with --port", opts.Port, addr)
 	}
@@ -118,7 +131,27 @@ func Start(opts Options) error {
 	}
 	log.Info().Msgf("Infisical agent proxy listening on :%d", opts.Port)
 
-	return ps.newFrontServer().Serve(newLimitListener(listener, maxConcurrentConns))
+	srv := ps.newFrontServer()
+
+	// Best-effort lease cleanup on shutdown. The server's per-lease scheduled revocation is the backstop,
+	// so a missed revoke here just means the lease lives out its TTL.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		log.Info().Msg("shutting down agent proxy; revoking active leases")
+		close(leaseStop)
+		ctx, cancel := context.WithTimeout(context.Background(), leaseRevokeShutdownTimeout)
+		defer cancel()
+		ps.leases.revokeAll(ctx)
+		_ = srv.Shutdown(ctx)
+	}()
+
+	err = srv.Serve(newLimitListener(listener, maxConcurrentConns))
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 func portInUse(port int) string {
@@ -348,8 +381,11 @@ func (ps *proxyServer) forward(req *http.Request, scheme, hostname, port, jwt st
 	// Strip hop-by-hop before injecting so a client's Connection header cannot delete the injected credential (injected always wins).
 	stripHopByHopHeaders(req.Header)
 
+	var dynamicKeys []leaseKey
 	if svc != nil {
-		if err := applyCredentials(req, svc); err != nil {
+		creds, keys := ps.materializeCredentials(svc)
+		dynamicKeys = keys
+		if err := applyCredentials(req, creds); err != nil {
 			return nil, fmt.Errorf("failed to apply credentials: %w", err)
 		}
 	}
@@ -363,9 +399,44 @@ func (ps *proxyServer) forward(req *http.Request, scheme, hostname, port, jwt st
 	// redirect Location) so the agent can't read a credential it was never allowed to retrieve. Bodies are
 	// streamed and intentionally not scanned; TRACE/TRACK (the main body-echo vector) is rejected upstream.
 	if svc != nil {
-		redactCredentialsFromHeaders(resp.Header, svc)
+		redactValuesFromHeaders(resp.Header, ps.redactionValues(svc, dynamicKeys))
 	}
 	return resp, nil
+}
+
+// materializeCredentials returns a per-request copy of the service's credentials with dynamic-secret values
+// resolved from the lease store (minting lazily). A dynamic credential with no available lease value is
+// dropped (fail-open, like a missing static secret). Returns the lease keys used, for response redaction.
+func (ps *proxyServer) materializeCredentials(svc *resolvedService) ([]resolvedCredential, []leaseKey) {
+	creds := make([]resolvedCredential, 0, len(svc.credentials))
+	var dynamicKeys []leaseKey
+	for _, cred := range svc.credentials {
+		if cred.dynamic == nil {
+			creds = append(creds, cred)
+			continue
+		}
+		dynamicKeys = append(dynamicKeys, cred.dynamic.key)
+		value, ok := ps.leases.value(cred.dynamic.key, cred.dynamic.field)
+		if !ok {
+			log.Warn().Msgf("proxied service %q: no valid lease value for dynamic secret %q field %q; skipping credential", svc.name, cred.dynamic.key.secretName, cred.dynamic.field)
+			continue
+		}
+		cred.value = value
+		creds = append(creds, cred)
+	}
+	return creds, dynamicKeys
+}
+
+// redactionValues gathers static credential values plus current/retired dynamic lease values for redaction.
+func (ps *proxyServer) redactionValues(svc *resolvedService, dynamicKeys []leaseKey) []string {
+	var values []string
+	for _, cred := range svc.credentials {
+		if cred.dynamic == nil && cred.value != "" {
+			values = append(values, cred.value)
+		}
+	}
+	values = append(values, ps.leases.redactionValues(dynamicKeys)...)
+	return values
 }
 
 func hostHeaderForScheme(scheme, target string) string {

--- a/packages/agentproxy/proxy.go
+++ b/packages/agentproxy/proxy.go
@@ -53,7 +53,6 @@ const (
 	// descriptors or goroutines. A live tunnel holds its slot for the tunnel's lifetime.
 	maxConcurrentConns = 512
 
-	// bound for best-effort lease revocation on shutdown before falling back to server-side expiry
 	leaseRevokeShutdownTimeout = 5 * time.Second
 )
 
@@ -133,8 +132,6 @@ func Start(opts Options) error {
 
 	srv := ps.newFrontServer()
 
-	// Best-effort lease cleanup on shutdown. The server's per-lease scheduled revocation is the backstop,
-	// so a missed revoke here just means the lease lives out its TTL.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	go func() {
@@ -391,9 +388,6 @@ func (ps *proxyServer) forward(req *http.Request, scheme, hostname, port, jwt st
 	return ps.transport.RoundTrip(req)
 }
 
-// materializeCredentials returns a per-request copy of the service's credentials with dynamic-secret values
-// resolved from the lease store (minting lazily). A dynamic credential with no available lease value is
-// dropped (fail-open, like a missing static secret).
 func (ps *proxyServer) materializeCredentials(svc *resolvedService) []resolvedCredential {
 	creds := make([]resolvedCredential, 0, len(svc.credentials))
 	for _, cred := range svc.credentials {

--- a/packages/agentproxy/proxy.go
+++ b/packages/agentproxy/proxy.go
@@ -381,41 +381,26 @@ func (ps *proxyServer) forward(req *http.Request, scheme, hostname, port, jwt st
 	// Strip hop-by-hop before injecting so a client's Connection header cannot delete the injected credential (injected always wins).
 	stripHopByHopHeaders(req.Header)
 
-	var dynamicKeys []leaseKey
 	if svc != nil {
-		creds, keys := ps.materializeCredentials(svc)
-		dynamicKeys = keys
+		creds := ps.materializeCredentials(svc)
 		if err := applyCredentials(req, creds); err != nil {
 			return nil, fmt.Errorf("failed to apply credentials: %w", err)
 		}
 	}
 
-	resp, err := ps.transport.RoundTrip(req)
-	if err != nil {
-		return nil, err
-	}
-
-	// Redact any brokered secret reflected back in a response header (e.g. a substituted value echoed in a
-	// redirect Location) so the agent can't read a credential it was never allowed to retrieve. Bodies are
-	// streamed and intentionally not scanned; TRACE/TRACK (the main body-echo vector) is rejected upstream.
-	if svc != nil {
-		redactValuesFromHeaders(resp.Header, ps.redactionValues(svc, dynamicKeys))
-	}
-	return resp, nil
+	return ps.transport.RoundTrip(req)
 }
 
 // materializeCredentials returns a per-request copy of the service's credentials with dynamic-secret values
 // resolved from the lease store (minting lazily). A dynamic credential with no available lease value is
-// dropped (fail-open, like a missing static secret). Returns the lease keys used, for response redaction.
-func (ps *proxyServer) materializeCredentials(svc *resolvedService) ([]resolvedCredential, []leaseKey) {
+// dropped (fail-open, like a missing static secret).
+func (ps *proxyServer) materializeCredentials(svc *resolvedService) []resolvedCredential {
 	creds := make([]resolvedCredential, 0, len(svc.credentials))
-	var dynamicKeys []leaseKey
 	for _, cred := range svc.credentials {
 		if cred.dynamic == nil {
 			creds = append(creds, cred)
 			continue
 		}
-		dynamicKeys = append(dynamicKeys, cred.dynamic.key)
 		value, ok := ps.leases.value(cred.dynamic.key, cred.dynamic.field)
 		if !ok {
 			log.Warn().Msgf("proxied service %q: no valid lease value for dynamic secret %q field %q; skipping credential", svc.name, cred.dynamic.key.secretName, cred.dynamic.field)
@@ -424,19 +409,7 @@ func (ps *proxyServer) materializeCredentials(svc *resolvedService) ([]resolvedC
 		cred.value = value
 		creds = append(creds, cred)
 	}
-	return creds, dynamicKeys
-}
-
-// redactionValues gathers static credential values plus current/retired dynamic lease values for redaction.
-func (ps *proxyServer) redactionValues(svc *resolvedService, dynamicKeys []leaseKey) []string {
-	var values []string
-	for _, cred := range svc.credentials {
-		if cred.dynamic == nil && cred.value != "" {
-			values = append(values, cred.value)
-		}
-	}
-	values = append(values, ps.leases.redactionValues(dynamicKeys)...)
-	return values
+	return creds
 }
 
 func hostHeaderForScheme(scheme, target string) string {

--- a/packages/agentproxy/reflect_test.go
+++ b/packages/agentproxy/reflect_test.go
@@ -58,7 +58,7 @@ func TestForwardRedactsReflectedSecretInResponseHeader(t *testing.T) {
 			{role: roleHeaderRewrite, headerName: "Authorization", headerPrefix: "Bearer", value: "real_secret"},
 		},
 	}}
-	cache := newAgentCache(func() string { return "" })
+	cache := newAgentCache(func() string { return "" }, newLeaseStore(func() string { return "" }))
 	cache.entries[cacheKey(jwt, scope)] = &agentEntry{jwt: jwt, scope: scope, services: services, lastSeen: time.Now()}
 
 	respHeader := make(http.Header)

--- a/packages/agentproxy/reflect_test.go
+++ b/packages/agentproxy/reflect_test.go
@@ -45,8 +45,7 @@ func (rt reflectingTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	}, nil
 }
 
-// The proxy injects credentials one-way and relays the upstream response untouched: it does not scan or
-// rewrite response headers. Reflected request data therefore passes through as-is (by design).
+// The proxy injects one-way and relays the response untouched; reflected request data passes through by design.
 func TestForwardPassesResponseHeadersThrough(t *testing.T) {
 	jwt := "test.jwt.token"
 	scope := agentScope{projectID: "proj", environment: "prod", secretPath: "/"}

--- a/packages/agentproxy/reflect_test.go
+++ b/packages/agentproxy/reflect_test.go
@@ -45,9 +45,9 @@ func (rt reflectingTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	}, nil
 }
 
-// A brokered secret reflected back in a response header (e.g. a redirect Location echoing a substituted
-// value) must be redacted so the agent can't read a credential it was never allowed to retrieve.
-func TestForwardRedactsReflectedSecretInResponseHeader(t *testing.T) {
+// The proxy injects credentials one-way and relays the upstream response untouched: it does not scan or
+// rewrite response headers. Reflected request data therefore passes through as-is (by design).
+func TestForwardPassesResponseHeadersThrough(t *testing.T) {
 	jwt := "test.jwt.token"
 	scope := agentScope{projectID: "proj", environment: "prod", secretPath: "/"}
 	services := []*resolvedService{{
@@ -74,11 +74,7 @@ func TestForwardRedactsReflectedSecretInResponseHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("forward: %v", err)
 	}
-	got := resp.Header.Get("Location")
-	if strings.Contains(got, "real_secret") {
-		t.Fatalf("secret was not redacted from response header: %q", got)
-	}
-	if !strings.Contains(got, "[redacted]") {
-		t.Fatalf("expected redaction marker in header, got %q", got)
+	if got := resp.Header.Get("Location"); got != "https://example.com/next?token=real_secret" {
+		t.Fatalf("response header should pass through unchanged, got %q", got)
 	}
 }

--- a/packages/agentproxy/rewrite.go
+++ b/packages/agentproxy/rewrite.go
@@ -61,25 +61,6 @@ func applyCredentials(req *http.Request, creds []resolvedCredential) error {
 	return nil
 }
 
-// redactCredentialsFromHeaders replaces any brokered secret value that appears in a response header with a
-// placeholder. Upstreams occasionally reflect request data (redirect Location, error echoes); without this an
-// agent could read a real credential it was never allowed to retrieve. A real high-entropy secret won't
-// collide with legitimate header content, so this only fires when a value is genuinely reflected.
-func redactValuesFromHeaders(h http.Header, values []string) {
-	for _, value := range values {
-		if value == "" {
-			continue
-		}
-		for name, headerValues := range h {
-			for i, v := range headerValues {
-				if strings.Contains(v, value) {
-					h[name][i] = strings.ReplaceAll(v, value, "[redacted]")
-				}
-			}
-		}
-	}
-}
-
 func hasSurface(surfaces []string, target string) bool {
 	for _, s := range surfaces {
 		if s == target {

--- a/packages/agentproxy/rewrite.go
+++ b/packages/agentproxy/rewrite.go
@@ -21,11 +21,11 @@ const (
 	maxBodyRewriteSize = 10 * 1024 * 1024
 )
 
-func applyCredentials(req *http.Request, svc *resolvedService) error {
+func applyCredentials(req *http.Request, creds []resolvedCredential) error {
 	var basicUser, basicPass string
 	haveBasic := false
 
-	for _, cred := range svc.credentials {
+	for _, cred := range creds {
 		switch cred.role {
 		case roleHeaderRewrite:
 			switch cred.headerPurpose {
@@ -65,15 +65,15 @@ func applyCredentials(req *http.Request, svc *resolvedService) error {
 // placeholder. Upstreams occasionally reflect request data (redirect Location, error echoes); without this an
 // agent could read a real credential it was never allowed to retrieve. A real high-entropy secret won't
 // collide with legitimate header content, so this only fires when a value is genuinely reflected.
-func redactCredentialsFromHeaders(h http.Header, svc *resolvedService) {
-	for _, cred := range svc.credentials {
-		if cred.value == "" {
+func redactValuesFromHeaders(h http.Header, values []string) {
+	for _, value := range values {
+		if value == "" {
 			continue
 		}
-		for name, values := range h {
-			for i, v := range values {
-				if strings.Contains(v, cred.value) {
-					h[name][i] = strings.ReplaceAll(v, cred.value, "[redacted]")
+		for name, headerValues := range h {
+			for i, v := range headerValues {
+				if strings.Contains(v, value) {
+					h[name][i] = strings.ReplaceAll(v, value, "[redacted]")
 				}
 			}
 		}

--- a/packages/agentproxy/rewrite_test.go
+++ b/packages/agentproxy/rewrite_test.go
@@ -20,7 +20,7 @@ func TestBearerHeaderRewrite(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleHeaderRewrite, headerName: "Authorization", headerPrefix: "Bearer", value: "sk_live_real"},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if got := req.Header.Get("Authorization"); got != "Bearer sk_live_real" {
@@ -33,7 +33,7 @@ func TestApiKeyHeaderNoPrefix(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleHeaderRewrite, headerName: "x-api-key", value: "abc123"},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if got := req.Header.Get("x-api-key"); got != "abc123" {
@@ -47,7 +47,7 @@ func TestBasicAuthFromTwoCredentials(t *testing.T) {
 		{role: roleHeaderRewrite, headerPurpose: purposeUsername, value: "user"},
 		{role: roleHeaderRewrite, headerPurpose: purposePassword, value: "pass"},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	// base64("user:pass") == "dXNlcjpwYXNz"
@@ -61,7 +61,7 @@ func TestSubstitutionInQuery(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "placeholder_x", value: "real_secret", surfaces: []string{surfaceQuery}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(req.URL.RawQuery, "real_secret") || strings.Contains(req.URL.RawQuery, "placeholder_x") {
@@ -75,7 +75,7 @@ func TestSubstitutionInPath(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "placeholder_tg", value: "12345:realtoken", surfaces: []string{surfacePath}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(req.URL.Path, "12345:realtoken") {
@@ -88,7 +88,7 @@ func TestSubstitutionInBody(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "placeholder_x", value: "real_secret", surfaces: []string{surfaceBody}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(req.Body)
@@ -113,7 +113,7 @@ func TestHeaderRewritePrefixVariations(t *testing.T) {
 			svc := &resolvedService{credentials: []resolvedCredential{
 				{role: roleHeaderRewrite, headerName: "Authorization", headerPrefix: tc.prefix, value: tc.value},
 			}}
-			if err := applyCredentials(req, svc); err != nil {
+			if err := applyCredentials(req, svc.credentials); err != nil {
 				t.Fatal(err)
 			}
 			if got := req.Header.Get("Authorization"); got != tc.want {
@@ -129,7 +129,7 @@ func TestSubstitutionInHeader(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "PLACEHOLDER", value: "REALSECRET", surfaces: []string{surfaceHeader}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if got := req.Header.Get("X-Custom"); got != "prefix-REALSECRET-suffix" {
@@ -148,7 +148,7 @@ func TestSubstitutionAcrossAllSurfacesInOneCredential(t *testing.T) {
 			surfaces:    []string{surfacePath, surfaceQuery, surfaceBody, surfaceHeader},
 		},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(req.URL.Path, "PLACEHOLDER") || !strings.Contains(req.URL.Path, "REALSECRET") {
@@ -172,7 +172,7 @@ func TestHeaderRewriteAndSubstitutionCombined(t *testing.T) {
 		{role: roleHeaderRewrite, headerName: "Authorization", headerPrefix: "Bearer", value: "sk_live_real"},
 		{role: roleCredentialSub, placeholder: "placeholder_x", value: "real_secret", surfaces: []string{surfaceQuery}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	if got := req.Header.Get("Authorization"); got != "Bearer sk_live_real" {
@@ -189,7 +189,7 @@ func TestMultipleSubstitutionsDistinctPlaceholders(t *testing.T) {
 		{role: roleCredentialSub, placeholder: "PH_ONE", value: "real_one", surfaces: []string{surfaceBody}},
 		{role: roleCredentialSub, placeholder: "PH_TWO", value: "real_two", surfaces: []string{surfaceBody}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(req.Body)
@@ -204,7 +204,7 @@ func TestBodySubstitutionUpdatesContentLength(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "placeholder_x", value: "a_substantially_longer_real_secret", surfaces: []string{surfaceBody}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(req.Body)
@@ -222,7 +222,7 @@ func TestBodySubstitutionSkippedWhenContentEncoded(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "placeholder_x", value: "real_secret", surfaces: []string{surfaceBody}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(req.Body)
@@ -237,7 +237,7 @@ func TestBodyOversizedForwardedUnchanged(t *testing.T) {
 	svc := &resolvedService{credentials: []resolvedCredential{
 		{role: roleCredentialSub, placeholder: "placeholder_x", value: "real_secret", surfaces: []string{surfaceBody}},
 	}}
-	if err := applyCredentials(req, svc); err != nil {
+	if err := applyCredentials(req, svc.credentials); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(req.Body)

--- a/packages/api/agent_proxy.go
+++ b/packages/api/agent_proxy.go
@@ -63,7 +63,7 @@ func CallSignAgentProxyIntermediateCa(httpClient *resty.Client, request SignAgen
 
 type ProxiedServiceCredential struct {
 	ID                   string   `json:"id"`
-	SecretKey            string   `json:"secretKey"`
+	SecretKey            string   `json:"secretKey,omitempty"`
 	Role                 string   `json:"role"`
 	HeaderName           string   `json:"headerName,omitempty"`
 	HeaderPrefix         string   `json:"headerPrefix,omitempty"`
@@ -71,6 +71,12 @@ type ProxiedServiceCredential struct {
 	PlaceholderKey       string   `json:"placeholderKey,omitempty"`
 	PlaceholderValue     string   `json:"placeholderValue,omitempty"`
 	SubstitutionSurfaces []string `json:"substitutionSurfaces,omitempty"`
+	// dynamic-secret-backed credential: the proxy mints a lease and injects DynamicSecretField from its output
+	DynamicSecretName   string                 `json:"dynamicSecretName,omitempty"`
+	DynamicSecretField  string                 `json:"dynamicSecretField,omitempty"`
+	DynamicSecretConfig map[string]interface{} `json:"dynamicSecretConfig,omitempty"`
+	// true when the calling identity could itself mint this dynamic secret's lease (connect-wrapper guardrail)
+	CallerCanLease bool `json:"callerCanLease,omitempty"`
 }
 
 type ProxiedService struct {
@@ -83,7 +89,9 @@ type ProxiedService struct {
 }
 
 type ListProxiedServicesResponse struct {
-	Services []ProxiedService `json:"services"`
+	// the project's slug, resolved server-side; the proxy needs it to call the projectSlug-based lease API
+	ProjectSlug string           `json:"projectSlug"`
+	Services    []ProxiedService `json:"services"`
 }
 
 type ListProxiedServicesRequest struct {

--- a/packages/api/agent_proxy.go
+++ b/packages/api/agent_proxy.go
@@ -62,21 +62,19 @@ func CallSignAgentProxyIntermediateCa(httpClient *resty.Client, request SignAgen
 }
 
 type ProxiedServiceCredential struct {
-	ID                   string   `json:"id"`
-	SecretKey            string   `json:"secretKey,omitempty"`
-	Role                 string   `json:"role"`
-	HeaderName           string   `json:"headerName,omitempty"`
-	HeaderPrefix         string   `json:"headerPrefix,omitempty"`
-	HeaderPurpose        string   `json:"headerPurpose,omitempty"`
-	PlaceholderKey       string   `json:"placeholderKey,omitempty"`
-	PlaceholderValue     string   `json:"placeholderValue,omitempty"`
-	SubstitutionSurfaces []string `json:"substitutionSurfaces,omitempty"`
-	// dynamic-secret-backed credential: the proxy mints a lease and injects DynamicSecretField from its output
-	DynamicSecretName   string                 `json:"dynamicSecretName,omitempty"`
-	DynamicSecretField  string                 `json:"dynamicSecretField,omitempty"`
-	DynamicSecretConfig map[string]interface{} `json:"dynamicSecretConfig,omitempty"`
-	// true when the calling identity could itself mint this dynamic secret's lease (connect-wrapper guardrail)
-	CallerCanLease bool `json:"callerCanLease,omitempty"`
+	ID                   string                 `json:"id"`
+	SecretKey            string                 `json:"secretKey,omitempty"`
+	Role                 string                 `json:"role"`
+	HeaderName           string                 `json:"headerName,omitempty"`
+	HeaderPrefix         string                 `json:"headerPrefix,omitempty"`
+	HeaderPurpose        string                 `json:"headerPurpose,omitempty"`
+	PlaceholderKey       string                 `json:"placeholderKey,omitempty"`
+	PlaceholderValue     string                 `json:"placeholderValue,omitempty"`
+	SubstitutionSurfaces []string               `json:"substitutionSurfaces,omitempty"`
+	DynamicSecretName    string                 `json:"dynamicSecretName,omitempty"`
+	DynamicSecretField   string                 `json:"dynamicSecretField,omitempty"`
+	DynamicSecretConfig  map[string]interface{} `json:"dynamicSecretConfig,omitempty"`
+	CallerCanLease       bool                   `json:"callerCanLease,omitempty"`
 }
 
 type ProxiedService struct {
@@ -89,7 +87,6 @@ type ProxiedService struct {
 }
 
 type ListProxiedServicesResponse struct {
-	// the project's slug, resolved server-side; the proxy needs it to call the projectSlug-based lease API
 	ProjectSlug string           `json:"projectSlug"`
 	Services    []ProxiedService `json:"services"`
 }

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -692,8 +692,6 @@ func CallCreateDynamicSecretLeaseV1(httpClient *resty.Client, request CreateDyna
 	return createDynamicSecretLeaseResponse, nil
 }
 
-// CallRevokeDynamicSecretLeaseV1 revokes a lease by ID. Used by the agent proxy for shutdown hygiene;
-// uses the APIError convention so callers can distinguish permanent 4xx from transient errors.
 func CallRevokeDynamicSecretLeaseV1(httpClient *resty.Client, request RevokeDynamicSecretLeaseV1Request) (RevokeDynamicSecretLeaseV1Response, error) {
 	var res RevokeDynamicSecretLeaseV1Response
 	response, err := httpClient.

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -692,6 +692,26 @@ func CallCreateDynamicSecretLeaseV1(httpClient *resty.Client, request CreateDyna
 	return createDynamicSecretLeaseResponse, nil
 }
 
+// CallRevokeDynamicSecretLeaseV1 revokes a lease by ID. Used by the agent proxy for shutdown hygiene;
+// uses the APIError convention so callers can distinguish permanent 4xx from transient errors.
+func CallRevokeDynamicSecretLeaseV1(httpClient *resty.Client, request RevokeDynamicSecretLeaseV1Request) (RevokeDynamicSecretLeaseV1Response, error) {
+	var res RevokeDynamicSecretLeaseV1Response
+	response, err := httpClient.
+		R().
+		SetResult(&res).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Delete(fmt.Sprintf("%v/v1/dynamic-secrets/leases/%s", config.INFISICAL_URL, request.LeaseID))
+
+	if err != nil {
+		return RevokeDynamicSecretLeaseV1Response{}, NewGenericRequestError("CallRevokeDynamicSecretLeaseV1", err)
+	}
+	if response.IsError() {
+		return RevokeDynamicSecretLeaseV1Response{}, NewAPIErrorWithResponse("CallRevokeDynamicSecretLeaseV1", response, nil)
+	}
+	return res, nil
+}
+
 func CallGetDynamicSecretLeaseV1(httpClient *resty.Client, request GetDynamicSecretLeaseV1Request) (GetDynamicSecretLeaseV1Response, error) {
 	var getDynamicSecretLeaseResponse GetDynamicSecretLeaseV1Response
 	response, err := httpClient.

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -631,7 +631,6 @@ type RevokeDynamicSecretLeaseV1Request struct {
 	Environment string `json:"environmentSlug"`
 	ProjectSlug string `json:"projectSlug"`
 	SecretPath  string `json:"path,omitempty"`
-	IsForced    bool   `json:"isForced,omitempty"`
 }
 
 type RevokeDynamicSecretLeaseV1Response struct {

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -618,9 +618,8 @@ type UniversalAuthRefreshResponse struct {
 }
 
 type CreateDynamicSecretLeaseV1Request struct {
-	Environment       string `json:"environmentSlug"`
-	ProjectSlug       string `json:"projectSlug"`
-	// the server route reads the path from "path" (not "secretPath"); a mismatched key silently defaults to "/"
+	Environment       string                 `json:"environmentSlug"`
+	ProjectSlug       string                 `json:"projectSlug"`
 	SecretPath        string                 `json:"path,omitempty"`
 	DynamicSecretName string                 `json:"dynamicSecretName"`
 	TTL               string                 `json:"ttl,omitempty"`

--- a/packages/api/model.go
+++ b/packages/api/model.go
@@ -620,9 +620,25 @@ type UniversalAuthRefreshResponse struct {
 type CreateDynamicSecretLeaseV1Request struct {
 	Environment       string `json:"environmentSlug"`
 	ProjectSlug       string `json:"projectSlug"`
-	SecretPath        string `json:"secretPath,omitempty"`
-	DynamicSecretName string `json:"dynamicSecretName"`
-	TTL               string `json:"ttl,omitempty"`
+	// the server route reads the path from "path" (not "secretPath"); a mismatched key silently defaults to "/"
+	SecretPath        string                 `json:"path,omitempty"`
+	DynamicSecretName string                 `json:"dynamicSecretName"`
+	TTL               string                 `json:"ttl,omitempty"`
+	Config            map[string]interface{} `json:"config,omitempty"`
+}
+
+type RevokeDynamicSecretLeaseV1Request struct {
+	LeaseID     string `json:"-"`
+	Environment string `json:"environmentSlug"`
+	ProjectSlug string `json:"projectSlug"`
+	SecretPath  string `json:"path,omitempty"`
+	IsForced    bool   `json:"isForced,omitempty"`
+}
+
+type RevokeDynamicSecretLeaseV1Response struct {
+	Lease struct {
+		Id string `json:"id"`
+	} `json:"lease"`
 }
 
 type CreateDynamicSecretLeaseV1Response struct {

--- a/packages/cmd/agent_proxy.go
+++ b/packages/cmd/agent_proxy.go
@@ -227,7 +227,6 @@ func writeMitmCa(certificatePem string) (string, error) {
 // credential-substitution placeholders to inject and the set of secret keys those services broker. The
 // brokered keys are what the agent is meant to receive only through the proxy, never as real values.
 type leasableDynamicCred struct {
-	serviceName       string
 	dynamicSecretName string
 }
 
@@ -251,7 +250,7 @@ func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment,
 		}
 		for _, cred := range svc.Credentials {
 			if cred.DynamicSecretName != "" && cred.CallerCanLease {
-				leasable = append(leasable, leasableDynamicCred{serviceName: svc.Name, dynamicSecretName: cred.DynamicSecretName})
+				leasable = append(leasable, leasableDynamicCred{dynamicSecretName: cred.DynamicSecretName})
 			}
 			if cred.SecretKey != "" {
 				brokeredKeys[cred.SecretKey] = struct{}{}

--- a/packages/cmd/agent_proxy.go
+++ b/packages/cmd/agent_proxy.go
@@ -152,7 +152,7 @@ func runAgentProxyConnect(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Failed to write the agent proxy CA to disk")
 	}
 
-	placeholderEnvs, brokeredKeys := fetchProxiedServiceConfig(httpClient, projectID, environment, secretPath)
+	placeholderEnvs, brokeredKeys, leasableDynamicCreds := fetchProxiedServiceConfig(httpClient, projectID, environment, secretPath)
 
 	realSecrets := fetchAgentRealSecrets(token, projectID, environment, secretPath)
 
@@ -160,6 +160,7 @@ func runAgentProxyConnect(cmd *cobra.Command, args []string) {
 	if !allowReadableBrokered {
 		assertNoBrokeredSecretsReadable(brokeredKeys, realSecrets)
 	}
+	warnAgentCanLeaseDynamicSecrets(leasableDynamicCreds)
 
 	extraNoProxy, _ := cmd.Flags().GetString("no-proxy")
 	env := buildAgentEnv(proxyURL(proxyAddr, projectID, environment, secretPath, token.Token), caPath, token.Token, extraNoProxy, placeholderEnvs, realSecrets)
@@ -223,7 +224,12 @@ func writeMitmCa(certificatePem string) (string, error) {
 // fetchProxiedServiceConfig lists the proxied services the agent can reach and returns both the
 // credential-substitution placeholders to inject and the set of secret keys those services broker. The
 // brokered keys are what the agent is meant to receive only through the proxy, never as real values.
-func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment, secretPath string) (map[string]string, map[string]struct{}) {
+type leasableDynamicCred struct {
+	serviceName       string
+	dynamicSecretName string
+}
+
+func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment, secretPath string) (map[string]string, map[string]struct{}, []leasableDynamicCred) {
 	resp, err := api.CallListProxiedServices(httpClient, api.ListProxiedServicesRequest{
 		ProjectID:   projectID,
 		Environment: environment,
@@ -235,19 +241,50 @@ func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment,
 
 	placeholders := map[string]string{}
 	brokeredKeys := map[string]struct{}{}
+	var leasable []leasableDynamicCred
 	for _, svc := range resp.Services {
 		// Disabled services aren't proxied, so their placeholders would reach upstream verbatim; don't inject them.
 		if !svc.CanProxy || !svc.IsEnabled {
 			continue
 		}
 		for _, cred := range svc.Credentials {
-			brokeredKeys[cred.SecretKey] = struct{}{}
+			// The agent identity holding Lease on a brokered dynamic secret defeats brokering: warn on it.
+			if cred.DynamicSecretName != "" && cred.CallerCanLease {
+				leasable = append(leasable, leasableDynamicCred{serviceName: svc.Name, dynamicSecretName: cred.DynamicSecretName})
+			}
+			if cred.SecretKey != "" {
+				brokeredKeys[cred.SecretKey] = struct{}{}
+			}
 			if cred.Role == "credential-substitution" && cred.PlaceholderKey != "" {
 				placeholders[cred.PlaceholderKey] = cred.PlaceholderValue
 			}
 		}
 	}
-	return placeholders, brokeredKeys
+	return placeholders, brokeredKeys, leasable
+}
+
+// warnAgentCanLeaseDynamicSecrets warns (does not block) when the agent identity itself holds Lease on a
+// dynamic secret that a proxied service brokers. Brokering hides the leased value from the agent, but with
+// Lease the agent could mint the credential directly and bypass the proxy.
+func warnAgentCanLeaseDynamicSecrets(leasable []leasableDynamicCred) {
+	if len(leasable) == 0 {
+		return
+	}
+	seen := map[string]struct{}{}
+	var names []string
+	for _, l := range leasable {
+		if _, ok := seen[l.dynamicSecretName]; ok {
+			continue
+		}
+		seen[l.dynamicSecretName] = struct{}{}
+		names = append(names, l.dynamicSecretName)
+	}
+	log.Warn().Msgf(
+		"the agent identity can itself mint leases for dynamic secret(s) brokered by proxied services: %s\n"+
+			"brokering hides leased credentials from the agent, but it holds the Lease permission and can obtain them directly, bypassing the proxy.\n"+
+			"consider removing the agent's Lease permission on these dynamic secrets.",
+		strings.Join(names, ", "),
+	)
 }
 
 // assertNoBrokeredSecretsReadable fails fast when the agent can read a secret that a proxied service

--- a/packages/cmd/agent_proxy.go
+++ b/packages/cmd/agent_proxy.go
@@ -158,6 +158,8 @@ func runAgentProxyConnect(cmd *cobra.Command, args []string) {
 
 	allowReadableBrokered, _ := cmd.Flags().GetBool("allow-readable-brokered-secrets")
 	if !allowReadableBrokered {
+		// static readability is derived from realSecrets we already fetch; dynamic lease-ability comes from
+		// the server (callerCanLease) since we don't fetch dynamic secrets here.
 		assertNoBrokeredSecretsReadable(brokeredKeys, realSecrets)
 		assertNoBrokeredDynamicSecretsLeasable(leasableDynamicCreds)
 	}

--- a/packages/cmd/agent_proxy.go
+++ b/packages/cmd/agent_proxy.go
@@ -248,7 +248,6 @@ func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment,
 			continue
 		}
 		for _, cred := range svc.Credentials {
-			// The agent identity holding Lease on a brokered dynamic secret defeats brokering: warn on it.
 			if cred.DynamicSecretName != "" && cred.CallerCanLease {
 				leasable = append(leasable, leasableDynamicCred{serviceName: svc.Name, dynamicSecretName: cred.DynamicSecretName})
 			}
@@ -263,9 +262,6 @@ func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment,
 	return placeholders, brokeredKeys, leasable
 }
 
-// warnAgentCanLeaseDynamicSecrets warns (does not block) when the agent identity itself holds Lease on a
-// dynamic secret that a proxied service brokers. Brokering hides the leased value from the agent, but with
-// Lease the agent could mint the credential directly and bypass the proxy.
 func warnAgentCanLeaseDynamicSecrets(leasable []leasableDynamicCred) {
 	if len(leasable) == 0 {
 		return

--- a/packages/cmd/agent_proxy.go
+++ b/packages/cmd/agent_proxy.go
@@ -159,8 +159,8 @@ func runAgentProxyConnect(cmd *cobra.Command, args []string) {
 	allowReadableBrokered, _ := cmd.Flags().GetBool("allow-readable-brokered-secrets")
 	if !allowReadableBrokered {
 		assertNoBrokeredSecretsReadable(brokeredKeys, realSecrets)
+		assertNoBrokeredDynamicSecretsLeasable(leasableDynamicCreds)
 	}
-	warnAgentCanLeaseDynamicSecrets(leasableDynamicCreds)
 
 	extraNoProxy, _ := cmd.Flags().GetString("no-proxy")
 	env := buildAgentEnv(proxyURL(proxyAddr, projectID, environment, secretPath, token.Token), caPath, token.Token, extraNoProxy, placeholderEnvs, realSecrets)
@@ -262,7 +262,9 @@ func fetchProxiedServiceConfig(httpClient *resty.Client, projectID, environment,
 	return placeholders, brokeredKeys, leasable
 }
 
-func warnAgentCanLeaseDynamicSecrets(leasable []leasableDynamicCred) {
+// assertNoBrokeredDynamicSecretsLeasable is the dynamic-secret counterpart of assertNoBrokeredSecretsReadable:
+// the agent holding Lease on a brokered dynamic secret can mint it directly, bypassing the proxy, so fail fast.
+func assertNoBrokeredDynamicSecretsLeasable(leasable []leasableDynamicCred) {
 	if len(leasable) == 0 {
 		return
 	}
@@ -275,12 +277,13 @@ func warnAgentCanLeaseDynamicSecrets(leasable []leasableDynamicCred) {
 		seen[l.dynamicSecretName] = struct{}{}
 		names = append(names, l.dynamicSecretName)
 	}
-	log.Warn().Msgf(
-		"the agent identity can itself mint leases for dynamic secret(s) brokered by proxied services: %s\n"+
-			"brokering hides leased credentials from the agent, but it holds the Lease permission and can obtain them directly, bypassing the proxy.\n"+
-			"consider removing the agent's Lease permission on these dynamic secrets.",
-		strings.Join(names, ", "),
-	)
+	sort.Strings(names)
+	util.HandleError(fmt.Errorf(
+		"the agent can lease dynamic secret(s) that are brokered by a proxied service: %s\n"+
+			"brokering hides these values from the agent, but it has Lease on them and would mint them directly, bypassing the proxy.\n"+
+			"fix: remove the agent's Lease permission on these dynamic secrets, or stop referencing them from proxied services.\n"+
+			"to start anyway, pass --allow-readable-brokered-secrets",
+		strings.Join(names, ", ")))
 }
 
 // assertNoBrokeredSecretsReadable fails fast when the agent can read a secret that a proxied service


### PR DESCRIPTION
# Description 📣

CLI side of dynamic secret support for proxied services. When a proxied-service credential references a dynamic secret, the agent proxy now mints a per-agent lease and injects a chosen output field into the outgoing request instead of using a static secret value. Backend PR: Infisical/infisical#7288.

**Lease store (`leases.go`):** a per-agent store keyed by `(jwt, scope, secret name, config hash)`, so every credential referencing the same dynamic secret shares one lease (e.g. basic-auth username and password come from the same mint). Minting is lazy via singleflight, leases re-mint before expiry (make-before-break), and are revoked best-effort on shutdown.

**Resolution (`resolve()`):** each dynamic credential registers a lease, and its value is resolved at request time into a per-request materialized copy of the credentials, so nothing shared is mutated mid-flight.

**API:** proxied-service credential dynamic fields + `callerCanLease`, list-response `projectSlug`, and the create-lease / revoke-lease calls (also fixes the `secretPath` → `path` json tag on the create-lease path).

**Connect wrapper:** warns when the agent identity itself can lease a brokered dynamic secret.

The review-fix commit drops response-header redaction in favor of one-way injection (credentials go up, the upstream response relays back untouched), which also removes the retired-values scrubbing machinery, and fixes a refresh-loop busy-spin where an unused-but-valid lease near expiry woke the loop every second until it lapsed.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
