### PR TITLE
fix(secrets): default delete --type to shared, matching set

### DIFF
--- a/packages/cmd/secrets.go
+++ b/packages/cmd/secrets.go
@@ -853,7 +853,7 @@ func init() {
 	secretsSetCmd.Flags().Bool("show-values", false, "reveal secret values in the output table instead of masking them")
 	util.AddOutputFlagsToCmd(secretsSetCmd, "The output to format the secrets in.")
 
-	secretsDeleteCmd.Flags().String("type", "personal", "the type of secret to delete: personal or shared  (default: personal)")
+	secretsDeleteCmd.Flags().String("type", util.SECRET_TYPE_SHARED, "the type of secret to delete: personal or shared")
 	secretsDeleteCmd.Flags().String("token", "", "Fetch secrets using service token or machine identity access token")
 	secretsDeleteCmd.Flags().String("projectId", "", "manually set the projectId to delete secrets from when using machine identity based auth")
 	secretsDeleteCmd.Flags().String("path", "/", "get secrets within a folder path")


### PR DESCRIPTION
Fixes Infisical/infisical#7805

`infisical secrets set` and `infisical secrets get` default to `--type shared`, but `infisical secrets delete` defaults to `--type personal`. So the obvious flow - set a secret, then delete it - always fails with a 404 "Secret not found" unless you remember to pass `--type shared`, and the error gives no hint that the type is the problem.

This flips the delete default to `util.SECRET_TYPE_SHARED` so it matches the rest of the group, and drops the manual "(default: personal)" suffix in the flag help since cobra prints the actual default anyway.

Builds clean (`go build ./packages/cmd/`); `go vet` only reports the four pre-existing `run.go` format-string warnings that are already on `main`.

If maintainers would rather not change the default, two alternatives I'm happy to implement instead: fall back to `shared` when the personal lookup 404s, or keep the defaults and just make the 404 message mention `--type`.
