### PR TITLE
fix(agent): run execute hook on initial render

### DIFF
--- a/packages/cmd/agent.go
+++ b/packages/cmd/agent.go
@@ -1932,7 +1932,7 @@ func (tm *AgentManager) MonitorSecretChanges(ctx context.Context, secretTemplate
 
 							existingEtag = currentEtag
 
-							if !firstRun && execCommand != "" {
+							if execCommand != "" {
 								log.Info().Msgf("executing command: %s", execCommand)
 								err := ExecuteCommandWithTimeout(execCommand, execTimeout)
 

--- a/packages/cmd/agent_execute_test.go
+++ b/packages/cmd/agent_execute_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMonitorSecretChanges_ExecutesCommandOnInitialRender(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test command uses touch")
+	}
+
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "secrets.env")
+	markerPath := filepath.Join(tempDir, "command-ran")
+
+	secretTemplate := Template{
+		DestinationPath: outputPath,
+		TemplateContent: "SECRET=value",
+	}
+	secretTemplate.Config.PollingInterval = "1ms"
+	secretTemplate.Config.Execute.Command = fmt.Sprintf("touch %q", markerPath)
+
+	manager := &AgentManager{
+		accessToken:             "test-token",
+		dynamicSecretLeases:     &DynamicSecretLeaseManager{},
+		templateFirstRenderOnce: map[int]*sync.Once{1: {}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		manager.MonitorSecretChanges(ctx, secretTemplate, 1, make(chan os.Signal), make(chan bool, 1))
+		close(done)
+	}()
+
+	deadline := time.After(time.Second)
+	for {
+		if _, err := os.Stat(markerPath); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("check command marker: %v", err)
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("execute command did not run after the initial render")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("secret monitor did not stop after context cancellation")
+	}
+}


### PR DESCRIPTION
# Description 📣

Fixes #340.

Run the configured post-render execute hook after every successful template render, including the first render after an agent restart. This ensures applications reload when a rotated secret is written while the agent is offline.

No new dependencies.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
go test -vet=off ./packages/cmd
go build ./...
```

The focused regression test verifies that an initial literal-template render executes the configured command. Standard `go test ./packages/cmd` is currently blocked by pre-existing vet findings in `packages/cmd/run.go`.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝