### PR TITLE
fix(cli): resolve project ID from workspace config

### DIFF
--- a/packages/util/secrets.go
+++ b/packages/util/secrets.go
@@ -276,6 +276,26 @@ func FilterSecretsByTag(plainTextSecrets []models.SingleEnvironmentVariable, tag
 	return filteredSecrets
 }
 
+func resolveWorkspaceID(workspaceID, projectConfigFilePath string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+
+	if projectConfigFilePath == "" {
+		workspaceConfig, err := GetWorkSpaceFromFile()
+		if err != nil {
+			return "", err
+		}
+		return workspaceConfig.WorkspaceId, nil
+	}
+
+	workspaceConfig, err := GetWorkSpaceFromFilePath(projectConfigFilePath)
+	if err != nil {
+		return "", err
+	}
+	return workspaceConfig.WorkspaceId, nil
+}
+
 func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectConfigFilePath string) ([]models.SingleEnvironmentVariable, error) {
 	var secretsToReturn []models.SingleEnvironmentVariable
 	// var serviceTokenDetails api.GetServiceTokenDetailsResponse
@@ -365,6 +385,13 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 			log.Debug().Msg("Trying to fetch secrets using service token")
 			secretsToReturn, errorToReturn = GetPlainTextSecretsViaServiceToken(params.InfisicalToken, params.Environment, params.SecretsPath, params.IncludeImport, params.Recursive, params.TagSlugs, params.ExpandSecretReferences, params.IncludePersonalOverrides)
 		} else if params.UniversalAuthAccessToken != "" {
+
+			if params.WorkspaceId == "" {
+				workspaceID, err := resolveWorkspaceID(params.WorkspaceId, projectConfigFilePath)
+				if err == nil {
+					params.WorkspaceId = workspaceID
+				}
+			}
 
 			if params.WorkspaceId == "" {
 				PrintErrorMessageAndExit("Project ID is required when using machine identity")

--- a/packages/util/secrets_test.go
+++ b/packages/util/secrets_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveWorkspaceID(t *testing.T) {
+	t.Run("uses explicit project ID before config", func(t *testing.T) {
+		workspaceID, err := resolveWorkspaceID("project-from-flag", t.TempDir())
+		if err != nil {
+			t.Fatalf("resolve workspace ID: %v", err)
+		}
+		if workspaceID != "project-from-flag" {
+			t.Errorf("workspace ID = %q, want %q", workspaceID, "project-from-flag")
+		}
+	})
+
+	t.Run("uses workspace config when project ID is omitted", func(t *testing.T) {
+		configDir := t.TempDir()
+		configPath := filepath.Join(configDir, INFISICAL_WORKSPACE_CONFIG_FILE_NAME)
+		if err := os.WriteFile(configPath, []byte(`{"workspaceId":"project-from-config"}`), 0600); err != nil {
+			t.Fatalf("write workspace config: %v", err)
+		}
+
+		workspaceID, err := resolveWorkspaceID("", configDir)
+		if err != nil {
+			t.Fatalf("resolve workspace ID: %v", err)
+		}
+		if workspaceID != "project-from-config" {
+			t.Errorf("workspace ID = %q, want %q", workspaceID, "project-from-config")
+		}
+	})
+}


### PR DESCRIPTION
# Description 📣

Fixes #284.

When machine-identity authentication is used without `--projectId` or `INFISICAL_PROJECT_ID`, resolve the project ID from `.infisical.json` before rejecting the request. Explicit project IDs retain precedence over the workspace configuration.

No new dependencies.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
go test ./packages/util
go build ./...
```

The regression tests cover explicit project-ID precedence and fallback to `workspaceId` from the configured `.infisical.json`.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝