### PR TITLE
improvement(agent-vault): read the session token from the environment

### DIFF
--- a/packages/cmd/agent_vault_run.go
+++ b/packages/cmd/agent_vault_run.go
@@ -409,6 +409,9 @@ func buildAgentVaultRunEnv(parent []string, proxyAddr, sessionToken, caPath, ext
 	for _, k := range proxyEnvKeys {
 		stale[k] = true
 	}
+	// The agent's session is the one in the proxy URL. An inherited token is either that same secret a
+	// second time or, on an --access-bundle run, the one this command just said it was ignoring.
+	stale[agentVaultSessionTokenEnv] = true
 
 	var operatorNoProxy []string
 	env := map[string]string{}

--- a/packages/cmd/agent_vault_run.go
+++ b/packages/cmd/agent_vault_run.go
@@ -101,7 +101,8 @@ Two ways to get a session, exactly one of them required:
 
   --access-bundle   mint one now over the named bundle (needs your login or a machine identity).
                     Revoked when the agent exits unless --keep-session is set.
-  --session-token   run with a session token minted in the dashboard. Never revoked by this command.
+  --session-token   run with a session token minted in the dashboard, or set INFISICAL_AGENT_VAULT_SESSION_TOKEN
+                    to keep it off the command line. Never revoked by this command.
 
 The proxy's certificate authority is fetched from the proxy on every run and trusted for the agent. Pass
 --ca-fingerprint to abort if the served certificate does not match a fingerprint from the Proxies page.
@@ -132,9 +133,35 @@ func nonBlank(values []string) []string {
 	return kept
 }
 
+const agentVaultSessionTokenEnv = "INFISICAL_AGENT_VAULT_SESSION_TOKEN"
+
+// An explicit but empty --session-token is an error rather than a fall back to the environment: that
+// shape is "$SOME_VAR" with the variable unset, and running on a session the operator did not name is
+// the surprise worth avoiding.
+func resolveAgentVaultSessionToken(cmd *cobra.Command) (token string, fromFlag bool, err error) {
+	fromFlag = cmd.Flags().Changed("session-token")
+	flagValue, err := cmd.Flags().GetString("session-token")
+	if err != nil {
+		return "", fromFlag, err
+	}
+	if fromFlag && strings.TrimSpace(flagValue) == "" {
+		return "", fromFlag, fmt.Errorf(
+			"--session-token was given but is empty; pass a session token from the dashboard, or drop the flag and set %s", agentVaultSessionTokenEnv)
+	}
+	token, err = util.GetCmdFlagOrEnvWithDefaultValue(cmd, "session-token", []string{agentVaultSessionTokenEnv}, "")
+	if err != nil {
+		return "", fromFlag, err
+	}
+	return strings.TrimSpace(token), fromFlag, nil
+}
+
 func runAgentVaultRun(cmd *cobra.Command, args []string) {
 	accessBundles, _ := cmd.Flags().GetStringArray("access-bundle")
-	sessionToken, _ := cmd.Flags().GetString("session-token")
+
+	sessionToken, sessionTokenFromFlag, err := resolveAgentVaultSessionToken(cmd)
+	if err != nil {
+		util.HandleError(err)
+	}
 
 	// Whether the flag was given has to come from the flag set: pflag discards a lone empty value, so
 	// --access-bundle "" parses to an empty slice and is otherwise indistinguishable from the flag never
@@ -144,15 +171,16 @@ func runAgentVaultRun(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("access-bundle") && len(accessBundles) == 0 {
 		util.HandleError(fmt.Errorf("--access-bundle was given but names no bundle; pass a name like 'coding-agent'"))
 	}
-	if cmd.Flags().Changed("session-token") && strings.TrimSpace(sessionToken) == "" {
-		util.HandleError(fmt.Errorf("--session-token was given but is empty; pass a session token from the dashboard"))
-	}
-
 	if len(accessBundles) == 0 && sessionToken == "" {
-		util.HandleError(fmt.Errorf("a session is required; pass --access-bundle <name> to mint one, or --session-token <session token> from the dashboard"))
+		util.HandleError(fmt.Errorf("a session is required; pass --access-bundle <name> to mint one, or --session-token <session token> (or %s) from the dashboard", agentVaultSessionTokenEnv))
 	}
 	if len(accessBundles) > 0 && sessionToken != "" {
-		util.HandleError(fmt.Errorf("--access-bundle and --session-token are two ways to get one session; pass one of them, not both"))
+		if sessionTokenFromFlag {
+			util.HandleError(fmt.Errorf("--access-bundle and --session-token are two ways to get one session; pass one of them, not both"))
+		}
+		// The flag was typed for this run; an exported variable may be left over from another one.
+		util.PrintWarning(fmt.Sprintf("%s is set, but --access-bundle was passed: minting a new session and ignoring the token in the environment.", agentVaultSessionTokenEnv))
+		sessionToken = ""
 	}
 	if len(accessBundles) > 1 {
 		util.HandleError(fmt.Errorf("a session carries one access bundle; pass --access-bundle once"))
@@ -512,7 +540,7 @@ func runAgentVaultChild(args, env []string) int {
 
 func init() {
 	agentVaultRunCmd.Flags().StringArray("access-bundle", nil, "mint a session over the access bundle with this `name`")
-	agentVaultRunCmd.Flags().String("session-token", "", "run with a session token minted in the dashboard instead of minting one")
+	agentVaultRunCmd.Flags().String("session-token", "", "run with a session token minted in the dashboard instead of minting one (falls back to "+agentVaultSessionTokenEnv+")")
 	agentVaultRunCmd.Flags().String("ttl", "7d", "lifetime of the session this command creates: one number and one unit, such as 30m, 8h or 7d (not 2h30m), or never")
 	agentVaultRunCmd.Flags().Bool("keep-session", false, "leave a minted session active when the agent exits")
 	agentVaultRunCmd.Flags().String("proxy", "", "address of the Agent Vault proxy as host:port (falls back to INFISICAL_AGENT_VAULT_PROXY_ADDRESS)")

--- a/packages/cmd/agent_vault_run_test.go
+++ b/packages/cmd/agent_vault_run_test.go
@@ -278,3 +278,21 @@ func TestResolveAgentVaultSessionTokenWithNeitherSourceIsEmpty(t *testing.T) {
 		t.Errorf("want no token, got %q fromFlag=%v", token, fromFlag)
 	}
 }
+
+func TestBuildAgentVaultRunEnvDropsTheSessionTokenVariable(t *testing.T) {
+	parent := []string{agentVaultSessionTokenEnv + "=agv_stale", "PATH=/usr/bin"}
+
+	env := buildAgentVaultRunEnv(parent, "10.0.1.5:17323", "agv_minted", "", "")
+
+	for _, kv := range env {
+		if strings.HasPrefix(kv, agentVaultSessionTokenEnv+"=") {
+			t.Fatalf("the agent must not inherit a session token the proxy URL did not give it, got %q", kv)
+		}
+		if strings.Contains(kv, "agv_stale") {
+			t.Fatalf("a stale token reached the agent through %q", kv)
+		}
+	}
+	if !strings.Contains(strings.Join(env, " "), "agv_minted") {
+		t.Error("the minted session should still reach the agent in the proxy URL")
+	}
+}

--- a/packages/cmd/agent_vault_run_test.go
+++ b/packages/cmd/agent_vault_run_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 func selfSignedPEM(t *testing.T, cn string) string {
@@ -205,5 +207,74 @@ func TestValidateProxyAddrNamesWhatFollowsThePort(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "nothing after the port") {
 			t.Errorf("%q: want the trailing-path message, got %v", addr, err)
 		}
+	}
+}
+
+func sessionTokenCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "run", Run: func(*cobra.Command, []string) {}}
+	cmd.Flags().String("session-token", "", "")
+	if err := cmd.Flags().Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	return cmd
+}
+
+func TestResolveAgentVaultSessionTokenPrefersTheFlag(t *testing.T) {
+	t.Setenv(agentVaultSessionTokenEnv, "agv_from_env")
+
+	token, fromFlag, err := resolveAgentVaultSessionToken(sessionTokenCmd(t, "--session-token", "agv_from_flag"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "agv_from_flag" || !fromFlag {
+		t.Errorf("the flag should win over the environment, got %q fromFlag=%v", token, fromFlag)
+	}
+}
+
+func TestResolveAgentVaultSessionTokenFallsBackToTheEnvironment(t *testing.T) {
+	t.Setenv(agentVaultSessionTokenEnv, "  agv_from_env  ")
+
+	token, fromFlag, err := resolveAgentVaultSessionToken(sessionTokenCmd(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "agv_from_env" {
+		t.Errorf("want the environment value trimmed, got %q", token)
+	}
+	if fromFlag {
+		t.Error("a token out of the environment must not report itself as coming from the flag")
+	}
+}
+
+func TestResolveAgentVaultSessionTokenIgnoresABlankEnvironmentValue(t *testing.T) {
+	t.Setenv(agentVaultSessionTokenEnv, "   ")
+
+	token, _, err := resolveAgentVaultSessionToken(sessionTokenCmd(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" {
+		t.Errorf("a blank variable names no session, got %q", token)
+	}
+}
+
+func TestResolveAgentVaultSessionTokenRefusesAnEmptyFlag(t *testing.T) {
+	t.Setenv(agentVaultSessionTokenEnv, "agv_from_env")
+
+	if _, _, err := resolveAgentVaultSessionToken(sessionTokenCmd(t, "--session-token", "")); err == nil {
+		t.Fatal("an explicitly empty --session-token should be an error, not a fall back to the environment")
+	}
+}
+
+func TestResolveAgentVaultSessionTokenWithNeitherSourceIsEmpty(t *testing.T) {
+	t.Setenv(agentVaultSessionTokenEnv, "")
+
+	token, fromFlag, err := resolveAgentVaultSessionToken(sessionTokenCmd(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" || fromFlag {
+		t.Errorf("want no token, got %q fromFlag=%v", token, fromFlag)
 	}
 }


### PR DESCRIPTION
# Description 📣

`--session-token` was the only Agent Vault flag with no environment fallback. `--proxy`, `--client-id`, `--client-secret` and the proxy's `--enrollment-token` and `--data-dir` all go through `GetCmdFlagOrEnvWithDefaultValue`, so the one credential that carries the whole access bundle had to sit on the command line, where it lands in shell history and in process listings. It now falls back to `INFISICAL_AGENT_VAULT_SESSION_TOKEN`.

Resolution moves into a single helper so the two rules that turn on where the token came from are testable:

- Flag beats environment. The environment value is trimmed, and a blank one names no session.
- `--session-token ""` stays a hard error rather than falling back to the environment. That shape is `"$AV_TOKEN"` with the variable unset, and running the agent on a session the operator did not name is the outcome worth refusing.
- `--access-bundle` alongside a flag token is still the existing "pass one of them, not both" error. Alongside an environment token it warns and mints instead, because an exported variable is ambient and may be left over from an unrelated run, while the flag was typed for this run.

Companion docs PR: https://github.com/Infisical/infisical/pull/8104

The agent process already receives the session token either way, as the password in the `HTTPS_PROXY` URL, so this does not widen what the child sees. It only keeps the token out of history and out of `ps`.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

