### PR TITLE
feat(cli): add Zsh shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Download binaries from [GitHub Releases](https://github.com/Infisical/cli/releas
 - **[Commands Reference](https://infisical.com/docs/cli/commands)** - All available commands
 - **[FAQ](https://infisical.com/docs/cli/faq)** - Common questions and troubleshooting
 
+## Shell Integration
+
+To automatically run selected Zsh commands through `infisical run`, add this to your `.zshrc`:
+
+```zsh
+eval "$(infisical shell-init zsh)"
+```
+
+The integration wraps commands beginning with `npm`, `pnpm`, `bun`, or `node`.
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/packages/cmd/shell_init.go
+++ b/packages/cmd/shell_init.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const zshShellInit = `# Infisical automatic command wrapper
+if [[ -o interactive ]]; then
+  _infisical_auto_run_prefixes=(npm pnpm bun node)
+
+  _infisical_auto_run_accept_line() {
+    local command="${BUFFER%%[[:space:]]*}"
+    local prefix
+
+    for prefix in "${_infisical_auto_run_prefixes[@]}"; do
+      if [[ "$command" == "$prefix" ]]; then
+        BUFFER="infisical run -- $BUFFER"
+        break
+      fi
+    done
+
+    zle .accept-line
+  }
+
+  zle -N accept-line _infisical_auto_run_accept_line
+fi
+`
+
+var shellInitCmd = &cobra.Command{
+	Use:                   "shell-init [zsh]",
+	Short:                 "prints shell integration for automatically injecting secrets",
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if args[0] != "zsh" {
+			return fmt.Errorf("unsupported shell %q, supported shells: zsh", args[0])
+		}
+
+		_, err := fmt.Fprint(cmd.OutOrStdout(), zshShellInit)
+		return err
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(shellInitCmd)
+}

--- a/packages/cmd/shell_init_test.go
+++ b/packages/cmd/shell_init_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZshShellInit(t *testing.T) {
+	for _, expected := range []string{
+		"if [[ -o interactive ]]; then",
+		"_infisical_auto_run_prefixes=(npm pnpm bun node)",
+		"BUFFER=\"infisical run -- $BUFFER\"",
+		"zle .accept-line",
+	} {
+		if !strings.Contains(zshShellInit, expected) {
+			t.Errorf("shell initialization script does not contain %q", expected)
+		}
+	}
+}


### PR DESCRIPTION
# Description 📣

Fixes #292.

Add an opt-in `infisical shell-init zsh` command that generates an interactive Zsh hook. Once sourced with `eval "$(infisical shell-init zsh)"`, commands beginning with `npm`, `pnpm`, `bun`, or `node` run through `infisical run --`. Other commands remain unchanged.

The README documents setup and the supported prefixes. No new dependencies.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
go test -vet=off ./packages/cmd
go build ./...
go run . shell-init zsh | zsh -n
```

The unit test verifies the generated hook is interactive-only, uses the requested command prefixes, wraps the command with `infisical run --`, and delegates execution back to Zsh.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝