### PR TITLE
improvement(login): treat INFISICAL_DOMAIN env as explicit instance selection for cloud URLs

### DIFF
--- a/packages/cmd/login.go
+++ b/packages/cmd/login.go
@@ -153,8 +153,9 @@ var loginCmd = &cobra.Command{
 			}
 
 			domainFlagExplicitlySet := cmd.Flags().Changed("domain")
+			_, domainEnvName, domainFromEnv := util.GetEnvDomainSource()
 			shouldPrintInfo := !silentMode && !plainOutput
-			usePresetDomain, err := usePresetDomain(presetDomain, domainFlagExplicitlySet, shouldPrintInfo)
+			usePresetDomain, err := usePresetDomain(presetDomain, domainFlagExplicitlySet, domainFromEnv, domainEnvName, shouldPrintInfo)
 
 			if err != nil {
 				util.HandleError(err)
@@ -452,19 +453,37 @@ func DomainOverridePrompt() (bool, error) {
 	return selectedOption == OVERRIDE, err
 }
 
-func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, shouldPrintInfo bool) (bool, error) {
+func shouldApplyPresetDomain(preconfiguredUrl string, domainExplicitlyProvided bool) bool {
+	if preconfiguredUrl == "" {
+		return false
+	}
+	if domainExplicitlyProvided {
+		return true
+	}
+
+	return preconfiguredUrl != util.INFISICAL_DEFAULT_US_URL && preconfiguredUrl != util.INFISICAL_DEFAULT_EU_URL
+}
+
+func presetDomainSourceLabel(domainFlagExplicitlySet bool, domainEnvName string) string {
+	if domainFlagExplicitlySet {
+		return "--domain flag"
+	}
+	if domainEnvName != "" {
+		return fmt.Sprintf("%s environment variable", domainEnvName)
+	}
+	return "configuration"
+}
+
+func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, domainFromEnv bool, domainEnvName string, shouldPrintInfo bool) (bool, error) {
 	infisicalConfig, err := util.GetConfigFile()
 	if err != nil {
 		return false, fmt.Errorf("askForDomain: unable to get config file because [err=%s]", err)
 	}
 
 	preconfiguredUrl := strings.TrimSuffix(presetDomain, "/api")
+	domainExplicitlyProvided := domainFlagExplicitlySet || domainFromEnv
 
-	// If the domain flag was explicitly set by the user, use it directly (even for US/EU cloud URLs)
-	// Otherwise, only use the preset domain if it's not a default cloud URL
-	shouldUsePresetDomain := preconfiguredUrl != "" && (domainFlagExplicitlySet || (preconfiguredUrl != util.INFISICAL_DEFAULT_US_URL && preconfiguredUrl != util.INFISICAL_DEFAULT_EU_URL))
-
-	if shouldUsePresetDomain {
+	if shouldApplyPresetDomain(preconfiguredUrl, domainExplicitlyProvided) {
 		parsedDomain := strings.TrimSuffix(strings.Trim(preconfiguredUrl, "/"), "/api")
 
 		_, err := url.ParseRequestURI(parsedDomain)
@@ -491,7 +510,7 @@ func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, shouldPr
 		boldWhite := whilte.Add(color.Bold)
 		time.Sleep(time.Second * 1)
 		if shouldPrintInfo {
-			boldWhite.Printf("[INFO] Using domain '%s' from domain flag or INFISICAL_DOMAIN environment variable\n", parsedDomain)
+			boldWhite.Printf("[INFO] Using domain '%s' from %s\n", parsedDomain, presetDomainSourceLabel(domainFlagExplicitlySet, domainEnvName))
 		}
 
 		return true, nil

--- a/packages/cmd/login.go
+++ b/packages/cmd/login.go
@@ -154,8 +154,10 @@ var loginCmd = &cobra.Command{
 
 			domainFlagExplicitlySet := cmd.Flags().Changed("domain")
 			_, domainEnvName, _ := util.GetEnvDomainSource()
+			_, validDomainFromFile := util.GetDomainFromFile()
+			domainSource := presetDomainSourceLabel(domainFlagExplicitlySet, domainEnvName, validDomainFromFile)
 			shouldPrintInfo := !silentMode && !plainOutput
-			usePresetDomain, err := usePresetDomain(presetDomain, domainFlagExplicitlySet, domainEnvName, shouldPrintInfo)
+			usePresetDomain, err := usePresetDomain(presetDomain, domainSource, shouldPrintInfo)
 
 			if err != nil {
 				util.HandleError(err)
@@ -457,39 +459,41 @@ func normalizePresetDomain(presetDomain string) string {
 	return strings.TrimSuffix(strings.TrimRight(presetDomain, "/"), "/api")
 }
 
-func shouldApplyPresetDomain(parsedDomain string, domainExplicitlyProvided bool) bool {
+func shouldApplyPresetDomain(parsedDomain string, domainSource string) bool {
 	if parsedDomain == "" {
 		return false
 	}
-	if domainExplicitlyProvided {
+	if domainSource != "" {
 		return true
 	}
 	return parsedDomain != util.INFISICAL_DEFAULT_US_URL && parsedDomain != util.INFISICAL_DEFAULT_EU_URL
 }
 
-func presetDomainSourceLabel(domainFlagExplicitlySet bool, domainEnvName string) string {
+func presetDomainSourceLabel(domainFlagExplicitlySet bool, domainEnvName string, domainFromProjectFile bool) string {
 	if domainFlagExplicitlySet {
 		return "--domain flag"
 	}
 	if domainEnvName != "" {
 		return fmt.Sprintf("%s environment variable", domainEnvName)
 	}
-	return "configuration"
+	if domainFromProjectFile {
+		return "configuration"
+	}
+	return ""
 }
 
-func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, domainEnvName string, shouldPrintInfo bool) (bool, error) {
+func usePresetDomain(presetDomain string, domainSource string, shouldPrintInfo bool) (bool, error) {
 	infisicalConfig, err := util.GetConfigFile()
 	if err != nil {
 		return false, fmt.Errorf("askForDomain: unable to get config file because [err=%s]", err)
 	}
 
 	parsedDomain := normalizePresetDomain(presetDomain)
-	domainExplicitlyProvided := domainFlagExplicitlySet || domainEnvName != ""
 
-	if shouldApplyPresetDomain(parsedDomain, domainExplicitlyProvided) {
+	if shouldApplyPresetDomain(parsedDomain, domainSource) {
 		_, err := url.ParseRequestURI(parsedDomain)
 		if err != nil {
-			return false, errors.New(fmt.Sprintf("Invalid domain URL: '%s'", parsedDomain))
+			return false, fmt.Errorf("Invalid domain URL: '%s'", parsedDomain)
 		}
 
 		config.INFISICAL_URL = fmt.Sprintf("%s/api", parsedDomain)
@@ -511,7 +515,7 @@ func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, domainEn
 			whilte := color.New(color.FgGreen)
 			boldWhite := whilte.Add(color.Bold)
 			time.Sleep(time.Second * 1)
-			boldWhite.Printf("[INFO] Using domain '%s' from %s\n", parsedDomain, presetDomainSourceLabel(domainFlagExplicitlySet, domainEnvName))
+			boldWhite.Printf("[INFO] Using domain '%s' from %s\n", parsedDomain, domainSource)
 		}
 
 		return true, nil

--- a/packages/cmd/login.go
+++ b/packages/cmd/login.go
@@ -454,7 +454,7 @@ func DomainOverridePrompt() (bool, error) {
 }
 
 func normalizePresetDomain(presetDomain string) string {
-	return strings.TrimSuffix(strings.Trim(strings.TrimSuffix(presetDomain, "/api"), "/"), "/api")
+	return strings.TrimSuffix(strings.TrimRight(presetDomain, "/"), "/api")
 }
 
 func shouldApplyPresetDomain(parsedDomain string, domainExplicitlyProvided bool) bool {

--- a/packages/cmd/login.go
+++ b/packages/cmd/login.go
@@ -153,9 +153,9 @@ var loginCmd = &cobra.Command{
 			}
 
 			domainFlagExplicitlySet := cmd.Flags().Changed("domain")
-			_, domainEnvName, domainFromEnv := util.GetEnvDomainSource()
+			_, domainEnvName, _ := util.GetEnvDomainSource()
 			shouldPrintInfo := !silentMode && !plainOutput
-			usePresetDomain, err := usePresetDomain(presetDomain, domainFlagExplicitlySet, domainFromEnv, domainEnvName, shouldPrintInfo)
+			usePresetDomain, err := usePresetDomain(presetDomain, domainFlagExplicitlySet, domainEnvName, shouldPrintInfo)
 
 			if err != nil {
 				util.HandleError(err)
@@ -453,15 +453,18 @@ func DomainOverridePrompt() (bool, error) {
 	return selectedOption == OVERRIDE, err
 }
 
-func shouldApplyPresetDomain(preconfiguredUrl string, domainExplicitlyProvided bool) bool {
-	if preconfiguredUrl == "" {
+func normalizePresetDomain(presetDomain string) string {
+	return strings.TrimSuffix(strings.Trim(strings.TrimSuffix(presetDomain, "/api"), "/"), "/api")
+}
+
+func shouldApplyPresetDomain(parsedDomain string, domainExplicitlyProvided bool) bool {
+	if parsedDomain == "" {
 		return false
 	}
 	if domainExplicitlyProvided {
 		return true
 	}
-
-	return preconfiguredUrl != util.INFISICAL_DEFAULT_US_URL && preconfiguredUrl != util.INFISICAL_DEFAULT_EU_URL
+	return parsedDomain != util.INFISICAL_DEFAULT_US_URL && parsedDomain != util.INFISICAL_DEFAULT_EU_URL
 }
 
 func presetDomainSourceLabel(domainFlagExplicitlySet bool, domainEnvName string) string {
@@ -474,18 +477,16 @@ func presetDomainSourceLabel(domainFlagExplicitlySet bool, domainEnvName string)
 	return "configuration"
 }
 
-func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, domainFromEnv bool, domainEnvName string, shouldPrintInfo bool) (bool, error) {
+func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, domainEnvName string, shouldPrintInfo bool) (bool, error) {
 	infisicalConfig, err := util.GetConfigFile()
 	if err != nil {
 		return false, fmt.Errorf("askForDomain: unable to get config file because [err=%s]", err)
 	}
 
-	preconfiguredUrl := strings.TrimSuffix(presetDomain, "/api")
-	domainExplicitlyProvided := domainFlagExplicitlySet || domainFromEnv
+	parsedDomain := normalizePresetDomain(presetDomain)
+	domainExplicitlyProvided := domainFlagExplicitlySet || domainEnvName != ""
 
-	if shouldApplyPresetDomain(preconfiguredUrl, domainExplicitlyProvided) {
-		parsedDomain := strings.TrimSuffix(strings.Trim(preconfiguredUrl, "/"), "/api")
-
+	if shouldApplyPresetDomain(parsedDomain, domainExplicitlyProvided) {
 		_, err := url.ParseRequestURI(parsedDomain)
 		if err != nil {
 			return false, errors.New(fmt.Sprintf("Invalid domain URL: '%s'", parsedDomain))
@@ -506,10 +507,10 @@ func usePresetDomain(presetDomain string, domainFlagExplicitlySet bool, domainFr
 			}
 		}
 
-		whilte := color.New(color.FgGreen)
-		boldWhite := whilte.Add(color.Bold)
-		time.Sleep(time.Second * 1)
 		if shouldPrintInfo {
+			whilte := color.New(color.FgGreen)
+			boldWhite := whilte.Add(color.Bold)
+			time.Sleep(time.Second * 1)
 			boldWhite.Printf("[INFO] Using domain '%s' from %s\n", parsedDomain, presetDomainSourceLabel(domainFlagExplicitlySet, domainEnvName))
 		}
 

--- a/packages/cmd/login_domain_test.go
+++ b/packages/cmd/login_domain_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Infisical/infisical-merge/packages/util"
+)
+
+// TestPresetDomainSelection drives the domain-selection path the way `login`
+// does: root.go's PersistentPreRun runs the configured domain through
+// AppendAPIEndpoint into config.INFISICAL_URL, which usePresetDomain then
+// normalizes, decides on, and attributes to a source.
+//
+// configured is the raw value from --domain, INFISICAL_DOMAIN,
+// INFISICAL_API_URL, or the 'domain' field in .infisical.json. wantApply false
+// means interactive login falls through to the hosting picker.
+func TestPresetDomainSelection(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		flagSet    bool
+		envName    string
+		wantDomain string
+		wantApply  bool
+		wantLabel  string
+	}{
+		{
+			name:       "default US cloud with no explicit source shows the picker",
+			configured: util.INFISICAL_DEFAULT_US_URL,
+			wantDomain: util.INFISICAL_DEFAULT_US_URL,
+			wantApply:  false,
+			wantLabel:  "configuration",
+		},
+		{
+			name:       "EU cloud with no explicit source shows the picker",
+			configured: util.INFISICAL_DEFAULT_EU_URL,
+			wantDomain: util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:  false,
+			wantLabel:  "configuration",
+		},
+		{
+			name:       "US cloud from --domain skips the picker",
+			configured: util.INFISICAL_DEFAULT_US_URL,
+			flagSet:    true,
+			wantDomain: util.INFISICAL_DEFAULT_US_URL,
+			wantApply:  true,
+			wantLabel:  "--domain flag",
+		},
+		{
+			name:       "US cloud from INFISICAL_DOMAIN skips the picker",
+			configured: util.INFISICAL_DEFAULT_US_URL,
+			envName:    util.INFISICAL_DOMAIN_ENV_NAME,
+			wantDomain: util.INFISICAL_DEFAULT_US_URL,
+			wantApply:  true,
+			wantLabel:  "INFISICAL_DOMAIN environment variable",
+		},
+		{
+			name:       "EU cloud from legacy INFISICAL_API_URL skips the picker",
+			configured: util.INFISICAL_DEFAULT_EU_URL,
+			envName:    util.LEGACY_INFISICAL_API_URL_ENV_NAME,
+			wantDomain: util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:  true,
+			wantLabel:  "INFISICAL_API_URL environment variable",
+		},
+		{
+			name:       "flag wins when both flag and env are set",
+			configured: util.INFISICAL_DEFAULT_EU_URL,
+			flagSet:    true,
+			envName:    util.INFISICAL_DOMAIN_ENV_NAME,
+			wantDomain: util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:  true,
+			wantLabel:  "--domain flag",
+		},
+		{
+			name:       "self-hosted from .infisical.json is used without prompting",
+			configured: "https://infisical.example.com",
+			wantDomain: "https://infisical.example.com",
+			wantApply:  true,
+			wantLabel:  "configuration",
+		},
+		{
+			name:       "self-hosted from INFISICAL_DOMAIN is used without prompting",
+			configured: "https://infisical.example.com",
+			envName:    util.INFISICAL_DOMAIN_ENV_NAME,
+			wantDomain: "https://infisical.example.com",
+			wantApply:  true,
+			wantLabel:  "INFISICAL_DOMAIN environment variable",
+		},
+		{
+			name:       "self-hosted on a port is used without prompting",
+			configured: "http://localhost:8080",
+			envName:    util.INFISICAL_DOMAIN_ENV_NAME,
+			wantDomain: "http://localhost:8080",
+			wantApply:  true,
+			wantLabel:  "INFISICAL_DOMAIN environment variable",
+		},
+		{
+			name:       "nothing configured shows the picker",
+			configured: "",
+			wantDomain: "",
+			wantApply:  false,
+			wantLabel:  "configuration",
+		},
+		// A trailing slash or an /api suffix must not disguise a cloud URL as
+		// self-hosted, which would skip the picker for a domain the user never
+		// explicitly selected.
+		{
+			name:       "US cloud with a trailing slash still shows the picker",
+			configured: util.INFISICAL_DEFAULT_US_URL + "/",
+			wantDomain: util.INFISICAL_DEFAULT_US_URL,
+			wantApply:  false,
+			wantLabel:  "configuration",
+		},
+		{
+			name:       "US cloud with an /api suffix still shows the picker",
+			configured: util.INFISICAL_DEFAULT_US_URL + "/api",
+			wantDomain: util.INFISICAL_DEFAULT_US_URL,
+			wantApply:  false,
+			wantLabel:  "configuration",
+		},
+		{
+			name:       "EU cloud with an /api/ suffix still shows the picker",
+			configured: util.INFISICAL_DEFAULT_EU_URL + "/api/",
+			wantDomain: util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:  false,
+			wantLabel:  "configuration",
+		},
+		{
+			name:       "cloud with an /api suffix from env still skips the picker",
+			configured: util.INFISICAL_DEFAULT_US_URL + "/api/",
+			envName:    util.INFISICAL_DOMAIN_ENV_NAME,
+			wantDomain: util.INFISICAL_DEFAULT_US_URL,
+			wantApply:  true,
+			wantLabel:  "INFISICAL_DOMAIN environment variable",
+		},
+		{
+			name:       "self-hosted with an /api/ suffix normalizes and is applied",
+			configured: "https://infisical.example.com/api/",
+			envName:    util.INFISICAL_DOMAIN_ENV_NAME,
+			wantDomain: "https://infisical.example.com",
+			wantApply:  true,
+			wantLabel:  "INFISICAL_DOMAIN environment variable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsedDomain := normalizePresetDomain(util.AppendAPIEndpoint(tc.configured))
+			if parsedDomain != tc.wantDomain {
+				t.Errorf("normalized domain = %q, want %q", parsedDomain, tc.wantDomain)
+			}
+
+			gotApply := shouldApplyPresetDomain(parsedDomain, tc.flagSet || tc.envName != "")
+			if gotApply != tc.wantApply {
+				t.Errorf("shouldApplyPresetDomain(%q, flagSet=%v, envName=%q) = %v, want %v",
+					parsedDomain, tc.flagSet, tc.envName, gotApply, tc.wantApply)
+			}
+
+			gotLabel := presetDomainSourceLabel(tc.flagSet, tc.envName)
+			if gotLabel != tc.wantLabel {
+				t.Errorf("presetDomainSourceLabel(%v, %q) = %q, want %q", tc.flagSet, tc.envName, gotLabel, tc.wantLabel)
+			}
+		})
+	}
+}
+
+// normalizePresetDomain is reached with config.INFISICAL_URL, which
+// AppendAPIEndpoint has already stripped of trailing slashes, so
+// TestPresetDomainSelection cannot tell which layer did the trimming. These
+// cases pin the trimming here too, against raw input.
+func TestNormalizePresetDomain(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"https://app.infisical.com", "https://app.infisical.com"},
+		{"https://app.infisical.com/", "https://app.infisical.com"},
+		{"https://app.infisical.com///", "https://app.infisical.com"},
+		{"https://app.infisical.com/api", "https://app.infisical.com"},
+		{"https://app.infisical.com/api/", "https://app.infisical.com"},
+		{"https://infisical.example.com/api", "https://infisical.example.com"},
+		{"http://localhost:8080/api/", "http://localhost:8080"},
+		{"/", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := normalizePresetDomain(tc.in); got != tc.want {
+				t.Errorf("normalizePresetDomain(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/cmd/login_domain_test.go
+++ b/packages/cmd/login_domain_test.go
@@ -16,27 +16,28 @@ import (
 // means interactive login falls through to the hosting picker.
 func TestPresetDomainSelection(t *testing.T) {
 	cases := []struct {
-		name       string
-		configured string
-		flagSet    bool
-		envName    string
-		wantDomain string
-		wantApply  bool
-		wantLabel  string
+		name        string
+		configured  string
+		flagSet     bool
+		envName     string
+		projectFile bool
+		wantDomain  string
+		wantApply   bool
+		wantLabel   string
 	}{
 		{
 			name:       "default US cloud with no explicit source shows the picker",
 			configured: util.INFISICAL_DEFAULT_US_URL,
 			wantDomain: util.INFISICAL_DEFAULT_US_URL,
 			wantApply:  false,
-			wantLabel:  "configuration",
+			wantLabel:  "",
 		},
 		{
 			name:       "EU cloud with no explicit source shows the picker",
 			configured: util.INFISICAL_DEFAULT_EU_URL,
 			wantDomain: util.INFISICAL_DEFAULT_EU_URL,
 			wantApply:  false,
-			wantLabel:  "configuration",
+			wantLabel:  "",
 		},
 		{
 			name:       "US cloud from --domain skips the picker",
@@ -72,11 +73,12 @@ func TestPresetDomainSelection(t *testing.T) {
 			wantLabel:  "--domain flag",
 		},
 		{
-			name:       "self-hosted from .infisical.json is used without prompting",
-			configured: "https://infisical.example.com",
-			wantDomain: "https://infisical.example.com",
-			wantApply:  true,
-			wantLabel:  "configuration",
+			name:        "self-hosted from .infisical.json is used without prompting",
+			configured:  "https://infisical.example.com",
+			projectFile: true,
+			wantDomain:  "https://infisical.example.com",
+			wantApply:   true,
+			wantLabel:   "configuration",
 		},
 		{
 			name:       "self-hosted from INFISICAL_DOMAIN is used without prompting",
@@ -99,7 +101,7 @@ func TestPresetDomainSelection(t *testing.T) {
 			configured: "",
 			wantDomain: "",
 			wantApply:  false,
-			wantLabel:  "configuration",
+			wantLabel:  "",
 		},
 		// A trailing slash or an /api suffix must not disguise a cloud URL as
 		// self-hosted, which would skip the picker for a domain the user never
@@ -109,21 +111,21 @@ func TestPresetDomainSelection(t *testing.T) {
 			configured: util.INFISICAL_DEFAULT_US_URL + "/",
 			wantDomain: util.INFISICAL_DEFAULT_US_URL,
 			wantApply:  false,
-			wantLabel:  "configuration",
+			wantLabel:  "",
 		},
 		{
 			name:       "US cloud with an /api suffix still shows the picker",
 			configured: util.INFISICAL_DEFAULT_US_URL + "/api",
 			wantDomain: util.INFISICAL_DEFAULT_US_URL,
 			wantApply:  false,
-			wantLabel:  "configuration",
+			wantLabel:  "",
 		},
 		{
 			name:       "EU cloud with an /api/ suffix still shows the picker",
 			configured: util.INFISICAL_DEFAULT_EU_URL + "/api/",
 			wantDomain: util.INFISICAL_DEFAULT_EU_URL,
 			wantApply:  false,
-			wantLabel:  "configuration",
+			wantLabel:  "",
 		},
 		{
 			name:       "cloud with an /api suffix from env still skips the picker",
@@ -141,6 +143,50 @@ func TestPresetDomainSelection(t *testing.T) {
 			wantApply:  true,
 			wantLabel:  "INFISICAL_DOMAIN environment variable",
 		},
+		// A cloud region named by .infisical.json is an instance selection, so it
+		// must be honored instead of dropping the user into the picker, where
+		// accepting the default would silently send them to US cloud.
+		{
+			name:        "EU cloud from .infisical.json skips the picker",
+			configured:  util.INFISICAL_DEFAULT_EU_URL,
+			projectFile: true,
+			wantDomain:  util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:   true,
+			wantLabel:   "configuration",
+		},
+		{
+			name:        "EU cloud with an /api/ suffix from .infisical.json skips the picker",
+			configured:  util.INFISICAL_DEFAULT_EU_URL + "/api/",
+			projectFile: true,
+			wantDomain:  util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:   true,
+			wantLabel:   "configuration",
+		},
+		{
+			name:        "US cloud from .infisical.json skips the picker",
+			configured:  util.INFISICAL_DEFAULT_US_URL,
+			projectFile: true,
+			wantDomain:  util.INFISICAL_DEFAULT_US_URL,
+			wantApply:   true,
+			wantLabel:   "configuration",
+		},
+		{
+			name:        "env beats .infisical.json in the source label",
+			configured:  util.INFISICAL_DEFAULT_EU_URL,
+			envName:     util.INFISICAL_DOMAIN_ENV_NAME,
+			projectFile: true,
+			wantDomain:  util.INFISICAL_DEFAULT_EU_URL,
+			wantApply:   true,
+			wantLabel:   "INFISICAL_DOMAIN environment variable",
+		},
+		{
+			name:        "an invalid .infisical.json domain is not a source",
+			configured:  util.INFISICAL_DEFAULT_US_URL,
+			projectFile: false,
+			wantDomain:  util.INFISICAL_DEFAULT_US_URL,
+			wantApply:   false,
+			wantLabel:   "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -150,15 +196,15 @@ func TestPresetDomainSelection(t *testing.T) {
 				t.Errorf("normalized domain = %q, want %q", parsedDomain, tc.wantDomain)
 			}
 
-			gotApply := shouldApplyPresetDomain(parsedDomain, tc.flagSet || tc.envName != "")
-			if gotApply != tc.wantApply {
-				t.Errorf("shouldApplyPresetDomain(%q, flagSet=%v, envName=%q) = %v, want %v",
-					parsedDomain, tc.flagSet, tc.envName, gotApply, tc.wantApply)
+			gotLabel := presetDomainSourceLabel(tc.flagSet, tc.envName, tc.projectFile)
+			if gotLabel != tc.wantLabel {
+				t.Errorf("presetDomainSourceLabel(%v, %q, %v) = %q, want %q",
+					tc.flagSet, tc.envName, tc.projectFile, gotLabel, tc.wantLabel)
 			}
 
-			gotLabel := presetDomainSourceLabel(tc.flagSet, tc.envName)
-			if gotLabel != tc.wantLabel {
-				t.Errorf("presetDomainSourceLabel(%v, %q) = %q, want %q", tc.flagSet, tc.envName, gotLabel, tc.wantLabel)
+			gotApply := shouldApplyPresetDomain(parsedDomain, gotLabel)
+			if gotApply != tc.wantApply {
+				t.Errorf("shouldApplyPresetDomain(%q, %q) = %v, want %v", parsedDomain, gotLabel, gotApply, tc.wantApply)
 			}
 		})
 	}

--- a/packages/cmd/root.go
+++ b/packages/cmd/root.go
@@ -112,7 +112,7 @@ func resolveDomain(cmd *cobra.Command, flagValue string) string {
 	}
 
 	if !valid {
-		util.PrintWarningWithWriter("The 'domain' field in .infisical.json is not a valid URL (must start with http:// or https://). It will be ignored.", cmd.ErrOrStderr())
+		util.PrintWarningWithWriter("The 'domain' field in .infisical.json is not a valid URL (must be an http:// or https:// URL with a host). It will be ignored.", cmd.ErrOrStderr())
 		return flagValue
 	}
 

--- a/packages/cmd/root.go
+++ b/packages/cmd/root.go
@@ -106,13 +106,12 @@ func resolveDomain(cmd *cobra.Command, flagValue string) string {
 		return envDomain
 	}
 
-	workspaceConfig, err := util.GetWorkSpaceFromFile()
-	if err != nil || workspaceConfig.Domain == "" {
+	domain, valid := util.GetDomainFromFile()
+	if domain == "" {
 		return flagValue
 	}
 
-	domain := workspaceConfig.Domain
-	if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
+	if !valid {
 		util.PrintWarningWithWriter("The 'domain' field in .infisical.json is not a valid URL (must start with http:// or https://). It will be ignored.", cmd.ErrOrStderr())
 		return flagValue
 	}

--- a/packages/util/config.go
+++ b/packages/util/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/config"
 	"github.com/Infisical/infisical-merge/packages/models"
@@ -115,6 +116,18 @@ func GetWorkSpaceFromFile() (models.WorkspaceConfigFile, error) {
 	}
 
 	return workspaceConfigFile, nil
+}
+
+func GetDomainFromFile() (domain string, valid bool) {
+	workspaceFile, err := GetWorkSpaceFromFile()
+	if err != nil {
+		log.Debug().Msgf("GetDomainFromFile: [err=%s]", err)
+		return "", false
+	}
+
+	domain = workspaceFile.Domain
+	valid = strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://")
+	return domain, valid
 }
 
 func GetWorkSpaceFromFilePath(configFileDir string) (models.WorkspaceConfigFile, error) {

--- a/packages/util/config.go
+++ b/packages/util/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -125,8 +126,11 @@ func GetDomainFromFile() (domain string, valid bool) {
 		return "", false
 	}
 
-	domain = workspaceFile.Domain
-	valid = strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://")
+	domain = strings.TrimSpace(workspaceFile.Domain)
+	parsed, err := url.Parse(domain)
+	valid = err == nil &&
+		(parsed.Scheme == "http" || parsed.Scheme == "https") &&
+		parsed.Host != ""
 	return domain, valid
 }
 

--- a/packages/util/config_test.go
+++ b/packages/util/config_test.go
@@ -82,3 +82,33 @@ func TestGetEnvDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDomainFromWorkspaceFile(t *testing.T) {
+	cases := []struct {
+		name       string
+		contents   string
+		wantDomain string
+		wantUsable bool
+	}{
+		{"https domain is usable", `{"domain":"https://eu.infisical.com"}`, "https://eu.infisical.com", true},
+		{"http domain is usable", `{"domain":"http://localhost:8080"}`, "http://localhost:8080", true},
+		{"domain with an /api suffix is usable", `{"domain":"https://eu.infisical.com/api/"}`, "https://eu.infisical.com/api/", true},
+		{"absent domain is not usable", `{"defaultEnvironment":"dev"}`, "", false},
+		{"schemeless domain is reported unusable", `{"domain":"eu.infisical.com"}`, "eu.infisical.com", false},
+		{"whitespace domain is reported unusable", `{"domain":"   "}`, "   ", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeWorkspace(t, tc.contents)
+
+			gotDomain, gotUsable := GetDomainFromFile()
+			if gotDomain != tc.wantDomain {
+				t.Errorf("domain = %q, want %q", gotDomain, tc.wantDomain)
+			}
+			if gotUsable != tc.wantUsable {
+				t.Errorf("usable = %v, want %v", gotUsable, tc.wantUsable)
+			}
+		})
+	}
+}

--- a/packages/util/config_test.go
+++ b/packages/util/config_test.go
@@ -92,10 +92,14 @@ func TestGetDomainFromWorkspaceFile(t *testing.T) {
 	}{
 		{"https domain is usable", `{"domain":"https://eu.infisical.com"}`, "https://eu.infisical.com", true},
 		{"http domain is usable", `{"domain":"http://localhost:8080"}`, "http://localhost:8080", true},
+		{"surrounding whitespace is trimmed", `{"domain":"  https://eu.infisical.com  "}`, "https://eu.infisical.com", true},
 		{"domain with an /api suffix is usable", `{"domain":"https://eu.infisical.com/api/"}`, "https://eu.infisical.com/api/", true},
 		{"absent domain is not usable", `{"defaultEnvironment":"dev"}`, "", false},
 		{"schemeless domain is reported unusable", `{"domain":"eu.infisical.com"}`, "eu.infisical.com", false},
-		{"whitespace domain is reported unusable", `{"domain":"   "}`, "   ", false},
+		{"scheme-only https is reported unusable", `{"domain":"https://"}`, "https://", false},
+		{"scheme-only http is reported unusable", `{"domain":"http://"}`, "http://", false},
+		{"non-http scheme is reported unusable", `{"domain":"ftp://example.com"}`, "ftp://example.com", false},
+		{"whitespace domain is reported unusable", `{"domain":"   "}`, "", false},
 	}
 
 	for _, tc := range cases {

--- a/packages/util/config_test.go
+++ b/packages/util/config_test.go
@@ -36,13 +36,14 @@ func TestGetEnvDomain(t *testing.T) {
 		domain  string // INFISICAL_DOMAIN
 		apiURL  string // INFISICAL_API_URL (legacy)
 		wantVal string
+		wantEnv string
 		wantOk  bool
 	}{
-		{"prefers INFISICAL_DOMAIN over legacy", "https://domain.infisical.com", "https://apiurl.infisical.com", "https://domain.infisical.com", true},
-		{"falls back to legacy INFISICAL_API_URL", unset, "https://apiurl.infisical.com", "https://apiurl.infisical.com", true},
-		{"blank INFISICAL_DOMAIN falls through to legacy", "  ", "https://apiurl.infisical.com", "https://apiurl.infisical.com", true},
-		{"neither set", unset, unset, "", false},
-		{"both blank are treated as unset", "  ", "  ", "", false},
+		{"prefers INFISICAL_DOMAIN over legacy", "https://domain.infisical.com", "https://apiurl.infisical.com", "https://domain.infisical.com", INFISICAL_DOMAIN_ENV_NAME, true},
+		{"falls back to legacy INFISICAL_API_URL", unset, "https://apiurl.infisical.com", "https://apiurl.infisical.com", LEGACY_INFISICAL_API_URL_ENV_NAME, true},
+		{"blank INFISICAL_DOMAIN falls through to legacy", "  ", "https://apiurl.infisical.com", "https://apiurl.infisical.com", LEGACY_INFISICAL_API_URL_ENV_NAME, true},
+		{"neither set", unset, unset, "", "", false},
+		{"both blank are treated as unset", "  ", "  ", "", "", false},
 	}
 
 	setOrUnset := func(t *testing.T, key, val string) {
@@ -66,6 +67,17 @@ func TestGetEnvDomain(t *testing.T) {
 			}
 			if got != tc.wantVal {
 				t.Errorf("value = %q, want %q", got, tc.wantVal)
+			}
+
+			gotDomain, gotEnv, gotOk := GetEnvDomainSource()
+			if gotOk != tc.wantOk {
+				t.Fatalf("GetEnvDomainSource ok = %v, want %v", gotOk, tc.wantOk)
+			}
+			if gotDomain != tc.wantVal {
+				t.Errorf("GetEnvDomainSource value = %q, want %q", gotDomain, tc.wantVal)
+			}
+			if gotEnv != tc.wantEnv {
+				t.Errorf("GetEnvDomainSource env = %q, want %q", gotEnv, tc.wantEnv)
 			}
 		})
 	}

--- a/packages/util/helper.go
+++ b/packages/util/helper.go
@@ -479,15 +479,9 @@ func GetEnvDomain() (string, bool) {
 }
 
 func AppendAPIEndpoint(address string) string {
-	// if it's empty return as it is
-	// Ensure the address does not already end with "/api"
+	address = strings.TrimRight(address, "/")
 	if address == "" || strings.HasSuffix(address, "/api") {
 		return address
-	}
-
-	// Check if the address ends with a slash and append accordingly
-	if address[len(address)-1] == '/' {
-		return address + "api"
 	}
 	return address + "/api"
 }

--- a/packages/util/helper.go
+++ b/packages/util/helper.go
@@ -459,15 +459,23 @@ func getCurrentBranch() (string, error) {
 // precedence order: INFISICAL_DOMAIN first, then the legacy INFISICAL_API_URL.
 var DomainEnvNames = []string{INFISICAL_DOMAIN_ENV_NAME, LEGACY_INFISICAL_API_URL_ENV_NAME}
 
+// GetEnvDomainSource returns the Infisical domain configured via environment
+// variables and the env var name it came from, preferring INFISICAL_DOMAIN
+// over the legacy INFISICAL_API_URL.
+func GetEnvDomainSource() (domain string, envName string, ok bool) {
+	for _, env := range DomainEnvNames {
+		if domain := strings.TrimSpace(os.Getenv(env)); domain != "" {
+			return domain, env, true
+		}
+	}
+	return "", "", false
+}
+
 // GetEnvDomain returns the Infisical domain configured via environment
 // variables, preferring INFISICAL_DOMAIN over the legacy INFISICAL_API_URL.
 func GetEnvDomain() (string, bool) {
-	for _, env := range DomainEnvNames {
-		if domain := strings.TrimSpace(os.Getenv(env)); domain != "" {
-			return domain, true
-		}
-	}
-	return "", false
+	domain, _, ok := GetEnvDomainSource()
+	return domain, ok
 }
 
 func AppendAPIEndpoint(address string) string {


### PR DESCRIPTION
# Description 📣

Setting `INFISICAL_DOMAIN` or legacy `INFISICAL_API_URL` should be treated as an explicit instance choice—the same as passing `--domain`. Before this change, user login only honored those env vars for non-default hosts; US Cloud (`https://app.infisical.com`) and EU Cloud (`https://eu.infisical.com`) from env were ignored and the interactive hosting picker still appeared.

Login now treats `--domain`, `INFISICAL_DOMAIN`, and `INFISICAL_API_URL` as explicit domain sources. When any of them is set (including US/EU cloud URLs), `usePresetDomain` skips the hosting picker and uses that instance. The INFO line names the source (`--domain flag`, `INFISICAL_DOMAIN environment variable`, or `INFISICAL_API_URL environment variable`). `--domain` still wins when both flag and env are set (via existing `resolveDomain` precedence).

Supporting changes: `GetEnvDomainSource()` returns the domain and which env var supplied it; `AppendAPIEndpoint` trims trailing slashes before appending `/api`; domain normalization is extracted into small helpers so origins ending in `/api` are not over-stripped.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

1. With no flag or env set, run `infisical login` and confirm the hosting picker appears.
2. Run `INFISICAL_DOMAIN=https://eu.infisical.com infisical login` and confirm:
   - INFO mentions `INFISICAL_DOMAIN environment variable`
   - No "Select your hosting option" prompt
   - Browser/callback targets `eu.infisical.com`
3. Repeat with `INFISICAL_DOMAIN=https://app.infisical.com` for US Cloud.
4. Run `infisical login --domain https://eu.infisical.com` with env unset; INFO should say `--domain flag`.
5. With both set (`INFISICAL_DOMAIN=https://app.infisical.com` and `--domain https://eu.infisical.com`), confirm the flag wins and INFO says `--domain flag`.
6. Run `INFISICAL_API_URL=https://eu.infisical.com infisical login` (no `INFISICAL_DOMAIN`) and confirm legacy env behaves like explicit domain selection.
7. Run `INFISICAL_DOMAIN=$API_URL infisical login --method=universal-auth --plain --silent` against a local/self-hosted instance and confirm login succeeds without the picker.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->