### PR TITLE
fix(machine-identity): fall back to .infisical.json for project ID

### DIFF
--- a/packages/models/cli.go
+++ b/packages/models/cli.go
@@ -158,6 +158,7 @@ type GetAllFoldersParameters struct {
 	FoldersPath              string
 	InfisicalToken           string
 	UniversalAuthAccessToken string
+	ProjectConfigFilePath    string
 }
 
 type CreateFolderParameters struct {

--- a/packages/util/config.go
+++ b/packages/util/config.go
@@ -139,6 +139,33 @@ func GetWorkSpaceFromFilePath(configFileDir string) (models.WorkspaceConfigFile,
 	return workspaceConfigFile, nil
 }
 
+func ResolveWorkspaceIdForMachineIdentity(projectConfigFilePath, explicitWorkspaceId string) (string, error) {
+	if explicitWorkspaceId != "" {
+		return explicitWorkspaceId, nil
+	}
+
+	var workspaceConfig models.WorkspaceConfigFile
+	if projectConfigFilePath != "" {
+		cfg, err := GetWorkSpaceFromFilePath(projectConfigFilePath)
+		if err != nil {
+			return "", fmt.Errorf("no project id found in %s: %w", projectConfigFilePath, err)
+		}
+		workspaceConfig = cfg
+	} else {
+		cfg, err := GetWorkSpaceFromFile()
+		if err != nil {
+			return "", fmt.Errorf("no project id found in .infisical.json: %w", err)
+		}
+		workspaceConfig = cfg
+	}
+
+	if workspaceConfig.WorkspaceId == "" {
+		return "", fmt.Errorf("project id is missing in .infisical.json")
+	}
+
+	return workspaceConfig.WorkspaceId, nil
+}
+
 // FindWorkspaceConfigFile searches for a .infisical.json file in the current directory and all parent directories.
 func FindWorkspaceConfigFile() (string, error) {
 	dir, err := os.Getwd()

--- a/packages/util/config_test.go
+++ b/packages/util/config_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -70,3 +71,125 @@ func TestGetEnvDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveWorkspaceIdForMachineIdentity(t *testing.T) {
+	t.Run("explicit value wins over file", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"fromfile"}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+
+		got, err := ResolveWorkspaceIdForMachineIdentity("", "fromflag")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "fromflag" {
+			t.Fatalf("got %q, want fromflag", got)
+		}
+	})
+
+	t.Run("falls back to .infisical.json in cwd", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"fromfile"}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+
+		got, err := ResolveWorkspaceIdForMachineIdentity("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "fromfile" {
+			t.Fatalf("got %q, want fromfile", got)
+		}
+	})
+
+	t.Run("falls back to .infisical.json in parent directory", func(t *testing.T) {
+		parent := t.TempDir()
+		if err := os.WriteFile(filepath.Join(parent, ".infisical.json"), []byte(`{"workspaceId":"fromparent"}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+		child := filepath.Join(parent, "nested", "dir")
+		if err := os.MkdirAll(child, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		t.Chdir(child)
+
+		got, err := ResolveWorkspaceIdForMachineIdentity("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "fromparent" {
+			t.Fatalf("got %q, want fromparent", got)
+		}
+	})
+
+	t.Run("uses explicit projectConfigFilePath when provided", func(t *testing.T) {
+		// cwd is empty; the file lives in a different dir passed explicitly.
+		t.Chdir(t.TempDir())
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"fromexplicitpath"}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+
+		got, err := ResolveWorkspaceIdForMachineIdentity(dir, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "fromexplicitpath" {
+			t.Fatalf("got %q, want fromexplicitpath", got)
+		}
+	})
+
+	t.Run("explicit path takes precedence over cwd file", func(t *testing.T) {
+		// cwd has a file with one id, the explicit path has another.
+		cwd := t.TempDir()
+		t.Chdir(cwd)
+		if err := os.WriteFile(filepath.Join(cwd, ".infisical.json"), []byte(`{"workspaceId":"fromcwd"}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"fromexplicitpath"}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+
+		got, err := ResolveWorkspaceIdForMachineIdentity(dir, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "fromexplicitpath" {
+			t.Fatalf("got %q, want fromexplicitpath", got)
+		}
+	})
+
+	t.Run("error when no file and no explicit value", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		_, err := ResolveWorkspaceIdForMachineIdentity("", "")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("error when explicit path file is missing", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		_, err := ResolveWorkspaceIdForMachineIdentity(t.TempDir(), "")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("error when workspaceId is empty in config file", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":""}`), 0o600); err != nil {
+			t.Fatalf("write workspace: %v", err)
+		}
+
+		_, err := ResolveWorkspaceIdForMachineIdentity("", "")
+		if err == nil {
+			t.Fatal("expected error when workspaceId is empty, got nil")
+		}
+	})
+}
+

--- a/packages/util/folders.go
+++ b/packages/util/folders.go
@@ -49,7 +49,11 @@ func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder
 		log.Debug().Msg("GetAllFolders: Trying to fetch folders using universal auth")
 
 		if params.WorkspaceId == "" {
-			PrintErrorMessageAndExit("Project ID is required when using machine identity")
+			resolved, err := ResolveWorkspaceIdForMachineIdentity(params.ProjectConfigFilePath, params.WorkspaceId)
+			if err != nil {
+				PrintErrorMessageAndExit("Project ID is required when using machine identity")
+			}
+			params.WorkspaceId = resolved
 		}
 
 		// get folders via machine identity

--- a/packages/util/machine_identity_test.go
+++ b/packages/util/machine_identity_test.go
@@ -1,0 +1,134 @@
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Infisical/infisical-merge/packages/config"
+	"github.com/Infisical/infisical-merge/packages/models"
+)
+
+func TestGetAllEnvironmentVariables_MachineIdentityFallsBackToConfig(t *testing.T) {
+	const fileWorkspaceID = "ws-from-config-file"
+
+	var seenProjectID atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenProjectID.Store(r.URL.Query().Get("projectId"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"secrets":[]}`))
+	}))
+	defer srv.Close()
+
+	parsed, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	prevURL := config.INFISICAL_URL
+	config.INFISICAL_URL = parsed.Scheme + "://" + parsed.Host + "/api"
+	t.Cleanup(func() { config.INFISICAL_URL = prevURL })
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"`+fileWorkspaceID+`"}`), 0o600); err != nil {
+		t.Fatalf("write workspace: %v", err)
+	}
+
+	_, err = GetAllEnvironmentVariables(models.GetAllSecretsParameters{
+		UniversalAuthAccessToken: "fake-universal-auth-token",
+		Environment:              "dev",
+	}, "")
+	if err != nil {
+		t.Fatalf("GetAllEnvironmentVariables: %v", err)
+	}
+
+	got, _ := seenProjectID.Load().(string)
+	if got != fileWorkspaceID {
+		t.Fatalf("workspace id sent to API = %q, want %q (issue #365: --projectId missing should fall back to .infisical.json)", got, fileWorkspaceID)
+	}
+}
+
+func TestGetAllEnvironmentVariables_MachineIdentityFlagWins(t *testing.T) {
+	const flagWorkspaceID = "ws-from-flag"
+	const fileWorkspaceID = "ws-from-config-file"
+
+	var seenProjectID atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenProjectID.Store(r.URL.Query().Get("projectId"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"secrets":[]}`))
+	}))
+	defer srv.Close()
+
+	parsed, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	prevURL := config.INFISICAL_URL
+	config.INFISICAL_URL = parsed.Scheme + "://" + parsed.Host + "/api"
+	t.Cleanup(func() { config.INFISICAL_URL = prevURL })
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"`+fileWorkspaceID+`"}`), 0o600); err != nil {
+		t.Fatalf("write workspace: %v", err)
+	}
+
+	_, err = GetAllEnvironmentVariables(models.GetAllSecretsParameters{
+		UniversalAuthAccessToken: "fake-universal-auth-token",
+		WorkspaceId:              flagWorkspaceID,
+		Environment:              "dev",
+	}, "")
+	if err != nil {
+		t.Fatalf("GetAllEnvironmentVariables: %v", err)
+	}
+
+	got, _ := seenProjectID.Load().(string)
+	if got != flagWorkspaceID {
+		t.Fatalf("workspace id sent to API = %q, want %q (--projectId should win over .infisical.json)", got, flagWorkspaceID)
+	}
+}
+
+
+func TestGetAllFolders_MachineIdentityFallsBackToConfig(t *testing.T) {
+	const fileWorkspaceID = "ws-from-config-file"
+
+	var seenWorkspaceID atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenWorkspaceID.Store(r.URL.Query().Get("workspaceId"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"folders":[]}`))
+	}))
+	defer srv.Close()
+
+	parsed, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	prevURL := config.INFISICAL_URL
+	config.INFISICAL_URL = parsed.Scheme + "://" + parsed.Host + "/api"
+	t.Cleanup(func() { config.INFISICAL_URL = prevURL })
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".infisical.json"), []byte(`{"workspaceId":"`+fileWorkspaceID+`"}`), 0o600); err != nil {
+		t.Fatalf("write workspace: %v", err)
+	}
+
+	_, err = GetAllFolders(models.GetAllFoldersParameters{
+		UniversalAuthAccessToken: "fake-universal-auth-token",
+		Environment:              "dev",
+	})
+	if err != nil {
+		t.Fatalf("GetAllFolders: %v", err)
+	}
+
+	got, _ := seenWorkspaceID.Load().(string)
+	if got != fileWorkspaceID {
+		t.Fatalf("workspace id sent to API = %q, want %q (issue #365: --projectId missing should fall back to .infisical.json)", got, fileWorkspaceID)
+	}
+}

--- a/packages/util/secrets.go
+++ b/packages/util/secrets.go
@@ -367,7 +367,11 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 		} else if params.UniversalAuthAccessToken != "" {
 
 			if params.WorkspaceId == "" {
-				PrintErrorMessageAndExit("Project ID is required when using machine identity")
+				resolved, err := ResolveWorkspaceIdForMachineIdentity(projectConfigFilePath, params.WorkspaceId)
+				if err != nil {
+					PrintErrorMessageAndExit("Project ID is required when using machine identity")
+				}
+				params.WorkspaceId = resolved
 			}
 
 			log.Debug().Msg("Trying to fetch secrets using universal auth")


### PR DESCRIPTION
# Description 📣

Fixes #365

When authenticating with machine identity (via `INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN` or a universal-auth access token) without passing `--projectId`, the CLI was unconditionally exiting with:
```
Project ID is required when using machine identity
```

This was wrong. The human-login path already falls back to `.infisical.json` when `--projectId` is missing - the machine identity path was the only one that didn't, forcing every machine-identity user to always pass `--projectId` even after running `infisical init`.

**Changes:**
- Added `ResolveWorkspaceIdForMachineIdentity(projectConfigFilePath, explicitWorkspaceId string)` helper in `config.go` - returns the explicit value if set, otherwise reads `workspaceId` from `.infisical.json` (walking up from cwd), and errors if neither resolves
- Applied the fallback in the `UniversalAuthAccessToken` branch of `GetAllEnvironmentVariables` (`secrets.go`)
- Applied the same fallback in `GetAllFolders` (`folders.go`)
- Added `ProjectConfigFilePath` field to `GetAllFoldersParameters` for parity with the secrets path

## Type ✨

- [x] Bug fix

# Tests 🛠️

**Unit tests** - `packages/util/config_test.go` (`TestResolveWorkspaceIdForMachineIdentity`, 8 subtests):
- explicit `--projectId` wins over file
- falls back to `.infisical.json` in cwd
- walks up to parent directories to find `.infisical.json`
- uses explicit `projectConfigFilePath` when provided
- explicit path takes precedence over cwd file
- errors when no file and no explicit value
- errors when explicit path file is missing
- errors when `workspaceId` field is empty in file

**Integration tests** - `packages/util/machine_identity_test.go` (3 tests using `httptest.NewServer` to assert what the API actually receives on the wire):
- `TestGetAllEnvironmentVariables_MachineIdentityFallsBackToConfig` - no `--projectId`, workspace id is read from `.infisical.json` and forwarded to API
- `TestGetAllEnvironmentVariables_MachineIdentityFlagWins` - explicit `--projectId` overrides the file
- `TestGetAllFolders_MachineIdentityFallsBackToConfig` - same fallback verified for the folders endpoint

```sh
go test ./packages/util/ -run "TestResolveWorkspaceIdForMachineIdentity|TestGetAllEnvironmentVariables_MachineIdentity|TestGetAllFolders_MachineIdentity" -v
# ok  github.com/Infisical/infisical-merge/packages/util  0.033s
```

Also verified:
```sh
go build ./...   # clean
go vet ./packages/util/   # clean
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝