### PR TITLE
test(agent-proxy): cover username-only basic auth rewrite

### DIFF
--- a/packages/agentproxy/rewrite_test.go
+++ b/packages/agentproxy/rewrite_test.go
@@ -64,7 +64,6 @@ func TestBasicAuthUsernameOnly(t *testing.T) {
 	if err := applyCredentials(req, svc); err != nil {
 		t.Fatal(err)
 	}
-	// base64("user:") == "dXNlcjo=" — an omitted password yields an empty password segment.
 	if got := req.Header.Get("Authorization"); got != "Basic dXNlcjo=" {
 		t.Fatalf("unexpected basic auth header: %q", got)
 	}

--- a/packages/agentproxy/rewrite_test.go
+++ b/packages/agentproxy/rewrite_test.go
@@ -56,6 +56,20 @@ func TestBasicAuthFromTwoCredentials(t *testing.T) {
 	}
 }
 
+func TestBasicAuthUsernameOnly(t *testing.T) {
+	req := newReq(t, "")
+	svc := &resolvedService{credentials: []resolvedCredential{
+		{role: roleHeaderRewrite, headerPurpose: purposeUsername, value: "user"},
+	}}
+	if err := applyCredentials(req, svc); err != nil {
+		t.Fatal(err)
+	}
+	// base64("user:") == "dXNlcjo=" — an omitted password yields an empty password segment.
+	if got := req.Header.Get("Authorization"); got != "Basic dXNlcjo=" {
+		t.Fatalf("unexpected basic auth header: %q", got)
+	}
+}
+
 func TestSubstitutionInQuery(t *testing.T) {
 	req := newReq(t, "")
 	svc := &resolvedService{credentials: []resolvedCredential{


### PR DESCRIPTION
# Description 📣

Basic auth on a proxied service now allows a username with no password (`Authorization: Basic base64(username:)`), which is how APIs like Ashby authenticate. No production code change was needed here since `applyCredentials` already sets `haveBasic` on the username alone and emits an empty password segment when none is present. This just adds a test to lock that behavior in.

Companion PR (backend/frontend/docs): https://github.com/Infisical/infisical/pull/7296

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

`TestBasicAuthUsernameOnly` asserts a username-only credential produces `Authorization: Basic dXNlcjo=` (`base64("user:")`).

```sh
go test ./packages/agentproxy/ -run TestBasicAuth
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
