### PR TITLE
improvement(ci): harden CLI release pipeline and alert on failure

### DIFF
--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -90,19 +90,21 @@ jobs:
             --jq '.assets[].name' | sort > /tmp/release-assets.txt
           echo "Release $TAG has $(wc -l < /tmp/release-assets.txt) asset(s)."
           missing=()
+          required=0
           for combo in \
-            linux_amd64:tar.gz linux_arm64:tar.gz linux_armv6:tar.gz linux_armv7:tar.gz \
+            linux_amd64:tar.gz linux_arm64:tar.gz linux_386:tar.gz linux_armv6:tar.gz linux_armv7:tar.gz \
             darwin_amd64:tar.gz darwin_arm64:tar.gz \
             windows_amd64:zip windows_arm64:zip \
             freebsd_amd64:tar.gz freebsd_arm64:tar.gz freebsd_armv6:tar.gz freebsd_armv7:tar.gz; do
+            required=$((required + 1))
             name="cli_${CLI_VERSION}_${combo%%:*}.${combo##*:}"
             grep -qxF "$name" /tmp/release-assets.txt || missing+=("$name")
           done
           if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Release $TAG is missing ${#missing[@]} asset(s) that the npm preinstall downloads, refusing to publish: ${missing[*]}"
+            echo "::error::Release $TAG is missing ${#missing[@]} of $required asset(s) that the npm preinstall downloads, refusing to publish: ${missing[*]}"
             exit 1
           fi
-          echo "All 12 assets required by the npm preinstall are present."
+          echo "All $required assets required by the npm preinstall are present."
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0

--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -48,8 +48,8 @@ jobs:
     if: |
       always() &&
       (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)) &&
-      needs.goreleaser.result == 'success' &&
-      needs.goreleaser-darwin.result == 'success' &&
+      needs.goreleaser.result != 'skipped' && needs.goreleaser.result != 'cancelled' &&
+      needs.goreleaser-darwin.result != 'skipped' && needs.goreleaser-darwin.result != 'cancelled' &&
       needs.cli-tests.result == 'success' &&
       (github.event_name == 'workflow_dispatch' || needs.validate-tag-branch.result == 'success')
     runs-on: ubuntu-latest
@@ -74,6 +74,35 @@ jobs:
 
       - name: Print version
         run: echo ${{ env.CLI_VERSION }}
+
+      # The real gate for this job. `npm install -g @infisical/cli` runs
+      # npm/src/index.cjs at preinstall, which downloads
+      # cli_<version>_<platform>_<arch>.<ext> from this release, so publishing
+      # before those assets exist ships a package that 404s on install.
+      # Keep in sync with getPlatform()/getArchitecture() in npm/src/index.cjs.
+      - name: Verify release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets[].name' | sort > /tmp/release-assets.txt
+          echo "Release $TAG has $(wc -l < /tmp/release-assets.txt) asset(s)."
+          missing=()
+          for combo in \
+            linux_amd64:tar.gz linux_arm64:tar.gz linux_armv6:tar.gz linux_armv7:tar.gz \
+            darwin_amd64:tar.gz darwin_arm64:tar.gz \
+            windows_amd64:zip windows_arm64:zip \
+            freebsd_amd64:tar.gz freebsd_arm64:tar.gz freebsd_armv6:tar.gz freebsd_armv7:tar.gz; do
+            name="cli_${CLI_VERSION}_${combo%%:*}.${combo##*:}"
+            grep -qxF "$name" /tmp/release-assets.txt || missing+=("$name")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Release $TAG is missing ${#missing[@]} asset(s) that the npm preinstall downloads, refusing to publish: ${missing[*]}"
+            exit 1
+          fi
+          echo "All 12 assets required by the npm preinstall are present."
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
@@ -285,20 +314,23 @@ jobs:
           GORELEASER_OUTCOME: ${{ steps.goreleaser.outcome }}
         run: |
           set -euo pipefail
+          # Keep in sync with the `builds:`
+          # list of the `infisical` nfpm in .goreleaser.yaml.
+          ARCHES="386 amd64 arm64 armv6 armv7"
           missing=()
           for ext in deb rpm apk; do
-            # `|| true`: goreleaser can fail before dist/ is even created, and
-            # pipefail would otherwise abort this step before it reports why.
-            count=$(find dist -maxdepth 1 -type f -name "*.${ext}" 2>/dev/null | wc -l | tr -d ' ' || true)
-            echo "dist/*.${ext}: ${count}"
-            [ "$count" -gt 0 ] || missing+=("${ext}")
+            for arch in $ARCHES; do
+              count=$(find dist -maxdepth 1 -type f -name "infisical_*_linux_${arch}.${ext}" 2>/dev/null | wc -l | tr -d ' ' || true)
+              [ "$count" -gt 0 ] || missing+=("linux_${arch}.${ext}")
+            done
           done
           if [ ${#missing[@]} -eq 0 ]; then
+            echo "All 15 expected linux packages present in dist/."
             echo "publish=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "publish=false" >> "$GITHUB_OUTPUT"
-          echo "::error::No ${missing[*]} package(s) in dist/ - skipping the repository publish."
+          echo "::error::dist/ is missing ${#missing[@]} expected package(s) - skipping the repository publish: ${missing[*]}"
           # If goreleaser reported success, an empty dist/ is an unexplained
           # failure that nothing downstream would catch, so fail here.
           if [ "$GORELEASER_OUTCOME" = "success" ]; then

--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -451,3 +451,67 @@ jobs:
           name: goreleaser-dist-windows
           path: dist/
           retention-days: 7
+
+  # Dry runs are excluded: those are manual tests with an operator already
+  # watching the run, so a failure there shouldn't page anyone.
+  notify-pipeline-blocked:
+    name: Notify incident.io if pipeline blocked
+    runs-on: ubuntu-latest
+    needs:
+      - validate-tag-branch
+      - cli-tests
+      - build-rdp-bridge
+      - goreleaser
+      - goreleaser-darwin
+      - goreleaser-windows
+      - npm-release
+    if: |
+      always() &&
+      contains(needs.*.result, 'failure') &&
+      (github.event_name == 'push' || !inputs.dry_run)
+    steps:
+      - name: Send blocked alert to incident.io
+        env:
+          ALERT_URL: ${{ secrets.INCIDENT_IO_DEPLOY_ALERT_URL }}
+          ALERT_TOKEN: ${{ secrets.INCIDENT_IO_DEPLOY_ALERT_TOKEN }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Guard against a misconfigured/rotated secret redirecting the POST (and the
+          # bearer token) to an unintended host: only allow the incident.io API origin.
+          case "$ALERT_URL" in
+            https://api.incident.io/*) ;;
+            *)
+              echo "::error::ALERT_URL does not point at https://api.incident.io/ — refusing to send alert."
+              exit 1
+              ;;
+          esac
+
+          FAILED=$(echo "$NEEDS_JSON" | jq -r 'to_entries | map(select(.value.result == "failure") | .key) | join(", ")')
+          BLOCKED=$(echo "$NEEDS_JSON" | jq -r 'to_entries | map(select(.value.result == "cancelled" or .value.result == "skipped") | .key) | join(", ")')
+          jq -n \
+            --arg title "[${REPO}] Build and release CLI pipeline blocked" \
+            --arg failed "${FAILED:-unknown}" \
+            --arg blocked "${BLOCKED:-none}" \
+            --arg dedup "cli-release-${RUN_ID}" \
+            --arg url "$RUN_URL" \
+            --arg tag "${RELEASE_TAG:-unknown}" \
+            --arg actor "$ACTOR" \
+            '{
+              title: $title,
+              description: ("Failed stage(s): " + $failed + "."),
+              deduplication_key: $dedup,
+              status: "firing",
+              source_url: $url,
+              metadata: { failed_stages: $failed, blocked_stages: $blocked, release_tag: $tag, actor: $actor }
+            }' \
+          | curl -sS --fail-with-body --connect-timeout 10 --max-time 30 -X POST "$ALERT_URL" \
+              -H "Authorization: Bearer $ALERT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d @-

--- a/.github/workflows/release_build_infisical_cli.yml
+++ b/.github/workflows/release_build_infisical_cli.yml
@@ -95,9 +95,17 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: npm pack
 
+      # npm publish returns E403 for a version that already exists, which would
+      # make a re-run of an otherwise-recoverable release fail here. Skip if the
+      # version is already on the registry.
       - name: Publish NPM
         working-directory: ${{ env.working-directory }}
-        run: npm publish --tarball=./infisical-sdk-${{github.ref_name}} --access public
+        run: |
+          if npm view "@infisical/cli@${{ env.CLI_VERSION }}" version >/dev/null 2>&1; then
+            echo "@infisical/cli@${{ env.CLI_VERSION }} already published, skipping"
+            exit 0
+          fi
+          npm publish --tarball=./infisical-sdk-${{github.ref_name}} --access public
 
   goreleaser:
     runs-on: ubuntu-latest-8-cores
@@ -212,7 +220,12 @@ jobs:
           name: goreleaser-dist-linux
           path: dist/
           retention-days: 7
+      # continue-on-error: without --fail-fast, goreleaser collects publisher
+      # errors and keeps going, so one failing publisher (e.g. an AUR outage)
+      # still leaves Docker and the GitHub release assets published
       - name: GoReleaser (release)
+        id: goreleaser
+        continue-on-error: true
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
         uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
@@ -260,16 +273,48 @@ jobs:
           chmod 600 /tmp/infisical-apk.rsa
         env:
           APK_PRIVATE_KEY: ${{ secrets.APK_PRIVATE_KEY }}
+      # The publish below no longer depends on goreleaser's exit code, so it can
+      # be reached with a dist/ that a failed build left empty or partial.
+      # upload_to_s3.sh globs (`for i in *.deb`) and would treat that as a
+      # no-op success, so require the packages we expect before touching the
+      # repos.
+      - name: Check release artifacts are present
+        id: artifacts
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        env:
+          GORELEASER_OUTCOME: ${{ steps.goreleaser.outcome }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for ext in deb rpm apk; do
+            # `|| true`: goreleaser can fail before dist/ is even created, and
+            # pipefail would otherwise abort this step before it reports why.
+            count=$(find dist -maxdepth 1 -type f -name "*.${ext}" 2>/dev/null | wc -l | tr -d ' ' || true)
+            echo "dist/*.${ext}: ${count}"
+            [ "$count" -gt 0 ] || missing+=("${ext}")
+          done
+          if [ ${#missing[@]} -eq 0 ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "publish=false" >> "$GITHUB_OUTPUT"
+          echo "::error::No ${missing[*]} package(s) in dist/ - skipping the repository publish."
+          # If goreleaser reported success, an empty dist/ is an unexplained
+          # failure that nothing downstream would catch, so fail here.
+          if [ "$GORELEASER_OUTCOME" = "success" ]; then
+            exit 1
+          fi
+
       # upload_to_s3.sh syncs the whole apk repo down before rebuilding the index, and
       # that repo holds the full backfilled history.
       - name: Free disk space before publish
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        if: steps.artifacts.outputs.publish == 'true'
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
           df -h /
       - name: Publish packages to repositories
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        if: steps.artifacts.outputs.publish == 'true'
         run: bash upload_to_s3.sh
         env:
           AWS_DEFAULT_REGION: us-east-1
@@ -279,13 +324,20 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.INFISICAL_CLI_REPO_AWS_SECRET_ACCESS_KEY }}
           APK_PRIVATE_KEY_PATH: /tmp/infisical-apk.rsa
       - name: Invalidate Cloudfront cache
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        if: steps.artifacts.outputs.publish == 'true'
         run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths '/rpm/*' '/deb/dists/stable/*' '/apk/stable/main/*'
         env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.INFISICAL_CLI_REPO_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.INFISICAL_CLI_REPO_AWS_SECRET_ACCESS_KEY }}
           CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.INFISICAL_CLI_REPO_CLOUDFRONT_DISTRIBUTION_ID }}
+
+      # Must stay the last step in this job: everything above is allowed to run
+      # despite a goreleaser publisher failure, and this is what keeps the run
+      # red so the failure is still visible and alerted on.
+      - name: Fail if GoReleaser reported errors
+        if: steps.goreleaser.outcome == 'failure'
+        run: exit 1
 
   goreleaser-darwin:
     runs-on: macos-latest

--- a/.goreleaser-darwin.yaml
+++ b/.goreleaser-darwin.yaml
@@ -46,7 +46,9 @@ archives:
       - completions/*
 
 release:
+  # replace_existing_artifacts so re-runs don't 422 on already-uploaded assets.
   mode: append
+  replace_existing_artifacts: true
 
 checksum:
   name_template: "checksums-darwin.txt"

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -1,5 +1,7 @@
 release:
+  # replace_existing_artifacts so re-runs don't 422 on already-uploaded assets.
   mode: append
+  replace_existing_artifacts: true
 
 builds:
   - id: windows-build

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -217,7 +217,11 @@ archives:
       - LICENSE*
 
 release:
+  # replace_existing_artifacts (Since: v1.25, GitHub only) makes each upload
+  # idempotent: on a 422 already_exists it deletes the conflicting asset and
+  # retries, so re-runs work without manually clearing assets first.
   mode: append
+  replace_existing_artifacts: true
 
 checksum:
   name_template: "checksums.txt"

--- a/npm/src/index.cjs
+++ b/npm/src/index.cjs
@@ -55,7 +55,9 @@ const getArchitecture = () => {
       arch = "armv7";
     }
   } else if (architecture === "ia32") {
-    arch = "i386";
+    // "386", not "i386": this has to match GoReleaser's {{ .Arch }}, which is
+    // the Go GOARCH value, so the release asset is cli_<version>_linux_386.tar.gz.
+    arch = "386";
   } else {
     console.error(
       "Your architecture doesn't seem to be supported. Your architecture is",


### PR DESCRIPTION
# Description 📣

CLI release runs can fail partway through (GoReleaser publisher outage, partial `dist/`, npm publish before GitHub assets exist) and leave installs broken or re-runs stuck on duplicate assets/version errors. Operators also had no automated signal when a tag push blocked the pipeline.

This PR hardens the release workflow and adds incident.io alerting:

- **GoReleaser resilience:** Linux GoReleaser runs with `continue-on-error` so a single publisher failure (e.g. AUR) does not block Docker/GitHub release uploads. A new artifact check verifies all 15 expected Linux packages (`deb`/`rpm`/`apk` × 5 arches) before S3 publish and CloudFront invalidation; a final step still fails the job if GoReleaser reported errors.
- **NPM safety and idempotency:** Before `npm publish`, a step verifies all 12 GitHub release assets the npm preinstall downloads. Publish is skipped if `@infisical/cli@<version>` is already on the registry. The `npm-release` job no longer requires GoReleaser jobs to succeed—only that they were not skipped/cancelled.
- **Re-run support:** `replace_existing_artifacts: true` is enabled in all three GoReleaser configs so re-runs replace conflicting GitHub release assets instead of 422ing.
- **Alerting:** A new `notify-pipeline-blocked` job posts to incident.io when any release stage fails (push or non–dry-run dispatch), with URL origin validation on the alert endpoint.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->