### PR TITLE
fix(secrets): default secrets delete --type to shared to match secrets set

### DIFF
--- a/packages/cmd/secrets.go
+++ b/packages/cmd/secrets.go
@@ -853,7 +853,7 @@ func init() {
 	secretsSetCmd.Flags().Bool("show-values", false, "reveal secret values in the output table instead of masking them")
 	util.AddOutputFlagsToCmd(secretsSetCmd, "The output to format the secrets in.")
 
-	secretsDeleteCmd.Flags().String("type", "personal", "the type of secret to delete: personal or shared  (default: personal)")
+	secretsDeleteCmd.Flags().String("type", util.SECRET_TYPE_SHARED, "the type of secret to delete: personal or shared")
 	secretsDeleteCmd.Flags().String("token", "", "Fetch secrets using service token or machine identity access token")
 	secretsDeleteCmd.Flags().String("projectId", "", "manually set the projectId to delete secrets from when using machine identity based auth")
 	secretsDeleteCmd.Flags().String("path", "/", "get secrets within a folder path")

--- a/packages/cmd/secrets_test.go
+++ b/packages/cmd/secrets_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Infisical/infisical-merge/packages/util"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretsTypeFlagDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{"secrets set", secretsSetCmd},
+		{"secrets delete", secretsDeleteCmd},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := tc.cmd.Flags().Lookup("type")
+			require.NotNil(t, flag, "the type flag should be registered")
+			assert.Equal(t, util.SECRET_TYPE_SHARED, flag.DefValue)
+		})
+	}
+}


### PR DESCRIPTION
Fixes Infisical/infisical#7805

`secrets set` creates a shared secret by default, but `secrets delete` looked for a personal one by default, so deleting a secret you had just created failed with a 404:

```
infisical secrets set TEST=x --env dev     # creates a shared secret
infisical secrets delete TEST --env dev    # 404 Secret not found
infisical secrets delete TEST --env dev --type shared   # works
```

The delete flag also hardcoded the string `"personal"` rather than using `util.SECRET_TYPE_PERSONAL`, and repeated the default in its usage text, which cobra already prints.

This aligns the two defaults on `util.SECRET_TYPE_SHARED`. Deleting a personal secret still works with an explicit `--type personal`.

Worth flagging: this is a behaviour change for anyone scripting `secrets delete` against personal secrets without passing `--type`. It seemed like the right call because `secrets set` already defaults to shared and the `personal` default on delete is not documented, but happy to switch to one of the other options in the issue if you would rather not change the default.

`TestSecretsTypeFlagDefaults` asserts both commands agree on the default so they cannot drift apart again.

One thing I noticed while adding it: nothing in CI runs `./packages/cmd`, and the package will not build under `go test` because of four pre-existing `non-constant format string` vet errors in `run.go`, so the existing unit tests there are not running either. I have left that alone here, but I am happy to open a separate PR fixing those if it would be useful.
