### PR TITLE
fix(update-check): detect nix and linuxbrew installs on linux

### DIFF
--- a/.github/workflows/test-update-instructions.yml
+++ b/.github/workflows/test-update-instructions.yml
@@ -115,3 +115,22 @@ jobs:
           output=$($HOME/.npm-global/lib/node_modules/@infisical/cli/bin/update-hint)
           echo "Output: $output"
           echo "$output" | grep -q "npm update -g @infisical/cli" || (echo "Expected npm instruction, got: $output" && exit 1)
+
+      # The runner has apt-get, so without install-source detection this falls
+      # through to the apt instruction. Asserting empty output is what makes
+      # this a real regression test for the nix case.
+      - name: Test nix path detection
+        run: |
+          mkdir -p $HOME/nix/store/abc123-infisical-0.0.1/bin
+          cp update-hint $HOME/nix/store/abc123-infisical-0.0.1/bin/update-hint
+          output=$($HOME/nix/store/abc123-infisical-0.0.1/bin/update-hint)
+          echo "Output: $output"
+          [ -z "$output" ] || (echo "Expected no instruction for nix, got: $output" && exit 1)
+
+      - name: Test linuxbrew path detection
+        run: |
+          mkdir -p $HOME/linuxbrew/.linuxbrew/bin
+          cp update-hint $HOME/linuxbrew/.linuxbrew/bin/update-hint
+          output=$($HOME/linuxbrew/.linuxbrew/bin/update-hint)
+          echo "Output: $output"
+          echo "$output" | grep -q "brew update" || (echo "Expected brew instruction, got: $output" && exit 1)

--- a/packages/util/check-for-update.go
+++ b/packages/util/check-for-update.go
@@ -407,6 +407,15 @@ func getUpdateInstructions(goos string, execPath string) string {
 		if isNpm {
 			return "To update, run: npm update -g @infisical/cli"
 		}
+		// Nix-managed binaries live in the immutable store. The system package
+		// manager did not install them and cannot update them, so stay quiet
+		// rather than print a command that will not work.
+		if strings.Contains(p, "/nix/store/") {
+			return ""
+		}
+		if strings.Contains(p, "linuxbrew") {
+			return "To update, run: brew update && brew upgrade infisical"
+		}
 		pkgManager := getLinuxPackageManager()
 		switch pkgManager {
 		case "apt-get":

--- a/packages/util/check-for-update.go
+++ b/packages/util/check-for-update.go
@@ -413,7 +413,11 @@ func getUpdateInstructions(goos string, execPath string) string {
 		if strings.Contains(p, "/nix/store/") {
 			return ""
 		}
-		if strings.Contains(p, "linuxbrew") {
+		// Trailing slash so this matches the linuxbrew prefix directory in both
+		// the multi-user (/home/linuxbrew/.linuxbrew) and single-user
+		// (~/.linuxbrew) layouts, without classifying unrelated paths such as
+		// /opt/linuxbrew-tools as a Homebrew install.
+		if strings.Contains(p, "linuxbrew/") {
 			return "To update, run: brew update && brew upgrade infisical"
 		}
 		pkgManager := getLinuxPackageManager()

--- a/packages/util/check-for-update_test.go
+++ b/packages/util/check-for-update_test.go
@@ -23,7 +23,8 @@ func TestGetUpdateInstructions(t *testing.T) {
 		goos        string
 		execPath    string
 		expected    string
-		expectEmpty bool // true means assert empty result (vs. skipping runtime-dependent cases)
+		expectEmpty bool   // true means assert empty result (vs. skipping runtime-dependent cases)
+		notExpected string // assert the result does NOT contain this, for paths that must not match a detector
 	}{
 		// darwin
 		{
@@ -108,6 +109,18 @@ func TestGetUpdateInstructions(t *testing.T) {
 			execPath: "/home/linuxbrew/.linuxbrew/bin/infisical",
 			expected: "brew update && brew upgrade infisical",
 		},
+		{
+			name:     "linux linuxbrew single-user prefix",
+			goos:     "linux",
+			execPath: "/home/user/.linuxbrew/bin/infisical",
+			expected: "brew update && brew upgrade infisical",
+		},
+		{
+			name:        "linux linuxbrew-tools is not a brew install",
+			goos:        "linux",
+			execPath:    "/opt/linuxbrew-tools/bin/infisical",
+			notExpected: "brew",
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +129,12 @@ func TestGetUpdateInstructions(t *testing.T) {
 			if tt.expectEmpty {
 				if result != "" {
 					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+			if tt.notExpected != "" {
+				if strings.Contains(result, tt.notExpected) {
+					t.Errorf("expected %q not to contain %q", result, tt.notExpected)
 				}
 				return
 			}

--- a/packages/util/check-for-update_test.go
+++ b/packages/util/check-for-update_test.go
@@ -96,6 +96,18 @@ func TestGetUpdateInstructions(t *testing.T) {
 			execPath: "/home/user/.npm-global/lib/node_modules/@infisical/cli/bin/infisical",
 			expected: "npm update -g @infisical/cli",
 		},
+		{
+			name:        "linux nix returns empty",
+			goos:        "linux",
+			execPath:    "/nix/store/abc123-infisical-0.41.90/bin/infisical",
+			expectEmpty: true,
+		},
+		{
+			name:     "linux linuxbrew",
+			goos:     "linux",
+			execPath: "/home/linuxbrew/.linuxbrew/bin/infisical",
+			expected: "brew update && brew upgrade infisical",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description 📣

On Linux, `getUpdateInstructions` never inspects the executable path outside the npm check. It falls through to `getLinuxPackageManager()`, which only probes which package managers happen to exist on the machine, so a Nix install on Debian or Ubuntu is told to run `apt-get install infisical` for a binary living in the immutable Nix store.

Homebrew-on-Linux hits the same gap, since `/home/linuxbrew/.linuxbrew/` does not match the `/homebrew/` substring the darwin branch checks for.

This mirrors the existing darwin handling: Nix returns no instruction rather than a wrong one, matching the `darwin nix returns empty` case already in the tests. Linuxbrew returns the brew command.

Fixes the Linux side of #226. The macOS path in that report already returns no instruction for Nix installs, via the existing `darwin nix returns empty` handling.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Added two cases to `TestGetUpdateInstructions`, and two steps to the `integration-linux` job following the existing `/tmp/homebrew` and npm patterns.

Worth noting for review: the `linux nix returns empty` unit case only asserts anything on a machine that actually has a package manager installed. On a dev Mac it passes with or without this change, because `getLinuxPackageManager()` returns empty there anyway. On the ubuntu runner, where apt-get is present, it fails without the fix. That is why the integration step matters here, and I left a comment above it explaining the same thing.

```sh
go test ./packages/util/ -run TestGetUpdateInstructions -v
```

```
--- PASS: TestGetUpdateInstructions/linux_nix_returns_empty (0.00s)
--- PASS: TestGetUpdateInstructions/linux_linuxbrew (0.00s)
PASS
ok      github.com/Infisical/infisical-merge/packages/util   0.523s
```

Verified the new tests are meaningful by stashing the change in `check-for-update.go` and re-running: `linux_linuxbrew` fails as expected.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

