### PR TITLE
docs: add security policy pointing to the vulnerability disclosure pr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The Infisical CLI is available under the [MIT License](LICENSE).
 
 ## Security
 
-Please do not file GitHub issues for security vulnerabilities. Instead, contact us at security@infisical.com.
+Please do not file GitHub issues or post on public forums for security vulnerabilities, as they are public. Report them privately through our vulnerability disclosure policy at <https://infisical.com/vulnerability-disclosure>. Scope, safe harbour and disclosure terms are all set out there. See also [SECURITY.md](./SECURITY.md).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Infisical's paid bug bounty is a separate **private, invitation-only program** c
 
 ## Supported versions
 
-Security fixes ship in the latest release. We always recommend running the latest version of the Infisical CLI.
+Security fixes ship in the latest release. Keep your Infisical CLI updated proactively so you pick them up.
 
 ## General security contact
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for a security problem.**
+
+Report it through our vulnerability disclosure policy at <https://infisical.com/vulnerability-disclosure>.
+
+Please include what you found, where, how to reproduce it, what an attacker could achieve, and how you would like to be credited.
+
+## Scope and safe harbour
+
+The full scope of the program, along with our safe harbour and coordinated disclosure terms, is set out in the policy linked above.
+
+## Rewards
+
+**This is a vulnerability disclosure program, not a bug bounty.** It offers acknowledgement and public credit rather than payment.
+
+Infisical's paid bug bounty is a separate **private, invitation-only program** covering Infisical Cloud. It is not open to public submissions, and reports made through this repository are not eligible for its rewards. Strong reports here are a good route to an invitation.
+
+## Supported versions
+
+Security fixes ship in the latest release. We always recommend running the latest version of the Infisical CLI.
+
+## General security contact
+
+For compliance documentation, security questionnaires, penetration-test reports and SOC 2 requests, use [security@infisical.com](mailto:security@infisical.com). That address is not a vulnerability intake channel.


### PR DESCRIPTION
# Description 📣

This adds the security policy already merged in the main `infisical` repository, so every public Infisical repository states one intake route and one set of terms. 

The text is identical across repositories apart from one sentence under "Supported versions", which names this component and how to stay current with it.

This is one of a set of matching pull requests opened across the public repositories. No code, build, configuration, or runtime behaviour changes.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

Documentation only, so there is nothing to exercise at runtime. 
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->
