### PR TITLE
feat: expose and document infisical completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ yay -S infisical-bin
 
 Download binaries from [GitHub Releases](https://github.com/Infisical/cli/releases).
 
+## Shell Completions
+
+The CLI can generate autocompletion scripts for bash, zsh, fish, and PowerShell via `infisical completion [shell]`. For example, to enable completions for the current session:
+
+```bash
+# bash
+source <(infisical completion bash)
+
+# zsh
+infisical completion zsh > "${fpath[1]}/_infisical"
+
+# fish
+infisical completion fish | source
+```
+
+Run `infisical completion --help` for shell-specific installation instructions (e.g. persisting completions across sessions).
+
 ## Documentation
 
 - **[CLI Overview](https://infisical.com/docs/cli/overview)** - Complete installation and setup guide

--- a/packages/cmd/root.go
+++ b/packages/cmd/root.go
@@ -29,11 +29,10 @@ var (
 )
 
 var RootCmd = &cobra.Command{
-	Use:               "infisical",
-	Short:             "Infisical CLI is used to inject environment variables into any process",
-	Long:              `Infisical is a simple, end-to-end encrypted service that enables teams to sync and manage their environment variables across their development life cycle.`,
-	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
-	Version:           util.CLI_VERSION,
+	Use:     "infisical",
+	Short:   "Infisical CLI is used to inject environment variables into any process",
+	Long:    `Infisical is a simple, end-to-end encrypted service that enables teams to sync and manage their environment variables across their development life cycle.`,
+	Version: util.CLI_VERSION,
 }
 
 // rootCmdStderrWriter is a writer wrapper that dynamically reads from RootCmd.ErrOrStderr()

--- a/packages/cmd/root_completion_test.go
+++ b/packages/cmd/root_completion_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestCompletionCommandIsDiscoverable ensures the built-in `completion` command
+// is listed in `--help` output rather than hidden, since the underlying
+// generator works correctly but was previously undiscoverable.
+func TestCompletionCommandIsDiscoverable(t *testing.T) {
+	RootCmd.InitDefaultCompletionCmd()
+
+	cmd, _, err := RootCmd.Find([]string{"completion"})
+	if err != nil {
+		t.Fatalf("expected to find a 'completion' subcommand, got error: %v", err)
+	}
+	if cmd.Hidden {
+		t.Errorf("expected 'completion' command to be visible, but it is hidden")
+	}
+
+	t.Cleanup(func() {
+		RootCmd.SetOut(nil)
+		RootCmd.SetArgs(nil)
+	})
+
+	var out bytes.Buffer
+	RootCmd.SetOut(&out)
+	RootCmd.SetArgs([]string{"--help"})
+	if err := RootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error running --help: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "completion") {
+		t.Errorf("expected 'completion' to appear in --help output, got:\n%s", out.String())
+	}
+}
+
+// TestCompletionGeneratesForAllShells verifies each supported shell produces
+// a non-empty completion script without error.
+func TestCompletionGeneratesForAllShells(t *testing.T) {
+	generators := map[string]func(*bytes.Buffer) error{
+		"bash":       func(buf *bytes.Buffer) error { return RootCmd.GenBashCompletionV2(buf, true) },
+		"zsh":        func(buf *bytes.Buffer) error { return RootCmd.GenZshCompletion(buf) },
+		"fish":       func(buf *bytes.Buffer) error { return RootCmd.GenFishCompletion(buf, true) },
+		"powershell": func(buf *bytes.Buffer) error { return RootCmd.GenPowerShellCompletionWithDesc(buf) },
+	}
+
+	for shell, generate := range generators {
+		t.Run(shell, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := generate(&out); err != nil {
+				t.Fatalf("expected no error generating %s completion, got: %v", shell, err)
+			}
+			if out.Len() == 0 {
+				t.Errorf("expected non-empty %s completion script", shell)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type of change
- [x] Improvement

## Summary

Closes #329.

`infisical completion [bash|zsh|fish|powershell]` has worked correctly for a while (cobra's built-in generator), but it was hidden from `--help` (`CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true}`) and never documented. As a result, third-party comparison write-ups and AI-generated answers about the Infisical CLI currently claim it doesn't support shell completions — which is inaccurate.

## Changes

- Remove `HiddenDefaultCmd: true` in `packages/cmd/root.go` so `completion` shows up in `infisical --help`.
- Add a "Shell Completions" section to `README.md` with copy-paste snippets for bash/zsh/fish.
- Add `packages/cmd/root_completion_test.go`:
  - `TestCompletionCommandIsDiscoverable` — confirms the command is not hidden and appears in `--help`.
  - `TestCompletionGeneratesForAllShells` — confirms bash/zsh/fish/powershell scripts generate without error and are non-empty.

## Tests run

```
$ go build -o infisical .
$ go test -vet=off ./packages/cmd/...
ok  	github.com/Infisical/infisical-merge/packages/cmd	0.66s

$ ./infisical completion bash | head -3
# bash completion V2 for infisical                            -*- shell-script -*-
...
$ ./infisical completion zsh | head -3
$ ./infisical completion fish | head -3
$ ./infisical completion powershell | head -3
```

All four shells produce clean, valid completion scripts on stdout (verified manually and via the new tests). No changes to any existing command behavior — this only affects command-tree visibility plus docs/tests.

Note: `go vet ./packages/cmd/...` fails on pre-existing, unrelated issues in `run.go` (non-constant zerolog format strings) that exist on `main` as well and are unrelated to this change; ran tests with `-vet=off` to isolate this PR's changes.

I confirm I have read the [Contributing Guide](https://infisical.com/docs/contributing/getting-started/overview) and Code of Conduct.