### PR TITLE
chore: add TTL to user get token

### DIFF
--- a/packages/cmd/user.go
+++ b/packages/cmd/user.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/Infisical/infisical-merge/packages/config"
 	"github.com/Infisical/infisical-merge/packages/models"
@@ -135,6 +136,7 @@ var userGetTokenCmd = &cobra.Command{
 
 		var tokenPayload struct {
 			TokenVersionId string `json:"tokenVersionId"`
+			Exp            int64  `json:"exp"`
 		}
 		if err := json.Unmarshal(payload, &tokenPayload); err != nil {
 			util.HandleError(err, "[infisical user get token]: Unable to parse token payload")
@@ -145,6 +147,18 @@ var userGetTokenCmd = &cobra.Command{
 		} else {
 			util.PrintlnStdout("Session ID:", tokenPayload.TokenVersionId)
 			util.PrintlnStdout("Token:", loggedInUserDetails.UserCredentials.JTWToken)
+
+			if tokenPayload.Exp != 0 {
+				expiresAt := time.Unix(tokenPayload.Exp, 0)
+				ttl := time.Until(expiresAt)
+				if ttl > 0 {
+					util.PrintlnStdout("Expires At:", expiresAt.Format(time.RFC1123))
+					util.PrintlnStdout("TTL:", ttl.Round(time.Second).String())
+				} else {
+					util.PrintlnStdout("Expires At:", expiresAt.Format(time.RFC1123), "(expired)")
+					util.PrintlnStdout("TTL: expired")
+				}
+			}
 		}
 	},
 }


### PR DESCRIPTION
# Description 📣

- Add `Expires At` and `TTL` information to `infisical user get token`

```
Session ID: <REDACTED>
Token: <REDACTED>
Expires At: Sun, 26 Jul 2026 10:49:01 -03
TTL: 239h58m58s
```

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->