### PR TITLE
fix(e2e): use a password-policy-compliant admin password in bootstrap

### DIFF
--- a/e2e/packages/client/provisioner.go
+++ b/e2e/packages/client/provisioner.go
@@ -54,7 +54,7 @@ func WithCookies(cookies ...*http.Cookie) RequestEditorFn {
 func (p *Provisioner) Bootstrap(ctx context.Context) (*ProvisionResult, error) {
 	slog.Info("Signing up Admin account ...")
 	email := faker.Email()
-	password := faker.Password()
+	password := "Infisical-E2E-Test1!"
 	signUpResp, err := p.Client.AdminSignUpWithResponse(ctx, AdminSignUpJSONRequestBody{
 		Email:     types.Email(email),
 		FirstName: faker.FirstName(),


### PR DESCRIPTION
# Description 📣

The CLI e2e suite started failing at the bootstrap step, admin signup returns `422`, so the whole relay/gateway suite fails before any test runs.

Cause: infisical backend #7350 ("enforce shared password policy during signup") now validates the signup password (>=14 chars, at least one letter, at least one number/special, no long repeats, no escape chars). The e2e bootstrap signs up its admin with `faker.Password()`, which doesn't reliably satisfy that policy, so signup is rejected.

Switches the bootstrap to a fixed password that meets the policy. Not tied to any CLI feature, this affects every CLI PR whose e2e runs against current backend main.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
