### PR TITLE
fix(auth): preserve the session domain during automatic re-login

### DIFF
--- a/packages/util/auth.go
+++ b/packages/util/auth.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/Infisical/infisical-merge/packages/config"
 	infisicalSdk "github.com/infisical/go-sdk"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -60,6 +61,35 @@ func IsAuthMethodValid(authMethod string, allowUserAuth bool) (isValid bool, str
 	return false, ""
 }
 
+// resolveReLoginDomain decides which domain the automatic re-login child process
+// should be pinned to, or returns "" to leave the child's normal domain
+// resolution (and its interactive region prompt) untouched.
+//
+// storedDomain is LoggedInUserDomain from the config file, i.e. the instance
+// whose session just expired, so it wins. resolvedURL is config.INFISICAL_URL as
+// already resolved by the root command from --domain, INFISICAL_DOMAIN or
+// .infisical.json; it is only forwarded when it differs from the built-in US
+// default, since that default is what an unconfigured invocation looks like and
+// forwarding it would silently skip the region prompt for first-time logins.
+func resolveReLoginDomain(storedDomain string, resolvedURL string) string {
+	if storedDomain != "" {
+		return storedDomain
+	}
+	if resolvedURL != "" && resolvedURL != AppendAPIEndpoint(INFISICAL_DEFAULT_US_URL) {
+		return resolvedURL
+	}
+	return ""
+}
+
+// buildReLoginArgs returns the argv for the re-login child process.
+func buildReLoginArgs(domain string) []string {
+	args := []string{"login", "--silent"}
+	if domain != "" {
+		args = append(args, "--domain", domain)
+	}
+	return args
+}
+
 // EstablishUserLoginSession handles the login flow to either create a new session or restore an expired one.
 // It returns fresh user details if login is successful.
 func EstablishUserLoginSession() LoggedInUserDetails {
@@ -70,8 +100,18 @@ func EstablishUserLoginSession() LoggedInUserDetails {
 		PrintErrorMessageAndExit(fmt.Sprintf("Failed to determine executable path: %v", err))
 	}
 
+	// The child process resolves its own domain from scratch and would otherwise
+	// fall back to US Cloud, so forward the domain this session was using.
+	// Without this an expired EU Cloud session re-prompts for a region, opens the
+	// US login page, and on completion rewrites LoggedInUserDomain to US.
+	var storedDomain string
+	if configFile, configErr := GetConfigFile(); configErr == nil {
+		storedDomain = configFile.LoggedInUserDomain
+	}
+	domain := resolveReLoginDomain(storedDomain, config.INFISICAL_URL)
+
 	// Spawn infisical login command
-	loginCmd := exec.Command(exePath, "login", "--silent")
+	loginCmd := exec.Command(exePath, buildReLoginArgs(domain)...)
 	loginCmd.Stdin = os.Stdin
 	loginCmd.Stdout = os.Stdout
 	loginCmd.Stderr = os.Stderr

--- a/packages/util/auth_test.go
+++ b/packages/util/auth_test.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveReLoginDomain(t *testing.T) {
+	usDefault := AppendAPIEndpoint(INFISICAL_DEFAULT_US_URL)
+	euAPI := AppendAPIEndpoint(INFISICAL_DEFAULT_EU_URL)
+
+	tests := []struct {
+		name         string
+		storedDomain string
+		resolvedURL  string
+		expected     string
+	}{
+		{
+			// The regression from the reported bug: an expired EU session must
+			// re-login against EU, not fall back to the US default.
+			name:         "stored EU domain wins over US default",
+			storedDomain: euAPI,
+			resolvedURL:  usDefault,
+			expected:     euAPI,
+		},
+		{
+			name:         "stored self-hosted domain is forwarded",
+			storedDomain: "https://vault.example.com/api",
+			resolvedURL:  usDefault,
+			expected:     "https://vault.example.com/api",
+		},
+		{
+			// --domain / INFISICAL_DOMAIN / .infisical.json, with nothing stored yet.
+			name:         "explicit non-default resolved URL is forwarded when nothing is stored",
+			storedDomain: "",
+			resolvedURL:  euAPI,
+			expected:     euAPI,
+		},
+		{
+			// Must stay empty: the US default is what an unconfigured invocation
+			// looks like, and forwarding it would skip the region prompt.
+			name:         "bare US default is not forwarded",
+			storedDomain: "",
+			resolvedURL:  usDefault,
+			expected:     "",
+		},
+		{
+			name:         "nothing known at all",
+			storedDomain: "",
+			resolvedURL:  "",
+			expected:     "",
+		},
+		{
+			// A user who explicitly logged in to US Cloud should stay pinned there
+			// rather than be re-prompted.
+			name:         "stored US domain is still forwarded",
+			storedDomain: usDefault,
+			resolvedURL:  usDefault,
+			expected:     usDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveReLoginDomain(tt.storedDomain, tt.resolvedURL); got != tt.expected {
+				t.Errorf("resolveReLoginDomain(%q, %q) = %q, expected %q",
+					tt.storedDomain, tt.resolvedURL, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildReLoginArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected []string
+	}{
+		{
+			name:     "no domain keeps the original argv",
+			domain:   "",
+			expected: []string{"login", "--silent"},
+		},
+		{
+			name:     "domain is forwarded as an explicit flag",
+			domain:   "https://eu.infisical.com/api",
+			expected: []string{"login", "--silent", "--domain", "https://eu.infisical.com/api"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildReLoginArgs(tt.domain); !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("buildReLoginArgs(%q) = %v, expected %v", tt.domain, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description 📣

`EstablishUserLoginSession()` re-execs the CLI as `login --silent`, forwarding only `--silent`. The child then resolves its domain from scratch, and because `usePresetDomain()` deliberately ignores default cloud URLs unless `--domain` was set on that specific invocation, an expired EU Cloud session falls through to the region prompt, opens `https://app.infisical.com/login`, and on completion rewrites `LoggedInUserDomain` to US. Every subsequent command then targets the wrong region.

This forwards the domain the parent has already resolved.

**Why this is the only change needed.** Because the child now sees an explicit `--domain`, `cmd.Flags().Changed("domain")` is true, so `usePresetDomain()` accepts the value even for EU/US cloud URLs. The exclusion at `login.go:465` is never reached, which means no change to `usePresetDomain()` itself. That function is shared with the normal `infisical login` path, so leaving its semantics alone seemed preferable to widening them. This also fixes every caller of `EstablishUserLoginSession()` at once rather than per command.

**Precedence.** The stored `LoggedInUserDomain` wins, since it is the instance whose session just expired. Otherwise `config.INFISICAL_URL` is used, as already resolved by the root command from `--domain`, `INFISICAL_DOMAIN`, or `.infisical.json`.

**One deliberate exception:** the bare US default is not forwarded. `config.INFISICAL_URL` defaults to the US URL rather than empty, so forwarding it unconditionally would set an explicit `--domain` on every re-login and silently skip the region prompt for users who have never configured one. Returning `""` in that case preserves today's behaviour exactly.

**Scoped to one of the three fixes suggested in #312.** Suggestion 2 is subsumed by the above. Suggestion 3, guarding `askForDomain()`/`browserCliLogin()` behind a TTY check, is a UX change for semi-interactive contexts and felt like a maintainer's call rather than something to fold into a bug fix. Happy to add it or open it separately if you want it.

Fixes #312

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Split the decision into two pure functions, `resolveReLoginDomain` and `buildReLoginArgs`, so the logic is testable without spawning a process. This mirrors the existing `GetUpdateInstructions()` / `getUpdateInstructions(goos, execPath)` split in `check-for-update.go`.

New `packages/util/auth_test.go` covers stored EU domain, stored self-hosted domain, explicit non-default override with nothing stored, the bare US default, nothing known at all, and stored US Cloud.

```sh
go test ./packages/util/ -run 'TestResolveReLoginDomain|TestBuildReLoginArgs' -v
```

```
--- PASS: TestResolveReLoginDomain (0.00s)
    --- PASS: .../stored_EU_domain_wins_over_US_default
    --- PASS: .../stored_self-hosted_domain_is_forwarded
    --- PASS: .../explicit_non-default_resolved_URL_is_forwarded_when_nothing_is_stored
    --- PASS: .../bare_US_default_is_not_forwarded
    --- PASS: .../nothing_known_at_all
    --- PASS: .../stored_US_domain_is_still_forwarded
--- PASS: TestBuildReLoginArgs (0.00s)
```

Verified the tests are meaningful by forcing `resolveReLoginDomain` to always return `""`, reproducing the pre-fix behaviour: the EU, self-hosted, and explicit-override cases all fail. Full `packages/util` suite passes with no regressions, and `go build ./...` is clean.

**What I could not test:** I do not have an EU Cloud account, so this was diagnosed by reading the code paths rather than reproducing end to end. The unit tests cover the decision logic; a reviewer with EU access confirming the real flow would be worthwhile.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
