### PR TITLE
fix(pam): stop retrying rejected recording chunks

### DIFF
--- a/packages/pam/session/chunk_uploader.go
+++ b/packages/pam/session/chunk_uploader.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -263,6 +264,41 @@ func (cu *ChunkUploader) EncryptAndQueueChunk(
 	return pc, nil
 }
 
+// Reconciliation never gives up, so a chunk that can only ever be rejected retries forever.
+func isPermanentUploadFailure(err error) bool {
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.StatusCode {
+	case http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+// flushSession has already advanced past it, so keeping the file only feeds the retry loop.
+func (cu *ChunkUploader) dropIfPermanent(sessionID string, pc *pendingChunk, err error) {
+	if !isPermanentUploadFailure(err) {
+		return
+	}
+
+	entry := log.Error().
+		Err(err).
+		Str("sessionId", sessionID).
+		Int("chunkIndex", pc.ChunkIndex).
+		Int("ciphertextBytes", len(pc.Ciphertext))
+
+	if rmErr := os.Remove(chunkPendingFile(sessionID, pc.ChunkIndex)); rmErr != nil {
+		entry.AnErr("removeError", rmErr).
+			Msg("Recording chunk permanently rejected but could not be removed; it stays queued and will keep failing")
+		return
+	}
+
+	entry.Msg("Recording chunk permanently rejected by platform; dropped instead of retrying")
+}
+
 func (cu *ChunkUploader) UploadChunk(sessionID string, pc *pendingChunk) error {
 	secrets := cu.credentialsManager.GetRecordingSecrets(sessionID)
 	if secrets == nil {
@@ -281,6 +317,7 @@ func (cu *ChunkUploader) UploadChunk(sessionID string, pc *pendingChunk) error {
 			},
 		)
 		if err != nil {
+			cu.dropIfPermanent(sessionID, pc, err)
 			return fmt.Errorf("presigned PUT mint failed: %w", err)
 		}
 		if err := s3PutCiphertext(presigned.URL, pc.Ciphertext); err != nil {
@@ -305,6 +342,7 @@ func (cu *ChunkUploader) UploadChunk(sessionID string, pc *pendingChunk) error {
 	}
 
 	if err := api.CallPAMSessionChunkMetadata(cu.httpClient, sessionID, secrets.UploadToken, metadataReq); err != nil {
+		cu.dropIfPermanent(sessionID, pc, err)
 		return fmt.Errorf("chunk metadata POST failed: %w", err)
 	}
 

--- a/packages/pam/session/chunk_uploader.go
+++ b/packages/pam/session/chunk_uploader.go
@@ -264,18 +264,16 @@ func (cu *ChunkUploader) EncryptAndQueueChunk(
 	return pc, nil
 }
 
-// Reconciliation never gives up, so a chunk that can only ever be rejected retries forever.
+const uploadTokenMismatchError = "PamUploadTokenHashMismatch"
+
+// Matched on the platform's error name rather than the status, because a 404 or a
+// missing-token 400 can just be a read replica that has not caught up with a new session.
 func isPermanentUploadFailure(err error) bool {
 	var apiErr *api.APIError
 	if !errors.As(err, &apiErr) {
 		return false
 	}
-	switch apiErr.StatusCode {
-	case http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound:
-		return true
-	default:
-		return false
-	}
+	return apiErr.StatusCode == http.StatusBadRequest && apiErr.Name == uploadTokenMismatchError
 }
 
 // flushSession has already advanced past it, so keeping the file only feeds the retry loop.

--- a/packages/pam/session/chunk_uploader_http_test.go
+++ b/packages/pam/session/chunk_uploader_http_test.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Infisical/infisical-merge/packages/config"
+	"github.com/go-resty/resty/v2"
+)
+
+// Uses a real HTTP server so the status code travels the same path it does in production.
+func newChunkUploaderAgainst(t *testing.T, status int, body string) (*ChunkUploader, *int) {
+	t.Helper()
+
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits += 1
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := config.INFISICAL_URL
+	config.INFISICAL_URL = srv.URL + "/api"
+	t.Cleanup(func() { config.INFISICAL_URL = orig })
+
+	cm := newTestCredentialsManager(t)
+	cm.recordingSecrets["sess"] = &PAMRecordingSecrets{
+		SessionKey:     make([]byte, 32),
+		UploadToken:    "fake-token-for-test",
+		StorageBackend: storageBackendPostgres,
+		ProjectId:      "proj",
+		SessionId:      "sess",
+	}
+
+	return NewChunkUploader(resty.New(), cm), &hits
+}
+
+func queuedChunk(t *testing.T, sessionID string) *pendingChunk {
+	t.Helper()
+	pc := &pendingChunk{
+		ChunkIndex:     0,
+		StartElapsedMs: 0,
+		EndElapsedMs:   10,
+		IV:             make([]byte, 12),
+		Ciphertext:     []byte("ciphertext"),
+		Sha256:         make([]byte, 32),
+		StorageBackend: storageBackendPostgres,
+	}
+	if err := writePendingChunk(sessionID, pc); err != nil {
+		t.Fatal(err)
+	}
+	return pc
+}
+
+func TestUploadChunk_RealInvalidUploadTokenIsDropped(t *testing.T) {
+	setupTestDir(t)
+
+	cu, hits := newChunkUploaderAgainst(t, http.StatusBadRequest,
+		`{"reqId":"req-x","statusCode":400,"message":"Invalid upload token","error":"PamUploadTokenHashMismatch"}`)
+	pc := queuedChunk(t, "sess")
+
+	if err := cu.UploadChunk("sess", pc); err == nil {
+		t.Fatal("expected UploadChunk to surface the 400")
+	}
+	if *hits != 1 {
+		t.Errorf("server saw %d requests, want 1", *hits)
+	}
+	if _, err := os.Stat(chunkPendingFile("sess", 0)); !os.IsNotExist(err) {
+		t.Error("a 400 is permanent: the chunk must be dropped, not left to retry forever")
+	}
+}
+
+func TestUploadChunk_RealRateLimitIsRetained(t *testing.T) {
+	setupTestDir(t)
+
+	cu, _ := newChunkUploaderAgainst(t, http.StatusTooManyRequests,
+		`{"reqId":"req-y","statusCode":429,"message":"Rate limit exceeded. Please try again in 14 seconds"}`)
+	pc := queuedChunk(t, "sess")
+
+	if err := cu.UploadChunk("sess", pc); err == nil {
+		t.Fatal("expected UploadChunk to surface the 429")
+	}
+	if _, err := os.Stat(chunkPendingFile("sess", 0)); err != nil {
+		t.Errorf("a 429 is transient: the chunk must stay queued for retry: %v", err)
+	}
+}
+
+func TestUploadChunk_RealServerErrorIsRetained(t *testing.T) {
+	setupTestDir(t)
+
+	cu, _ := newChunkUploaderAgainst(t, http.StatusInternalServerError, `{"statusCode":500,"message":"boom"}`)
+	pc := queuedChunk(t, "sess")
+
+	if err := cu.UploadChunk("sess", pc); err == nil {
+		t.Fatal("expected UploadChunk to surface the 500")
+	}
+	if _, err := os.Stat(chunkPendingFile("sess", 0)); err != nil {
+		t.Errorf("a 500 is transient: the chunk must stay queued for retry: %v", err)
+	}
+}
+
+func TestReconcileSession_DrainsPermanentlyRejectedQueue(t *testing.T) {
+	setupTestDir(t)
+
+	cu, hits := newChunkUploaderAgainst(t, http.StatusBadRequest,
+		`{"statusCode":400,"message":"Invalid upload token","error":"PamUploadTokenHashMismatch"}`)
+
+	const queued = 5
+	for i := 0; i < queued; i += 1 {
+		pc := &pendingChunk{
+			ChunkIndex:     i,
+			IV:             make([]byte, 12),
+			Ciphertext:     []byte("ciphertext"),
+			Sha256:         make([]byte, 32),
+			StorageBackend: storageBackendPostgres,
+		}
+		if err := writePendingChunk("sess", pc); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cu.ReconcileSession("sess")
+	if *hits != queued {
+		t.Errorf("first pass made %d requests, want %d", *hits, queued)
+	}
+
+	before := *hits
+	cu.ReconcileSession("sess")
+	if *hits != before {
+		t.Errorf("second pass made %d more requests; the queue was not drained", *hits-before)
+	}
+
+	if cu.HasPendingChunks("sess") {
+		t.Error("queue still holds permanently rejected chunks")
+	}
+}

--- a/packages/pam/session/chunk_uploader_test.go
+++ b/packages/pam/session/chunk_uploader_test.go
@@ -356,15 +356,16 @@ func TestIsPermanentUploadFailure(t *testing.T) {
 		err  error
 		want bool
 	}{
-		{"body too large is retryable after re-chunking", &api.APIError{StatusCode: http.StatusRequestEntityTooLarge}, false},
-		{"bad request", &api.APIError{StatusCode: http.StatusBadRequest}, true},
-		{"forbidden gateway", &api.APIError{StatusCode: http.StatusForbidden}, true},
-		{"session gone", &api.APIError{StatusCode: http.StatusNotFound}, true},
+		{"token mismatch", &api.APIError{StatusCode: http.StatusBadRequest, Name: uploadTokenMismatchError}, true},
+		{"missing token may be an unreplicated session", &api.APIError{StatusCode: http.StatusBadRequest, Name: "PamUploadTokenMissing"}, false},
+		{"session not found may be an unreplicated session", &api.APIError{StatusCode: http.StatusNotFound}, false},
+		{"forbidden gateway", &api.APIError{StatusCode: http.StatusForbidden}, false},
+		{"body too large", &api.APIError{StatusCode: http.StatusRequestEntityTooLarge}, false},
 		{"rate limited", &api.APIError{StatusCode: http.StatusTooManyRequests}, false},
 		{"server error", &api.APIError{StatusCode: http.StatusInternalServerError}, false},
 		{"unauthorized retries after token refresh", &api.APIError{StatusCode: http.StatusUnauthorized}, false},
 		{"network error", errors.New("dial tcp: connection refused"), false},
-		{"wrapped bad request", fmt.Errorf("chunk metadata POST failed: %w", &api.APIError{StatusCode: http.StatusBadRequest}), true},
+		{"wrapped token mismatch", fmt.Errorf("chunk metadata POST failed: %w", &api.APIError{StatusCode: http.StatusBadRequest, Name: uploadTokenMismatchError}), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -391,7 +392,7 @@ func TestDropIfPermanent(t *testing.T) {
 	if err := writePendingChunk(sid, pc); err != nil {
 		t.Fatal(err)
 	}
-	cu.dropIfPermanent(sid, pc, fmt.Errorf("wrapped: %w", &api.APIError{StatusCode: http.StatusBadRequest}))
+	cu.dropIfPermanent(sid, pc, fmt.Errorf("wrapped: %w", &api.APIError{StatusCode: http.StatusBadRequest, Name: uploadTokenMismatchError}))
 	if _, err := os.Stat(chunkPendingFile(sid, 0)); !os.IsNotExist(err) {
 		t.Error("permanently rejected chunk should have been dropped from the queue")
 	}

--- a/packages/pam/session/chunk_uploader_test.go
+++ b/packages/pam/session/chunk_uploader_test.go
@@ -5,11 +5,15 @@ import (
 	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Infisical/infisical-merge/packages/api"
 )
 
 func setupTestDir(t *testing.T) {
@@ -343,6 +347,62 @@ func TestDeletePendingChunk(t *testing.T) {
 	deletePendingChunk(sid, 0)
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("chunk file should have been deleted")
+	}
+}
+
+func TestIsPermanentUploadFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"body too large is retryable after re-chunking", &api.APIError{StatusCode: http.StatusRequestEntityTooLarge}, false},
+		{"bad request", &api.APIError{StatusCode: http.StatusBadRequest}, true},
+		{"forbidden gateway", &api.APIError{StatusCode: http.StatusForbidden}, true},
+		{"session gone", &api.APIError{StatusCode: http.StatusNotFound}, true},
+		{"rate limited", &api.APIError{StatusCode: http.StatusTooManyRequests}, false},
+		{"server error", &api.APIError{StatusCode: http.StatusInternalServerError}, false},
+		{"unauthorized retries after token refresh", &api.APIError{StatusCode: http.StatusUnauthorized}, false},
+		{"network error", errors.New("dial tcp: connection refused"), false},
+		{"wrapped bad request", fmt.Errorf("chunk metadata POST failed: %w", &api.APIError{StatusCode: http.StatusBadRequest}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPermanentUploadFailure(tc.err); got != tc.want {
+				t.Errorf("isPermanentUploadFailure() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDropIfPermanent(t *testing.T) {
+	setupTestDir(t)
+	cu := newTestChunkUploader(t, newTestCredentialsManager(t))
+
+	pc := &pendingChunk{
+		ChunkIndex:     0,
+		IV:             make([]byte, 12),
+		Ciphertext:     []byte("ct"),
+		Sha256:         make([]byte, 32),
+		StorageBackend: "postgres",
+	}
+
+	sid := "drop-permanent"
+	if err := writePendingChunk(sid, pc); err != nil {
+		t.Fatal(err)
+	}
+	cu.dropIfPermanent(sid, pc, fmt.Errorf("wrapped: %w", &api.APIError{StatusCode: http.StatusBadRequest}))
+	if _, err := os.Stat(chunkPendingFile(sid, 0)); !os.IsNotExist(err) {
+		t.Error("permanently rejected chunk should have been dropped from the queue")
+	}
+
+	sid = "keep-transient"
+	if err := writePendingChunk(sid, pc); err != nil {
+		t.Fatal(err)
+	}
+	cu.dropIfPermanent(sid, pc, &api.APIError{StatusCode: http.StatusTooManyRequests})
+	if _, err := os.Stat(chunkPendingFile(sid, 0)); err != nil {
+		t.Errorf("rate-limited chunk must stay queued for retry: %v", err)
 	}
 }
 


### PR DESCRIPTION
# Description 📣

Chunk reconciliation retried every failed upload on a 5-minute tick with no give-up, so a chunk the platform rejects for a reason that cannot change was re-POSTed for the life of the gateway. One stuck queue produced 22,511 errors in three hours in production, and the burst also saturated the write rate limit.

Fixes the gateway half of [PAM-463](https://linear.app/infisical/issue/PAM-463/investigate-session-recording-endpoint-error-spike); the platform half is in Infisical/infisical#8043. This is the only change that clears an already-stuck queue, so it needs to reach affected gateways for the error rate to drop.

## Type ✨

- [x] Bug fix

# Tests 🛠️

Four new tests drive `UploadChunk` against a real `httptest` server with `config.INFISICAL_URL` overridden, so the status code travels the genuine production path (resty response → `NewAPIErrorWithResponse` → `fmt.Errorf("%w")` → `errors.As`) rather than a synthetic error:

- a real `400 Invalid upload token` drops the chunk
- a real `429` and a real `500` both keep it queued
- a queue of five permanently rejected chunks drains in one reconcile pass and makes **zero** requests on the second pass

The second commit adds `singleflight` around session credential fetches. Recording secrets are minted on a session's first fetch, and the cache check released its lock before the API call, so two connections on one session both fetched and both minted, leaving this gateway holding a token the platform had discarded. Covered by a test that fires 16 concurrent callers and asserts one fetch, run under `-race`.

```sh
go test ./packages/pam/... 
go test ./packages/pam/session/ -run "Real|DrainsPermanently|Cached|Singleflight" -race -v
```

Also built the binary from this branch and ran it as a real gateway against a local platform: it enrolls, connects to the relay, heartbeats, and starts the session uploader with no errors.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
