### PR TITLE
chore(goreleaser): change release mode to keep-existing in configurat…

### DIFF
--- a/.goreleaser-darwin.yaml
+++ b/.goreleaser-darwin.yaml
@@ -47,7 +47,7 @@ archives:
 
 release:
   # replace_existing_artifacts so re-runs don't 422 on already-uploaded assets.
-  mode: append
+  mode: keep-existing
   replace_existing_artifacts: true
 
 checksum:

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -1,6 +1,6 @@
 release:
   # replace_existing_artifacts so re-runs don't 422 on already-uploaded assets.
-  mode: append
+  mode: keep-existing
   replace_existing_artifacts: true
 
 builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -220,7 +220,7 @@ release:
   # replace_existing_artifacts (Since: v1.25, GitHub only) makes each upload
   # idempotent: on a 422 already_exists it deletes the conflicting asset and
   # retries, so re-runs work without manually clearing assets first.
-  mode: append
+  mode: keep-existing
   replace_existing_artifacts: true
 
 checksum:


### PR DESCRIPTION
# Description 📣

The release pipeline runs GoReleaser three times against the same tag — `goreleaser` (linux), `goreleaser-darwin` (`.goreleaser-darwin.yaml`), and `goreleaser-windows` (`.goreleaser-windows.yaml`). All three had `release.mode: append`, and none of them define a `changelog:` section, so each job generated the same default git changelog and appended it to the GitHub release body. The result was the release notes repeated up to three times per release, and more on every re-run of a job.

This switches all three configs to `release.mode: keep-existing`. The first job to reach the release step creates the release with its notes; the other two upload their artifacts and leave the existing body untouched. `replace_existing_artifacts: true` is unchanged, so re-runs are still idempotent for assets (a 422 `already_exists` deletes the conflicting asset and retries).

# Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝